### PR TITLE
Ensure FileSystem clean respects file permissions

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -80,6 +80,12 @@ func (fs *FileSystem) Clean() error {
 		return fmt.Errorf("failed to close file %s before cleaning: %w", fs.Path(), err)
 	}
 
+	if info, err := os.Stat(fs.Path()); err == nil {
+		if info.Mode().Perm()&0o200 == 0 {
+			return fmt.Errorf("file %s is not writable", fs.Path())
+		}
+	}
+
 	// Open with truncation
 	cleanFile, err := os.OpenFile(fs.Path(), os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileSystemPermission)
 	if err != nil {

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -73,11 +73,11 @@ func TestFileSystem_Clean_Errors(t *testing.T) {
 		err = os.Chmod(filePath, 0o444)
 		assert.NoError(t, err)
 
-		// Attempt to clean - this should fail when trying to reopen with O_RDWR | O_TRUNC
+		// Attempt to clean - this should fail due to read-only permissions
 		err = fs.Clean()
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to open/truncate file")
-		assert.Contains(t, err.Error(), "permission denied") // Check for the underlying OS error
+		assert.Contains(t, err.Error(), "file")
+		assert.Contains(t, err.Error(), "not writable")
 
 		// Clean up: Make writable again so defer closer() can remove it
 		_ = os.Chmod(filePath, 0o600)

--- a/wal_test.go
+++ b/wal_test.go
@@ -23,6 +23,9 @@ func validateWALFormat(t *testing.T, file io.ReadSeeker) {
 		valueLenBytes := [mdByteSize]byte{}
 		_, err = file.Read(valueLenBytes[:])
 		assert.NoError(t, err)
+		seqNumBytes := [mdByteSize]byte{}
+		_, err = file.Read(seqNumBytes[:])
+		assert.NoError(t, err)
 		keyLen := byteOrder.Uint64(keyLenBytes[:])
 		valueLen := byteOrder.Uint64(valueLenBytes[:])
 		_, err = file.Seek(int64(keyLen+valueLen), io.SeekCurrent)


### PR DESCRIPTION
## Summary
- check writability before truncating files in FileSystem.Clean
- adjust FileSystem clean error test for new behavior
- fix WAL format validator to consume sequence numbers between key and value data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689eea008144832598990a93d2c35b12