### PR TITLE
Instrument WAL operations with OpenTelemetry

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -60,7 +60,7 @@ func InitRinDB(ctx context.Context, opts ...Option) (Rindb, error) {
 		return Rindb{}, fmt.Errorf("failed to open WAL file %s: %w", walPath, err)
 	}
 	wal := NewWAL(cfg, fs)
-	memtable, err := wal.Load()
+	memtable, err := wal.Load(ctx)
 	if err != nil {
 		return Rindb{}, err
 	}

--- a/wal.go
+++ b/wal.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type WAL struct {
@@ -21,7 +25,32 @@ func NewWAL(config Config, fs *FileSystem) WAL {
 	}
 }
 
-func (w *WAL) Load() (Memtable, error) {
+var (
+	walTracer             = otel.Tracer("rindb/wal")
+	walMeter              = otel.Meter("rindb/wal")
+	walLoadDuration       metric.Float64Histogram
+	walAppendDuration     metric.Float64Histogram
+	walAppendManyDuration metric.Float64Histogram
+	walRecordsCounter     metric.Int64Counter
+	walBytesCounter       metric.Int64Counter
+)
+
+func init() {
+	walLoadDuration, _ = walMeter.Float64Histogram("rindb.wal.load.duration", metric.WithUnit("s"))
+	walAppendDuration, _ = walMeter.Float64Histogram("rindb.wal.append.duration", metric.WithUnit("s"))
+	walAppendManyDuration, _ = walMeter.Float64Histogram("rindb.wal.append_many.duration", metric.WithUnit("s"))
+	walRecordsCounter, _ = walMeter.Int64Counter("rindb.wal.records")
+	walBytesCounter, _ = walMeter.Int64Counter("rindb.wal.bytes")
+}
+
+func (w *WAL) Load(ctx context.Context) (Memtable, error) {
+	ctx, span := walTracer.Start(ctx, "WAL.Load")
+	start := time.Now()
+	defer func() {
+		walLoadDuration.Record(ctx, time.Since(start).Seconds())
+		span.End()
+	}()
+
 	_, err := w.file.Seek(0, io.SeekStart)
 	if err != nil {
 		return Memtable{}, fmt.Errorf("failed to seek to start of WAL file %s: %w", w.Path(), err)
@@ -42,6 +71,13 @@ func (w *WAL) Load() (Memtable, error) {
 }
 
 func (w *WAL) Append(ctx context.Context, record Record) error {
+	ctx, span := walTracer.Start(ctx, "WAL.Append")
+	start := time.Now()
+	defer func() {
+		walAppendDuration.Record(ctx, time.Since(start).Seconds())
+		span.End()
+	}()
+
 	tx := w.tm.Begin()
 	defer tx.Rollback(ctx)
 
@@ -62,10 +98,20 @@ func (w *WAL) Append(ctx context.Context, record Record) error {
 		return fmt.Errorf("failed to sync WAL file %s: %w", w.Path(), err)
 	}
 
+	walRecordsCounter.Add(ctx, 1)
+	walBytesCounter.Add(ctx, int64(CalOnDiskSize(record)))
+
 	return nil
 }
 
 func (w *WAL) AppendMany(ctx context.Context, records []Record) error {
+	ctx, span := walTracer.Start(ctx, "WAL.AppendMany")
+	start := time.Now()
+	defer func() {
+		walAppendManyDuration.Record(ctx, time.Since(start).Seconds())
+		span.End()
+	}()
+
 	tx := w.tm.Begin()
 	defer tx.Rollback(ctx)
 
@@ -74,10 +120,12 @@ func (w *WAL) AppendMany(ctx context.Context, records []Record) error {
 		return fmt.Errorf("failed to seek to end of WAL file %s: %w", w.Path(), err)
 	}
 
+	var totalBytes int
 	for i, record := range records {
 		if err := WriteRecord(tx, record); err != nil {
 			return fmt.Errorf("failed to write record %d to WAL transaction: %w", i, err)
 		}
+		totalBytes += CalOnDiskSize(record)
 	}
 
 	if err = tx.Commit(ctx, w.file); err != nil {
@@ -87,6 +135,9 @@ func (w *WAL) AppendMany(ctx context.Context, records []Record) error {
 	if err = w.Sync(); err != nil {
 		return fmt.Errorf("failed to sync WAL file %s after multi-record append: %w", w.Path(), err)
 	}
+
+	walRecordsCounter.Add(ctx, int64(len(records)))
+	walBytesCounter.Add(ctx, int64(totalBytes))
 
 	return nil
 }

--- a/wal_test.go
+++ b/wal_test.go
@@ -52,7 +52,7 @@ func TestWAL_Clean(t *testing.T) {
 	b2 := make(Bytes, 5)
 	_, err = fs.Read(b2)
 	assert.NotNil(t, err)
-	mem, err := w.Load()
+	mem, err := w.Load(context.Background())
 	assert.NoError(t, err)
 	assert.Empty(t, mem.data.Len())
 	err = w.Close()
@@ -69,7 +69,7 @@ func TestWAL_AppendAndLoad(t *testing.T) {
 		w := NewWAL(cfg, fs)
 		err := w.Append(context.Background(), NewRecord(Bytes("single_key"), Bytes("single_value"), 1))
 		assert.NoError(t, err)
-		mem, err := w.Load()
+		mem, err := w.Load(context.Background())
 		assert.NoError(t, err)
 		got, err := mem.Get(Bytes("single_key"))
 		assert.NoError(t, err)
@@ -91,7 +91,7 @@ func TestWAL_AppendAndLoad(t *testing.T) {
 		err = w.AppendMany(context.Background(), records)
 		assert.NoError(t, err)
 		validateWALFormat(t, w.file)
-		mem, err := w.Load()
+		mem, err := w.Load(context.Background())
 		assert.NoError(t, err)
 		for i := 0; i < recordsSize; i++ {
 			key := Bytes(fmt.Sprintf("key.%d", i))
@@ -123,7 +123,7 @@ func TestWALCrashRecovery(t *testing.T) {
 	fs, err := OpenFS(context.Background(), fs.Path())
 	assert.NoError(t, err)
 	w = NewWAL(cfg, fs)
-	mem, err := w.Load()
+	mem, err := w.Load(context.Background())
 	assert.NoError(t, err)
 	v1, err := mem.Get(k1)
 	assert.NoError(t, err)
@@ -177,7 +177,7 @@ func TestWALCrashRecovery_PartialWrite(t *testing.T) {
 	w = NewWAL(cfg, fs)
 
 	// Load the WAL and verify that only the complete records are loaded
-	mem, err := w.Load()
+	mem, err := w.Load(context.Background())
 	assert.NoError(t, err) // Load should ideally not return an error for partial records
 
 	// Verify records 1 and 2 are present


### PR DESCRIPTION
## Summary
- add OpenTelemetry spans, histograms, and counters for WAL Load, Append, and AppendMany
- track appended records and bytes written
- propagate context through WAL Load and callers

## Testing
- `go test -count=1 ./... 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a07aa875888325bc5c83cd6fe8e186