### PR TITLE
chore: run staticcheck via go run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ check:
 	@$(MAKE) check-spanname
 	@go fmt ./...
 	@echo "Running staticcheck..."
-	@go install honnef.co/go/tools/cmd/staticcheck@v0.5.0
-	@staticcheck ./...
+	@go run honnef.co/go/tools/cmd/staticcheck@v0.5.0 ./...
 	@echo "Done."
 
 check-spanname:


### PR DESCRIPTION
## Summary
- run staticcheck through `go run` to avoid repeated installations

## Testing
- `make check` *(fails: internal error importing std packages)*
- `make test` *(did not complete: hang)*

------
https://chatgpt.com/codex/tasks/task_e_68a310e20878832588ee987f3bd9854c