### PR TITLE
Detach compaction goroutine from request context

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ErrDatabaseClosed is returned when an operation is attempted on a closed database.
@@ -367,6 +368,7 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 		// Trigger compaction in a goroutine *after* flushing
 		INFO(ctx, "Triggering background compaction check.")
 		r.wg.Add(1)
+		compactionCtx := trace.ContextWithSpan(context.Background(), trace.SpanFromContext(ctx))
 		go func(ctx context.Context) {
 			defer r.wg.Done()
 			INFO(ctx, "Background compaction goroutine started.")
@@ -375,7 +377,7 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			} else {
 				INFO(ctx, "Background compaction goroutine finished.")
 			}
-		}(ctx)
+		}(compactionCtx)
 	}
 
 	if span.IsRecording() {


### PR DESCRIPTION
## Summary
- ensure compaction runs to completion by detaching its context from the originating request while preserving trace info

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a092cc25b4832581f08e2922a77292