### PR TITLE
feat: Implement PushFront for LinkedList and enhance SSTableManager

### DIFF
--- a/linkedlist.go
+++ b/linkedlist.go
@@ -37,20 +37,16 @@ func (l *LinkedList[V]) PushBack(value V) {
 func (l *LinkedList[V]) PushFront(value V) {
 	newNode := &llNode[V]{
 		Value: value,
-		prev:  l.rootNode, // New node's prev points to the root (dummy) node
+		prev:  l.rootNode,
+		next:  l.rootNode.next,
 	}
 
-	// If the list is empty (only rootNode exists), the new node becomes the lastNode
 	if l.len == 0 {
 		l.lastNode = newNode
 	} else {
-		// Otherwise, the new node's next points to the current first node
-		// and the current first node's prev points to the new node.
-		firstNode := l.rootNode.next
-		newNode.next = firstNode
-		firstNode.prev = newNode
+		l.rootNode.next.prev = newNode
 	}
-	l.rootNode.next = newNode // Root node's next points to the new node
+	l.rootNode.next = newNode
 	l.len += 1
 }
 

--- a/linkedlist.go
+++ b/linkedlist.go
@@ -33,6 +33,27 @@ func (l *LinkedList[V]) PushBack(value V) {
 	l.len += 1
 }
 
+// PushFront adds a new node with the given value to the front of the list.
+func (l *LinkedList[V]) PushFront(value V) {
+	newNode := &llNode[V]{
+		Value: value,
+		prev:  l.rootNode, // New node's prev points to the root (dummy) node
+	}
+
+	// If the list is empty (only rootNode exists), the new node becomes the lastNode
+	if l.len == 0 {
+		l.lastNode = newNode
+	} else {
+		// Otherwise, the new node's next points to the current first node
+		// and the current first node's prev points to the new node.
+		firstNode := l.rootNode.next
+		newNode.next = firstNode
+		firstNode.prev = newNode
+	}
+	l.rootNode.next = newNode // Root node's next points to the new node
+	l.len += 1
+}
+
 func (l *LinkedList[V]) Len() int {
 	return l.len
 }

--- a/linkedlist_test.go
+++ b/linkedlist_test.go
@@ -30,6 +30,62 @@ func TestLinkedListPushBack(t *testing.T) {
 	})
 }
 
+func TestLinkedListPushFront(t *testing.T) {
+	t.Run("Push to an empty list", func(t *testing.T) {
+		l := InitLinkedList[int]()
+		l.PushFront(10)
+
+		assert.Equal(t, 1, l.Len())
+		assert.Equal(t, 10, l.rootNode.next.Value)
+		assert.Equal(t, 10, l.lastNode.Value)
+		assert.Equal(t, l.rootNode.next, l.lastNode) // For a single node, root.next should be lastNode
+		assert.Nil(t, l.rootNode.next.next)
+		assert.Equal(t, l.rootNode, l.rootNode.next.prev)
+	})
+
+	t.Run("Push multiple values to the front", func(t *testing.T) {
+		l := InitLinkedList[int]()
+		l.PushFront(1) // List: 1
+		l.PushFront(2) // List: 2, 1
+		l.PushFront(3) // List: 3, 2, 1
+
+		assert.Equal(t, 3, l.Len())
+		assert.Equal(t, 3, l.rootNode.next.Value) // First node should be 3
+		assert.Equal(t, 1, l.lastNode.Value)      // Last node should still be 1
+
+		expected := []int{3, 2, 1}
+		assertLinkedListContents(t, l, expected)
+
+		// Verify prev/next pointers for all nodes
+		node3 := l.rootNode.next
+		node2 := node3.next
+		node1 := node2.next
+
+		assert.Equal(t, l.rootNode, node3.prev)
+		assert.Equal(t, node2, node3.next)
+
+		assert.Equal(t, node3, node2.prev)
+		assert.Equal(t, node1, node2.next)
+
+		assert.Equal(t, node2, node1.prev)
+		assert.Nil(t, node1.next)
+	})
+
+	t.Run("PushFront after PushBack", func(t *testing.T) {
+		l := InitLinkedList[int]()
+		l.PushBack(1)  // List: 1
+		l.PushBack(2)  // List: 1, 2
+		l.PushFront(0) // List: 0, 1, 2
+
+		assert.Equal(t, 3, l.Len())
+		assert.Equal(t, 0, l.rootNode.next.Value) // First node should be 0
+		assert.Equal(t, 2, l.lastNode.Value)      // Last node should still be 2
+
+		expected := []int{0, 1, 2}
+		assertLinkedListContents(t, l, expected)
+	})
+}
+
 //nolint:funlen
 func TestLinkedListIterator(t *testing.T) {
 	t.Run("Check Iterator for the empty linked list", func(t *testing.T) {

--- a/rindb.go
+++ b/rindb.go
@@ -173,9 +173,6 @@ func (r *Rindb) Put(key, value Bytes) error {
 			return fmt.Errorf("failed to flush memtable: %w", err)
 		}
 
-		// Wont close the file system here, as it will be managed by ssTableManager
-		r.ssTableManager.openedFs.PushBack(fs) // Add to opened file systems
-
 		// Register the new SSTable with ssTableManager
 		if err := r.ssTableManager.AddSSTable(0, fs); err != nil {
 			ERROR("Failed to register new SSTable %s: %v", fs.Path(), err)

--- a/rindb.go
+++ b/rindb.go
@@ -82,7 +82,7 @@ func InitRinDB(opts ...Option) (Rindb, error) {
 
 	// Only scan L0 SSTables for max sequence number during initialization.
 	// L0 SSTables contain the most recent data after the memtable.
-	sstMaxSeqNum, err := getMaxSequenceNumberFromSSTables(cfg, ssTableManager)
+	sstMaxSeqNum, err := getMaxSequenceNumberFromSSTables(ssTableManager)
 	if err != nil {
 		return Rindb{}, err
 	}

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -22,10 +22,26 @@ import (
 // - Manages file handles for SSTables
 // - Coordinates concurrent access with read/write locks
 type SSTableManager struct {
-	openedFs *list.List
+	openedFs *list.List // List of *FileSystem that are currently opened
 	levels   []*LinkedList[*FileSystem]
 	config   Config
 	mu       sync.RWMutex
+}
+
+// openAndLoadSSTable opens a FileSystem, creates an SSTable object from it,
+// and adds the FileSystem to the manager's list of opened file systems.
+// It returns the created *SSTable or an error.
+func (h *SSTableManager) openAndLoadSSTable(fs *FileSystem) (*SStable, error) {
+	if err := fs.Open(); err != nil {
+		return nil, fmt.Errorf("failed to open sstable file %s: %w", fs.Path(), err)
+	}
+	sstable, err := NewSSTable(h.config, fs)
+	if err != nil {
+		_ = fs.Close() // Ensure file is closed on SSTable creation error
+		return nil, fmt.Errorf("failed to create sstable object for %s: %w", fs.Path(), err)
+	}
+	h.openedFs.PushBack(fs) // Track opened file system
+	return &sstable, nil
 }
 
 func InitSSTableManager(config Config) (*SSTableManager, error) {
@@ -103,6 +119,8 @@ func (h *SSTableManager) NewSSTableFS(levelNumb int) (*FileSystem, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	h.openedFs.PushBack(fs)
 	return fs, nil
 }
 
@@ -255,15 +273,11 @@ func (h *SSTableManager) compactLevel0(level *LinkedList[*FileSystem], newLevelN
 		if err != nil {
 			return err
 		}
-		if err := fs.Open(); err != nil {
-			return err
-		}
-		sstable, err := NewSSTable(h.config, fs)
+		sstable, err := h.openAndLoadSSTable(fs)
 		if err != nil {
-			_ = fs.Close()
 			return err
 		}
-		sstablesToMerge = append(sstablesToMerge, sstable)
+		sstablesToMerge = append(sstablesToMerge, *sstable)
 	}
 
 	// Find overlapping SSTables in the next level
@@ -289,23 +303,15 @@ func (h *SSTableManager) compactHigherLevel(level *LinkedList[*FileSystem], newL
 			}
 			return fmt.Errorf("error picking next SSTable from level: %w", err)
 		}
-		if err := fs.Open(); err != nil {
-			// Attempt to close any already opened SSTables before returning error
-			for _, sst := range sstablesToMerge {
-				_ = sst.Close()
-			}
-			return fmt.Errorf("error opening picked SSTable %s: %w", fs.Path(), err)
-		}
-		sstable, err := NewSSTable(h.config, fs)
+		sstable, err := h.openAndLoadSSTable(fs)
 		if err != nil {
-			_ = fs.Close()
 			// Attempt to close any already opened SSTables before returning error
 			for _, sst := range sstablesToMerge {
 				_ = sst.Close()
 			}
 			return fmt.Errorf("error creating SStable object for %s: %w", fs.Path(), err)
 		}
-		sstablesToMerge = append(sstablesToMerge, sstable)
+		sstablesToMerge = append(sstablesToMerge, *sstable)
 	}
 
 	if len(sstablesToMerge) == 0 {
@@ -356,16 +362,12 @@ func (h *SSTableManager) findOverlappingSSTables(levelNumb int, sources []SStabl
 		if err != nil {
 			return nil, err
 		}
-		if err := fs.Open(); err != nil {
-			return nil, err
-		}
-		sstable, err := NewSSTable(h.config, fs)
+		sstable, err := h.openAndLoadSSTable(fs)
 		if err != nil {
-			_ = fs.Close()
 			return nil, err
 		}
 		if sstable.Overlaps(minKey, maxKey) {
-			overlapping = append(overlapping, sstable)
+			overlapping = append(overlapping, *sstable)
 		} else {
 			_ = fs.Close() // Close if not overlapping
 		}
@@ -399,6 +401,69 @@ func (h *SSTableManager) mergeSSTables(newLevelNumb int, pickedUpSSTable []SStab
 	return nil
 }
 
+// GetRelevantSSTables finds SSTables that might contain keys within the given range [startKey, endKey].
+// For Level 0, all SSTables are considered relevant.
+// For Level 1 and higher, SSTables are checked for overlap with the given key range.
+// The returned LinkedList contains *SSTable objects, which are opened and ready for use.
+// The SSTables in Level 0 are appended to the list, maintaining newest-first order.
+// while SSTables from higher levels are added to the back.
+func (h *SSTableManager) GetRelevantSSTables(startKey, endKey Bytes) (*LinkedList[*SStable], error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	relevantSSTables := InitLinkedList[*SStable]()
+
+	for levelNumb, level := range h.levels {
+		if level == nil || level.Len() == 0 {
+			continue
+		}
+
+		// Level 0: All SSTables are considered relevant.
+		// Iterate from newest to oldest (bottom to top) to prioritize newer data.
+		if levelNumb == 0 {
+			iterator := level.IteratorFromBottom()
+			fs := iterator.Value()
+			for fs != nil {
+				sstable, err := h.openAndLoadSSTable(fs)
+				if err != nil {
+					return nil, fmt.Errorf("failed to open and load sstable %s: %w", fs.Path(), err)
+				}
+
+				relevantSSTables.PushBack(sstable) // Add to back to maintain newest-first order for L0
+
+				if !iterator.HasPrev() {
+					break
+				}
+				fs, err = iterator.Prev()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get previous sstable in level %d: %w", levelNumb, err)
+				}
+			}
+		} else {
+			// Levels 1+: Check for overlap with the given key range.
+			// Iterate from oldest to newest (top to bottom) for higher levels.
+			iterator := level.Iterator()
+			for iterator.HasNext() {
+				fs, err := iterator.Next()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get next sstable in level %d: %w", levelNumb, err)
+				}
+				sstable, err := h.openAndLoadSSTable(fs)
+				if err != nil {
+					return nil, fmt.Errorf("failed to open and load sstable %s: %w", fs.Path(), err)
+				}
+
+				if sstable.Overlaps(startKey, endKey) {
+					relevantSSTables.PushBack(sstable) // Add to back for higher levels
+				} else {
+					_ = fs.Close() // Close if not relevant
+				}
+			}
+		}
+	}
+	return relevantSSTables, nil
+}
+
 func (h *SSTableManager) searchKey(key Bytes) (Bytes, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -423,12 +488,8 @@ func (h *SSTableManager) searchKey(key Bytes) (Bytes, error) {
 		iterator := h.levels[levelNumb].IteratorFromBottom()
 		fs := iterator.Value()
 		for fs != nil {
-			if err := fs.Open(); err != nil {
-				return nil, err
-			}
-			sstable, err := NewSSTable(h.config, fs)
+			sstable, err := h.openAndLoadSSTable(fs)
 			if err != nil {
-				_ = fs.Close()
 				return nil, err
 			}
 
@@ -482,12 +543,8 @@ func getMaxSequenceNumberFromSSTables(cfg Config, ssTableManager *SSTableManager
 			if err != nil {
 				return 0, err
 			}
-			if err := fs.Open(); err != nil {
-				return 0, err
-			}
-			sstable, err := NewSSTable(cfg, fs)
+			sstable, err := ssTableManager.openAndLoadSSTable(fs)
 			if err != nil {
-				_ = fs.Close()
 				return 0, err
 			}
 			sstSeqNum, err := sstable.MaxSequenceNumber()

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -533,7 +533,7 @@ func (h *SSTableManager) searchKey(key Bytes) (Bytes, error) {
 // We should scan *all* levels to find the true max sequence number.
 // The correct long-term solution is to maintain a MANIFEST file
 // that tracks global sequence number metadata across all levels.
-func getMaxSequenceNumberFromSSTables(cfg Config, ssTableManager *SSTableManager) (uint64, error) {
+func getMaxSequenceNumberFromSSTables(ssTableManager *SSTableManager) (uint64, error) {
 	var maxSeqNum uint64
 	if len(ssTableManager.levels) > 0 && ssTableManager.levels[0] != nil {
 		level0 := ssTableManager.levels[0]

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -60,19 +60,19 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 
 		// Case 1: ssTableManager.levels is nil
 		ts.Manager.levels = nil
-		maxSeqNum, err := getMaxSequenceNumberFromSSTables(cfg, ts.Manager)
+		maxSeqNum, err := getMaxSequenceNumberFromSSTables(ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), maxSeqNum)
 
 		// Case 2: ssTableManager.levels is empty slice
 		ts.Manager.levels = []*LinkedList[*FileSystem]{}
-		maxSeqNum, err = getMaxSequenceNumberFromSSTables(cfg, ts.Manager)
+		maxSeqNum, err = getMaxSequenceNumberFromSSTables(ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), maxSeqNum)
 
 		// Case 3: Level 0 exists but is empty
 		ts.Manager.levels = []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()}
-		maxSeqNum, err = getMaxSequenceNumberFromSSTables(cfg, ts.Manager)
+		maxSeqNum, err = getMaxSequenceNumberFromSSTables(ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), maxSeqNum)
 	})
@@ -85,7 +85,7 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 		sstable := ts.createSSTableWithSequence(0, map[string]string{"key1": "val1"}, 100)
 		ts.AddSSTableToLevel(0, sstable)
 
-		maxSeqNum, err := getMaxSequenceNumberFromSSTables(cfg, ts.Manager)
+		maxSeqNum, err := getMaxSequenceNumberFromSSTables(ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(100), maxSeqNum)
 	})
@@ -100,7 +100,7 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 		ts.AddSSTableToLevel(0, ts.createSSTableWithSequence(0, map[string]string{"k3": "v3"}, 75))
 		ts.AddSSTableToLevel(0, ts.createSSTableWithSequence(0, map[string]string{"k4": "v4"}, 200)) // Max
 
-		maxSeqNum, err := getMaxSequenceNumberFromSSTables(cfg, ts.Manager)
+		maxSeqNum, err := getMaxSequenceNumberFromSSTables(ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(200), maxSeqNum)
 	})
@@ -112,7 +112,7 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 		ts.AddSSTableToLevel(0, ts.createSSTableWithSequence(0, map[string]string{"k1": "v1"}, 0))
 		ts.AddSSTableToLevel(0, ts.createSSTableWithSequence(0, map[string]string{"k2": "v2"}, 0))
 
-		maxSeqNum, err := getMaxSequenceNumberFromSSTables(cfg, ts.Manager)
+		maxSeqNum, err := getMaxSequenceNumberFromSSTables(ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), maxSeqNum)
 	})
@@ -126,7 +126,7 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 		ts.Manager.levels = []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()}
 		ts.Manager.levels[0].PushBack(badFs)
 
-		maxSeqNum, err := getMaxSequenceNumberFromSSTables(cfg, ts.Manager)
+		maxSeqNum, err := getMaxSequenceNumberFromSSTables(ts.Manager)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "no such file or directory")
 		assert.Equal(t, uint64(0), maxSeqNum)

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -916,7 +916,7 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		// Verify order: L0 newest first, then L1+ oldest first
 		iter := relevantSSTables.Iterator()
 
-		// L0 SSTables (pushed to front, so newest first)
+		// L0 SSTables (iterated newest-to-oldest, added to the back of the list)
 		s, err := iter.Next()
 		assert.NoError(t, err)
 		assert.Equal(t, sstableL0_B.Path(), s.Path(), "Expected L0 newest first")

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -756,3 +756,184 @@ func TestSSTableManager_shouldCompact(t *testing.T) {
 		assert.False(t, ts.Manager.shouldCompact(2, levelList)) // Check level 2 as well
 	})
 }
+
+func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
+	cfg := testConfig()
+
+	t.Run("Level 0 returns all SSTables in newest-first order", func(t *testing.T) {
+		ts := newTestRindbSetup(t, &cfg)
+		defer ts.Cleanup()
+
+		// Create SSTables for Level 0
+		sstableL0_1 := ts.createSSTable(0, map[string]string{"k1": "v1", "k2": "v2"}) // Older
+		sstableL0_2 := ts.createSSTable(0, map[string]string{"k3": "v3", "k4": "v4"}) // Newer
+		ts.AddSSTableToLevel(0, sstableL0_1)
+		ts.AddSSTableToLevel(0, sstableL0_2)
+
+		// Call GetRelevantSSTables for Level 0
+		relevantSSTables, err := ts.Manager.GetRelevantSSTables(Bytes("a"), Bytes("z"))
+		assert.NoError(t, err)
+		assert.NotNil(t, relevantSSTables)
+		assert.Equal(t, 2, relevantSSTables.Len(), "Expected 2 relevant SSTables in Level 0")
+
+		iter := relevantSSTables.Iterator()
+		s1, err := iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, sstableL0_2.Path(), s1.Path())
+
+		s2, err := iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, sstableL0_1.Path(), s2.Path())
+
+		// Ensure SSTables are opened
+		assert.True(t, s1.IsOpened(), "SSTable 1 should be opened")
+		assert.True(t, s2.IsOpened(), "SSTable 2 should be opened")
+	})
+
+	t.Run("Level 1+ returns only overlapping SSTables in oldest-first order", func(t *testing.T) {
+		ts := newTestRindbSetup(t, &cfg)
+		defer ts.Cleanup()
+
+		// Create SSTables for Level 1
+		// sstableL1_1: range [b, c] - overlaps with [b, d]
+		sstableL1_1 := ts.createSSTable(1, map[string]string{"b": "vb", "c": "vc"})
+		// sstableL1_2: range [e, g] - does not overlap with [b, d]
+		sstableL1_2 := ts.createSSTable(1, map[string]string{"e": "ve", "f": "vf", "g": "vg"})
+		// sstableL1_3: range [c, d] - overlaps with [b, d]
+		sstableL1_3 := ts.createSSTable(1, map[string]string{"c": "vc2", "d": "vd"})
+
+		ts.AddSSTableToLevel(1, sstableL1_1)
+		ts.AddSSTableToLevel(1, sstableL1_2)
+		ts.AddSSTableToLevel(1, sstableL1_3)
+
+		// Call GetRelevantSSTables for Level 1 with a specific range
+		startKey := Bytes("b")
+		endKey := Bytes("d")
+		relevantSSTables, err := ts.Manager.GetRelevantSSTables(startKey, endKey)
+		assert.NoError(t, err)
+		assert.NotNil(t, relevantSSTables)
+		assert.Equal(t, 2, relevantSSTables.Len(), "Expected 2 relevant SSTables in Level 1")
+
+		// Verify order: oldest first (sstableL1_1 then sstableL1_3)
+		iter := relevantSSTables.Iterator()
+		s1, err := iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, sstableL1_1.Path(), s1.Path(), "Expected oldest overlapping SSTable first")
+
+		s2, err := iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, sstableL1_3.Path(), s2.Path(), "Expected next oldest overlapping SSTable second")
+
+		// Ensure SSTables are opened
+		assert.True(t, s1.IsOpened(), "SSTable 1 should be opened")
+		assert.True(t, s2.IsOpened(), "SSTable 2 should be opened")
+
+		// Ensure non-overlapping SSTable is closed
+		sstableL1_2.Close() // Close it if it was opened by createSSTable
+		assert.False(t, sstableL1_2.IsOpened(), "Non-overlapping SSTable should be closed")
+	})
+
+	t.Run("No relevant SSTables found", func(t *testing.T) {
+		ts := newTestRindbSetup(t, &cfg)
+		defer ts.Cleanup()
+
+		// Create some SSTables that won't overlap
+		sstableL1_nonOverlap := ts.createSSTable(1, map[string]string{"x": "1", "y": "2"})
+		ts.AddSSTableToLevel(1, sstableL1_nonOverlap)
+
+		relevantSSTables, err := ts.Manager.GetRelevantSSTables(Bytes("a"), Bytes("b"))
+		assert.NoError(t, err)
+		assert.NotNil(t, relevantSSTables)
+		assert.Equal(t, 0, relevantSSTables.Len(), "Expected 0 relevant SSTables")
+
+		// Ensure the non-overlapping SSTable is closed
+		sstableL1_nonOverlap.Close() // Close it if it was opened by createSSTable
+		assert.False(t, sstableL1_nonOverlap.IsOpened(), "Non-overlapping SSTable should be closed")
+	})
+
+	t.Run("Empty SSTableManager", func(t *testing.T) {
+		ts := newTestRindbSetup(t, &cfg)
+		defer ts.Cleanup()
+
+		ts.Manager.levels = nil // Explicitly empty manager
+
+		relevantSSTables, err := ts.Manager.GetRelevantSSTables(Bytes("a"), Bytes("z"))
+		assert.NoError(t, err)
+		assert.NotNil(t, relevantSSTables)
+		assert.Equal(t, 0, relevantSSTables.Len(), "Expected 0 relevant SSTables from empty manager")
+	})
+
+	t.Run("Error opening SSTable", func(t *testing.T) {
+		ts := newTestRindbSetup(t, &cfg)
+		defer ts.Cleanup()
+
+		// Create a dummy FS that will return an error on Open
+		badFs := &FileSystem{filePath: "/non/existent/path.sst"}
+		ts.Manager.levels = []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()}
+		ts.Manager.levels[0].PushBack(badFs)
+
+		relevantSSTables, err := ts.Manager.GetRelevantSSTables(Bytes("a"), Bytes("z"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no such file or directory")
+		assert.Nil(t, relevantSSTables)
+	})
+
+	t.Run("Mixed levels with overlapping and non-overlapping", func(t *testing.T) {
+		ts := newTestRindbSetup(t, &cfg)
+		defer ts.Cleanup()
+
+		// Level 0 (newest first)
+		sstableL0_A := ts.createSSTable(0, map[string]string{"key0_A": "val0_A"}) // Range [key0_A, key0_A]
+		sstableL0_B := ts.createSSTable(0, map[string]string{"key0_B": "val0_B"}) // Range [key0_B, key0_B]
+		ts.AddSSTableToLevel(0, sstableL0_A)
+		ts.AddSSTableToLevel(0, sstableL0_B)
+
+		// Level 1 (oldest first)
+		sstableL1_X := ts.createSSTable(1, map[string]string{"key1_X": "val1_X", "key1_Y": "val1_Y"}) // Range [key1_X, key1_Y]
+		sstableL1_Z := ts.createSSTable(1, map[string]string{"key1_Z": "val1_Z"})                     // Range [key1_Z, key1_Z]
+		ts.AddSSTableToLevel(1, sstableL1_X)
+		ts.AddSSTableToLevel(1, sstableL1_Z)
+
+		// Level 2 (oldest first)
+		sstableL2_P := ts.createSSTable(2, map[string]string{"key2_P": "val2_P", "key2_Q": "val2_Q"}) // Range [key2_P, key2_Q]
+		ts.AddSSTableToLevel(2, sstableL2_P)
+
+		// Search range: [key0_A, key1_Y]
+		startKey := Bytes("key0_A")
+		endKey := Bytes("key1_Y")
+
+		relevantSSTables, err := ts.Manager.GetRelevantSSTables(startKey, endKey)
+		assert.NoError(t, err)
+		assert.NotNil(t, relevantSSTables)
+
+		// Expected:
+		// L0: sstableL0_B (newest), sstableL0_A (older)
+		// L1: sstableL1_X (overlaps [key0_A, key1_Y])
+		// L2: sstableL2_P (does not overlap)
+		// Total expected: 3
+		assert.Equal(t, 3, relevantSSTables.Len(), "Expected 3 relevant SSTables from mixed levels")
+
+		// Verify order: L0 newest first, then L1+ oldest first
+		iter := relevantSSTables.Iterator()
+
+		// L0 SSTables (pushed to front, so newest first)
+		s, err := iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, sstableL0_B.Path(), s.Path(), "Expected L0 newest first")
+
+		s, err = iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, sstableL0_A.Path(), s.Path(), "Expected L0 older second")
+
+		// L1 SSTables (pushed to back, so oldest first among them)
+		s, err = iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, sstableL1_X.Path(), s.Path(), "Expected L1 overlapping oldest first")
+
+		// Ensure non-relevant SSTables are closed
+		sstableL1_Z.Close()
+		assert.False(t, sstableL1_Z.IsOpened(), "Non-overlapping L1 SSTable should be closed")
+		sstableL2_P.Close()
+		assert.False(t, sstableL2_P.IsOpened(), "Non-overlapping L2 SSTable should be closed")
+	})
+}


### PR DESCRIPTION
Adds the `PushFront` method to the `LinkedList` and improves the `SSTableManager` by introducing `openAndLoadSSTable` for consistent SSTable handling and `GetRelevantSSTables` to efficiently retrieve overlapping SSTables across levels.