### PR TITLE
Add merged range iterator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ func main() {
 		fmt.Println("Error initializing database:", err)
 		return
 	}
-	fmt.Println("rindb started. Commands: put <key> <value>, get <key>, remove <key>, exit")
+	fmt.Println("rindb started. Commands: put <key> <value>, get <key>, remove <key>, range <start> <end>, exit")
 	defer db.Close()
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -59,6 +59,24 @@ func main() {
 				fmt.Println("Error:", err)
 			} else {
 				fmt.Println("OK")
+			}
+		case "range":
+			if len(parts) != 3 {
+				fmt.Println("Usage: range <start> <end>")
+				continue
+			}
+			iter, err := db.RangeIterator(rindb.Bytes(parts[1]), rindb.Bytes(parts[2]))
+			if err != nil {
+				fmt.Println("Error:", err)
+				continue
+			}
+			for iter.HasNext() {
+				rec, err := iter.Next()
+				if err != nil {
+					fmt.Println("Error:", err)
+					break
+				}
+				fmt.Printf("%s:%s\n", rec.GetKey(), rec.GetValue())
 			}
 		case "exit":
 			return

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,7 @@ func main() {
 				}
 				fmt.Printf("%s:%s\n", rec.GetKey(), rec.GetValue())
 			}
+			rindb.CloseIterator(iter)
 		case "exit":
 			return
 		default:

--- a/range_test.go
+++ b/range_test.go
@@ -3,6 +3,7 @@ package rindb
 import (
 	"testing"
 
+	"errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,4 +48,65 @@ func TestRindbRange(t *testing.T) {
 		NewRecord(Bytes("z"), Bytes("sstZ"), 4),
 	}
 	assertIteratorRecords(t, iter, expected)
+}
+
+// errIterator yields one record then returns an error on subsequent Next calls.
+type errIterator struct {
+	records []Record
+	idx     int
+}
+
+func (e *errIterator) HasNext() bool { return e.idx < len(e.records) }
+
+func (e *errIterator) Next() (Record, error) {
+	if e.idx == 1 {
+		var empty Record
+		return empty, errors.New("boom")
+	}
+	rec := e.records[e.idx]
+	e.idx++
+	return rec, nil
+}
+
+func TestMergedRangeIteratorErrorPropagates(t *testing.T) {
+	r1 := NewRecord(Bytes("a"), Bytes("1"), 1)
+	r2 := NewRecord(Bytes("b"), Bytes("2"), 2)
+	it := &errIterator{records: []Record{r1, r2}}
+	pq := buildRangePQ([]Iterator[Record]{it})
+	cleaned := false
+	iter := &mergedRangeIterator{pq: pq, cleanup: func() { cleaned = true }}
+
+	assert.True(t, iter.HasNext())
+	rec, err := iter.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+
+	assert.False(t, iter.HasNext())
+	_, err = iter.Next()
+	assert.EqualError(t, err, "boom")
+	assert.True(t, cleaned)
+}
+
+func TestRangeIteratorCloseReleasesSSTables(t *testing.T) {
+	ts := newTestRindbSetup(t, nil)
+	defer ts.Cleanup()
+
+	mem1 := InitMemtable(ts.Manager.config)
+	mem1.Put(NewRecord(Bytes("a"), Bytes("sstA"), 1))
+	sst1, err := Flush(ts.Manager.config, mem1, ts.newSSTableFS(0))
+	assert.NoError(t, err)
+	ts.AddSSTableToLevel(0, &sst1)
+
+	mem := InitMemtable(ts.Manager.config)
+	r := Rindb{memtable: mem, ssTableManager: ts.Manager, config: ts.Manager.config}
+	iter, err := r.RangeIterator(Bytes("a"), Bytes("z"))
+	assert.NoError(t, err)
+
+	if iter.HasNext() {
+		_, err = iter.Next()
+		assert.NoError(t, err)
+	}
+	assert.True(t, sst1.IsOpened())
+	CloseIterator(iter)
+	assert.False(t, sst1.IsOpened())
 }

--- a/range_test.go
+++ b/range_test.go
@@ -38,18 +38,13 @@ func TestRindbRange(t *testing.T) {
 		config:         ts.Manager.config,
 	}
 
-	records, err := r.Range(Bytes("a"), Bytes("z"))
+	iter, err := r.RangeIterator(Bytes("a"), Bytes("z"))
 	assert.NoError(t, err)
 
-	expected := map[string]string{"a": "memA", "k": "memK", "z": "sstZ"}
-	assert.Equal(t, len(expected), len(records))
-	for _, rec := range records {
-		key := string(rec.GetKey())
-		val := string(rec.GetValue())
-		expectedVal, ok := expected[key]
-		assert.True(t, ok, "unexpected key %s", key)
-		assert.Equal(t, expectedVal, val)
-		delete(expected, key)
+	expected := []Record{
+		NewRecord(Bytes("a"), Bytes("memA"), 5),
+		NewRecord(Bytes("k"), Bytes("memK"), 7),
+		NewRecord(Bytes("z"), Bytes("sstZ"), 4),
 	}
-	assert.Empty(t, expected)
+	assertIteratorRecords(t, iter, expected)
 }

--- a/rindb.go
+++ b/rindb.go
@@ -126,8 +126,9 @@ func (r *Rindb) Get(key Bytes) (Bytes, error) {
 	return r.ssTableManager.searchKey(key)
 }
 
-// Range returns all records with keys in [start, end], merged across memtable and SSTables.
-func (r *Rindb) Range(start, end Bytes) ([]Record, error) {
+// RangeIterator returns an iterator over records with keys in [start, end],
+// merged across the memtable and relevant SSTables.
+func (r *Rindb) RangeIterator(start, end Bytes) (Iterator[Record], error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -141,30 +142,54 @@ func (r *Rindb) Range(start, end Bytes) ([]Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Ensure SSTables are closed after use
-	defer func() {
+
+	cleanup := func() {
 		it := sstables.Iterator()
 		for it.HasNext() {
 			sst, _ := it.Next()
 			_ = sst.Close()
 		}
-	}()
+	}
 
 	it := sstables.Iterator()
 	for it.HasNext() {
 		sst, _ := it.Next()
 		rangeIter, err := sst.RangeIterator(start, end)
 		if err != nil {
+			cleanup()
 			return nil, err
 		}
 		iterators = append(iterators, rangeIter)
 	}
 
-	type pqItem struct {
-		rec  Record
-		iter Iterator[Record]
-	}
+	pq := buildRangePQ(iterators)
 
+	return &mergedRangeIterator{pq: pq, cleanup: cleanup}, nil
+}
+
+// Range returns all records with keys in [start, end], merged across memtable and SSTables.
+func (r *Rindb) Range(start, end Bytes) ([]Record, error) {
+	iter, err := r.RangeIterator(start, end)
+	if err != nil {
+		return nil, err
+	}
+	var result []Record
+	for iter.HasNext() {
+		rec, err := iter.Next()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, rec)
+	}
+	return result, nil
+}
+
+type pqItem struct {
+	rec  Record
+	iter Iterator[Record]
+}
+
+func buildRangePQ(iterators []Iterator[Record]) *PriorityQueue[pqItem] {
 	less := func(a, b pqItem) bool {
 		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
 		if cmp == CmpEqual {
@@ -182,31 +207,59 @@ func (r *Rindb) Range(start, end Bytes) ([]Record, error) {
 			}
 		}
 	}
+	return pq
+}
 
-	var result []Record
-	var lastKey Bytes
-	lastKeySet := false
-	for pq.Len() > 0 {
-		item := pq.PopItem()
+type mergedRangeIterator struct {
+	pq         *PriorityQueue[pqItem]
+	lastKey    Bytes
+	lastKeySet bool
+	next       Record
+	prepared   bool
+	cleanup    func()
+}
+
+func (m *mergedRangeIterator) prepare() {
+	for !m.prepared && m.pq.Len() > 0 {
+		item := m.pq.PopItem()
 		key := item.rec.GetKey()
 
-		if !lastKeySet || key.Compare(lastKey) != CmpEqual {
+		if !m.lastKeySet || key.Compare(m.lastKey) != CmpEqual {
 			if len(item.rec.GetValue()) > 0 {
-				result = append(result, item.rec)
+				m.next = item.rec
+				m.prepared = true
 			}
-			lastKey = key
-			lastKeySet = true
+			m.lastKey = key
+			m.lastKeySet = true
 		}
 
 		if item.iter.HasNext() {
 			rec, err := item.iter.Next()
 			if err == nil {
-				pq.PushItem(pqItem{rec: rec, iter: item.iter})
+				m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
 			}
 		}
 	}
+	if !m.prepared && m.cleanup != nil {
+		m.cleanup()
+		m.cleanup = nil
+	}
+}
 
-	return result, nil
+// HasNext implements Iterator[Record].
+func (m *mergedRangeIterator) HasNext() bool {
+	m.prepare()
+	return m.prepared
+}
+
+// Next implements Iterator[Record].
+func (m *mergedRangeIterator) Next() (Record, error) {
+	if !m.HasNext() {
+		var empty Record
+		return empty, EOI
+	}
+	m.prepared = false
+	return m.next, nil
 }
 
 // Put inserts or updates a key-value pair in the database.

--- a/rindb.go
+++ b/rindb.go
@@ -173,6 +173,8 @@ func (r *Rindb) Range(start, end Bytes) ([]Record, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer CloseIterator(iter)
+
 	var result []Record
 	for iter.HasNext() {
 		rec, err := iter.Next()
@@ -217,10 +219,11 @@ type mergedRangeIterator struct {
 	next       Record
 	prepared   bool
 	cleanup    func()
+	err        error
 }
 
 func (m *mergedRangeIterator) prepare() {
-	for !m.prepared && m.pq.Len() > 0 {
+	for !m.prepared && m.err == nil && m.pq.Len() > 0 {
 		item := m.pq.PopItem()
 		key := item.rec.GetKey()
 
@@ -235,14 +238,17 @@ func (m *mergedRangeIterator) prepare() {
 
 		if item.iter.HasNext() {
 			rec, err := item.iter.Next()
-			if err == nil {
+			if err != nil {
+				if !errors.Is(err, EOI) {
+					m.err = err
+				}
+			} else {
 				m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
 			}
 		}
 	}
-	if !m.prepared && m.cleanup != nil {
-		m.cleanup()
-		m.cleanup = nil
+	if m.err != nil || (!m.prepared && m.pq.Len() == 0) {
+		_ = m.Close()
 	}
 }
 
@@ -256,10 +262,30 @@ func (m *mergedRangeIterator) HasNext() bool {
 func (m *mergedRangeIterator) Next() (Record, error) {
 	if !m.HasNext() {
 		var empty Record
+		if m.err != nil {
+			return empty, m.err
+		}
 		return empty, EOI
 	}
 	m.prepared = false
 	return m.next, nil
+}
+
+// Close releases any resources held by the iterator. It is safe to call multiple times.
+func (m *mergedRangeIterator) Close() error {
+	if m.cleanup != nil {
+		m.cleanup()
+		m.cleanup = nil
+	}
+	return m.err
+}
+
+// CloseIterator calls Close on iter if it implements it.
+func CloseIterator[T any](iter Iterator[T]) error {
+	if c, ok := any(iter).(interface{ Close() error }); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 // Put inserts or updates a key-value pair in the database.

--- a/test_utils.go
+++ b/test_utils.go
@@ -339,6 +339,7 @@ func assertIteratorRecords(t *testing.T, iter Iterator[Record], expected []Recor
 	assert.Equal(t, len(expected), idx, "Number of records iterated does not match expected count")
 	_, err := iter.Next()
 	assert.ErrorIs(t, err, EOI, "Iterator should return EOI after iterating through all expected records")
+	_ = CloseIterator(iter)
 }
 
 // assertIteratorValues iterates through a generic Iterator[T] and asserts that the values match the expected slice.


### PR DESCRIPTION
## Summary
- expose `RangeIterator` returning merged records across memtable and SSTables
- consume iterator in `Range` and CLI range command
- update range tests to verify iterator output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689feee3a4888325b37d9aeaf70732e7