### PR TITLE
Instrument SSTable operations with OpenTelemetry

### DIFF
--- a/sstable.go
+++ b/sstable.go
@@ -8,6 +8,10 @@ import (
 	"log"
 	"os"
 	"sort"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 )
 
 var (
@@ -73,7 +77,35 @@ type SStable struct {
 	Bloom       *BloomFilter
 }
 
+var (
+	sstableTracer = otel.Tracer("rindb/sstable")
+	sstableMeter  = otel.Meter("rindb/sstable")
+
+	flushLatency    metric.Float64Histogram
+	flushIOSize     metric.Int64Counter
+	getValueLatency metric.Float64Histogram
+	getValueIOSize  metric.Int64Counter
+)
+
+func init() {
+	flushLatency, _ = sstableMeter.Float64Histogram("rindb.sstable.flush.latency", metric.WithUnit("ms"))
+	flushIOSize, _ = sstableMeter.Int64Counter("rindb.sstable.flush.io_bytes", metric.WithUnit("By"))
+	getValueLatency, _ = sstableMeter.Float64Histogram("rindb.sstable.get_value.latency", metric.WithUnit("ms"))
+	getValueIOSize, _ = sstableMeter.Int64Counter("rindb.sstable.get_value.io_bytes", metric.WithUnit("By"))
+}
+
 func (s SStable) GetValue(ctx context.Context, key Bytes) (Bytes, error) {
+	ctx, span := sstableTracer.Start(ctx, "SSTable.GetValue")
+	start := time.Now()
+	var bytesRead int
+	defer func() {
+		span.End()
+		getValueLatency.Record(ctx, float64(time.Since(start).Milliseconds()))
+		if bytesRead > 0 {
+			getValueIOSize.Add(ctx, int64(bytesRead))
+		}
+	}()
+
 	if !s.Bloom.Lookup(key) {
 		return nil, ErrKeyNotFound
 	}
@@ -98,6 +130,7 @@ func (s SStable) GetValue(ctx context.Context, key Bytes) (Bytes, error) {
 		ERROR(ctx, "Failed to read record at offset %d in %s: %v", offset, s.Path(), err)
 		return nil, fmt.Errorf("failed to read record at offset %d: %w", offset, err)
 	}
+	bytesRead = CalOnDiskSize(record)
 	return record.GetValue(), nil
 }
 
@@ -234,6 +267,17 @@ func (s SStable) MaxSequenceNumber() (uint64, error) {
 }
 
 func Flush(ctx context.Context, config Config, mem Memtable, fs *FileSystem) (SStable, error) {
+	ctx, span := sstableTracer.Start(ctx, "Flush")
+	start := time.Now()
+	var written int
+	defer func() {
+		span.End()
+		flushLatency.Record(ctx, float64(time.Since(start).Milliseconds()))
+		if written > 0 {
+			flushIOSize.Add(ctx, int64(written))
+		}
+	}()
+
 	if mem.data.Len() == 0 {
 		WARN(ctx, "Flushing empty memtable!")
 		log.Panic("empty memtable!")
@@ -264,6 +308,7 @@ func Flush(ctx context.Context, config Config, mem Memtable, fs *FileSystem) (SS
 		return SStable{}, fmt.Errorf("failed to write sparse index offset to transaction buffer: %w", err)
 	}
 
+	written = tx.buffer.Len()
 	if err := tx.Commit(ctx, fs); err != nil {
 		return SStable{}, fmt.Errorf("failed to commit transaction to file system %s: %w", fs.Path(), err)
 	}

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -12,8 +12,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // SSTableManager manages SSTable storage and compaction in a leveled structure.
@@ -27,6 +30,29 @@ type SSTableManager struct {
 	levels   []*LinkedList[*FileSystem]
 	config   Config
 	mu       sync.RWMutex
+}
+
+var (
+	sstableMgmtTracer = otel.Tracer("rindb/sstablemgmt")
+	sstableMgmtMeter  = otel.Meter("rindb/sstablemgmt")
+
+	addSSTableLatency   metric.Float64Histogram
+	addSSTableCalls     metric.Int64Counter
+	compactLatency      metric.Float64Histogram
+	compactCalls        metric.Int64Counter
+	getRelevantLatency  metric.Float64Histogram
+	getRelevantCalls    metric.Int64Counter
+	getRelevantSSTables metric.Int64Counter
+)
+
+func init() {
+	addSSTableLatency, _ = sstableMgmtMeter.Float64Histogram("rindb.sstablemgmt.add.latency", metric.WithUnit("ms"))
+	addSSTableCalls, _ = sstableMgmtMeter.Int64Counter("rindb.sstablemgmt.add.calls")
+	compactLatency, _ = sstableMgmtMeter.Float64Histogram("rindb.sstablemgmt.compact.latency", metric.WithUnit("ms"))
+	compactCalls, _ = sstableMgmtMeter.Int64Counter("rindb.sstablemgmt.compact.calls")
+	getRelevantLatency, _ = sstableMgmtMeter.Float64Histogram("rindb.sstablemgmt.get_relevant.latency", metric.WithUnit("ms"))
+	getRelevantCalls, _ = sstableMgmtMeter.Int64Counter("rindb.sstablemgmt.get_relevant.calls")
+	getRelevantSSTables, _ = sstableMgmtMeter.Int64Counter("rindb.sstablemgmt.get_relevant.sstables")
 }
 
 // openAndLoadSSTable opens a FileSystem, creates an SSTable object from it,
@@ -56,6 +82,14 @@ func InitSSTableManager(ctx context.Context, config Config) (*SSTableManager, er
 
 // AddSSTable registers a new SSTable file system with the manager at the specified level.
 func (h *SSTableManager) AddSSTable(ctx context.Context, levelNumb int, fs *FileSystem) error {
+	ctx, span := sstableMgmtTracer.Start(ctx, "SSTableManager.AddSSTable")
+	start := time.Now()
+	defer func() {
+		span.End()
+		addSSTableLatency.Record(ctx, float64(time.Since(start).Milliseconds()))
+		addSSTableCalls.Add(ctx, 1)
+	}()
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -217,6 +251,14 @@ func (h *SSTableManager) shouldCompact(ctx context.Context, levelNumb int, level
 }
 
 func (h *SSTableManager) Compact(ctx context.Context) error {
+	ctx, span := sstableMgmtTracer.Start(ctx, "SSTableManager.Compact")
+	start := time.Now()
+	defer func() {
+		span.End()
+		compactLatency.Record(ctx, float64(time.Since(start).Milliseconds()))
+		compactCalls.Add(ctx, 1)
+	}()
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	INFO(ctx, "Starting compaction check across %d levels", len(h.levels))
@@ -409,6 +451,14 @@ func (h *SSTableManager) mergeSSTables(ctx context.Context, newLevelNumb int, pi
 // The SSTables in Level 0 are appended to the list, maintaining newest-first order.
 // while SSTables from higher levels are added to the back.
 func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endKey Bytes) (*LinkedList[*SStable], error) {
+	ctx, span := sstableMgmtTracer.Start(ctx, "SSTableManager.GetRelevantSSTables")
+	start := time.Now()
+	defer func() {
+		span.End()
+		getRelevantLatency.Record(ctx, float64(time.Since(start).Milliseconds()))
+		getRelevantCalls.Add(ctx, 1)
+	}()
+
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
@@ -462,6 +512,8 @@ func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 			}
 		}
 	}
+
+	getRelevantSSTables.Add(ctx, int64(relevantSSTables.Len()))
 	return relevantSSTables, nil
 }
 


### PR DESCRIPTION
## Summary
- add tracing and metrics scaffolding for SSTable manager operations
- record latency and I/O sizes for Flush and SSTable.GetValue

## Testing
- `go test -run TestCalOnDiskSize -v`


------
https://chatgpt.com/codex/tasks/task_e_68a07a972c488325945ce5a75885585f