### PR TITLE
test: add span name analyzer unit tests

### DIFF
--- a/tool/spanname/main.go
+++ b/tool/spanname/main.go
@@ -29,7 +29,7 @@ var Analyzer = &analysis.Analyzer{
 					currentFunc = nil
 				}
 			case *ast.CallExpr:
-				if currentFunc == nil {
+				if !push || currentFunc == nil {
 					return true
 				}
 				// opt-out via comment

--- a/tool/spanname/main_test.go
+++ b/tool/spanname/main_test.go
@@ -50,19 +50,15 @@ func (t T) MethodValueBad() { tracer.Start(context.Background(), "MethodValueBad
 func Ignored() { tracer.Start(context.Background(), "Whatever") }
 `
 	diags := runAnalyzer(t, src)
-	msgs := map[string]struct{}{}
-	for _, d := range diags {
-		msgs[d.Message] = struct{}{}
-	}
-	require.Len(t, msgs, 3)
+	require.Len(t, diags, 3)
 	want := []string{
 		"span name \"Nope\" does not match function \"Bad\"",
 		"span name \"MethodPointerBad\" does not match function \"S.MethodPointerBad\"",
 		"span name \"MethodValueBad\" does not match function \"T.MethodValueBad\"",
 	}
-	got := make([]string, 0, len(msgs))
-	for m := range msgs {
-		got = append(got, m)
+	got := make([]string, 0, len(diags))
+	for _, d := range diags {
+		got = append(got, d.Message)
 	}
 	require.ElementsMatch(t, want, got)
 }


### PR DESCRIPTION
## Summary
- add tests exercising spanname analyzer for mismatched spans and ignored functions

## Testing
- `make check` *(fails: internal error in staticcheck import unsupported version)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a28ac4534483258076e1c5e1bf1792