### PR TITLE
Return closable iterator from IRange

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,7 +80,7 @@ func main() {
 				}
 				fmt.Printf("%s:%s\n", rec.GetKey(), rec.GetValue())
 			}
-			rindb.CloseIterator(iter)
+			_ = iter.Close()
 		case "exit":
 			return
 		default:

--- a/range_test.go
+++ b/range_test.go
@@ -112,7 +112,7 @@ func TestRindbRange(t *testing.T) {
 			iter, err := r.IRange(context.Background(), tt.start, tt.end)
 			assert.NoError(t, err)
 			assertIteratorRecords(t, iter, tt.expected)
-			CloseIterator(iter)
+			_ = iter.Close()
 		})
 	}
 }
@@ -135,13 +135,13 @@ func (e *errIterator) Next() (Record, error) {
 	return rec, nil
 }
 
-func TestMergedIRangeErrorPropagates(t *testing.T) {
+func TestRangeIteratorErrorPropagates(t *testing.T) {
 	r1 := NewRecord(Bytes("a"), Bytes("1"), 1)
 	r2 := NewRecord(Bytes("b"), Bytes("2"), 2)
 	it := &errIterator{records: []Record{r1, r2}}
 	pq := buildRangePQ([]Iterator[Record]{it})
 	cleaned := false
-	iter := &mergedIRange{pq: pq, cleanup: func() { cleaned = true }}
+	iter := &RangeIterator{pq: pq, cleanup: func() { cleaned = true }}
 
 	assert.True(t, iter.HasNext())
 	rec, err := iter.Next()
@@ -174,6 +174,6 @@ func TestIRangeCloseReleasesSSTables(t *testing.T) {
 		assert.NoError(t, err)
 	}
 	assert.True(t, sst1.IsOpened())
-	CloseIterator(iter)
+	_ = iter.Close()
 	assert.False(t, sst1.IsOpened())
 }

--- a/rindb.go
+++ b/rindb.go
@@ -147,7 +147,10 @@ func (r *Rindb) Get(ctx context.Context, key Bytes) (Bytes, error) {
 
 // IRange returns an iterator over records with keys in [start, end],
 // merged across the memtable and relevant SSTables.
-func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (Iterator[Record], error) {
+//
+// The returned iterator must be closed when no longer needed to release
+// any associated resources.
+func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (*RangeIterator, error) {
 	ctx, span := tracer.Start(ctx, "db.irange")
 	if span.IsRecording() {
 		span.SetAttributes(
@@ -192,7 +195,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (Iterator[Record],
 
 	pq := buildRangePQ(iterators)
 
-	return &mergedIRange{pq: pq, cleanup: cleanup}, nil
+	return &RangeIterator{pq: pq, cleanup: cleanup}, nil
 }
 
 type pqItem struct {
@@ -221,7 +224,10 @@ func buildRangePQ(iterators []Iterator[Record]) *PriorityQueue[pqItem] {
 	return pq
 }
 
-type mergedIRange struct {
+// RangeIterator merges multiple iterators and iterates over them in order.
+// It implements Iterator[Record] and provides a Close method for resource
+// cleanup.
+type RangeIterator struct {
 	pq         *PriorityQueue[pqItem]
 	lastKey    Bytes
 	lastKeySet bool
@@ -231,7 +237,7 @@ type mergedIRange struct {
 	err        error
 }
 
-func (m *mergedIRange) prepare() {
+func (m *RangeIterator) prepare() {
 	for !m.prepared && m.err == nil && m.pq.Len() > 0 {
 		item := m.pq.PopItem()
 		key := item.rec.GetKey()
@@ -262,13 +268,13 @@ func (m *mergedIRange) prepare() {
 }
 
 // HasNext implements Iterator[Record].
-func (m *mergedIRange) HasNext() bool {
+func (m *RangeIterator) HasNext() bool {
 	m.prepare()
 	return m.prepared
 }
 
 // Next implements Iterator[Record].
-func (m *mergedIRange) Next() (Record, error) {
+func (m *RangeIterator) Next() (Record, error) {
 	if !m.HasNext() {
 		var empty Record
 		if m.err != nil {
@@ -281,7 +287,7 @@ func (m *mergedIRange) Next() (Record, error) {
 }
 
 // Close releases any resources held by the iterator. It is safe to call multiple times.
-func (m *mergedIRange) Close() error {
+func (m *RangeIterator) Close() error {
 	if m.cleanup != nil {
 		m.cleanup()
 		m.cleanup = nil

--- a/test_utils.go
+++ b/test_utils.go
@@ -340,7 +340,9 @@ func assertIteratorRecords(t *testing.T, iter Iterator[Record], expected []Recor
 	assert.Equal(t, len(expected), idx, "Number of records iterated does not match expected count")
 	_, err := iter.Next()
 	assert.ErrorIs(t, err, EOI, "Iterator should return EOI after iterating through all expected records")
-	_ = CloseIterator(iter)
+	if c, ok := iter.(interface{ Close() error }); ok {
+		_ = c.Close()
+	}
 }
 
 // assertIteratorValues iterates through a generic Iterator[T] and asserts that the values match the expected slice.


### PR DESCRIPTION
## Summary
- return a `RangeIterator` from `IRange` that exposes a `Close` method
- update range tests and CLI to call `iter.Close()` directly
- clean up test utilities to close iterators when possible

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a09dcece9083258fbffad708916a13