### PR TITLE
test: add integration tests for concurrency and transactions

### DIFF
--- a/integration/concurrency_test.go
+++ b/integration/concurrency_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestConcurrentPutGet(t *testing.T) {
+	db, cleanup := initTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			key := rindb.Bytes(fmt.Sprintf("key-%d", i))
+			val := rindb.Bytes(fmt.Sprintf("value-%d", i))
+			require.NoError(t, db.Put(ctx, key, val))
+			got, err := db.Get(ctx, key)
+			require.NoError(t, err)
+			require.Equal(t, val, got)
+		}()
+	}
+
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		key := rindb.Bytes(fmt.Sprintf("key-%d", i))
+		val := rindb.Bytes(fmt.Sprintf("value-%d", i))
+		got, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.Equal(t, val, got)
+	}
+}

--- a/integration/concurrency_test.go
+++ b/integration/concurrency_test.go
@@ -5,7 +5,6 @@ package rindb_test
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,33 +14,21 @@ import (
 
 func TestConcurrentPutGet(t *testing.T) {
 	db, cleanup := initTestDB(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	ctx := context.Background()
 
 	const goroutines = 50
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
 
 	for i := 0; i < goroutines; i++ {
 		i := i
-		go func() {
-			defer wg.Done()
+		t.Run(fmt.Sprintf("put-get-%d", i), func(t *testing.T) {
+			t.Parallel()
 			key := rindb.Bytes(fmt.Sprintf("key-%d", i))
 			val := rindb.Bytes(fmt.Sprintf("value-%d", i))
 			require.NoError(t, db.Put(ctx, key, val))
 			got, err := db.Get(ctx, key)
 			require.NoError(t, err)
 			require.Equal(t, val, got)
-		}()
-	}
-
-	wg.Wait()
-
-	for i := 0; i < goroutines; i++ {
-		key := rindb.Bytes(fmt.Sprintf("key-%d", i))
-		val := rindb.Bytes(fmt.Sprintf("value-%d", i))
-		got, err := db.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, val, got)
+		})
 	}
 }

--- a/integration/transaction_test.go
+++ b/integration/transaction_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestTransactionManagerIntegration(t *testing.T) {
+	ctx := context.Background()
+	cfg := rindb.NewConfig(rindb.WithDatabaseDir(t.TempDir()))
+	w, err := rindb.DefaultNewWALFunc(ctx, cfg)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, w.Close()) }()
+
+	tm := rindb.NewTransactionManager()
+
+	t.Run("commit", func(t *testing.T) {
+		require.NoError(t, w.Clean())
+		txn := tm.Begin()
+		rec := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("value"), SequenceNumber: 1}
+		require.NoError(t, rindb.WriteRecord(txn, rec))
+		require.NoError(t, txn.Commit(ctx, w))
+		require.NoError(t, w.Sync())
+
+		mem, err := w.Load(ctx)
+		require.NoError(t, err)
+		got, err := mem.Get(rindb.Bytes("key"))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes("value"), got)
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		require.NoError(t, w.Clean())
+		txn := tm.Begin()
+		rec := rindb.RecordImpl{Key: rindb.Bytes("key2"), Value: rindb.Bytes("value2"), SequenceNumber: 1}
+		require.NoError(t, rindb.WriteRecord(txn, rec))
+		require.NoError(t, txn.Rollback(ctx))
+		require.NoError(t, w.Sync())
+
+		mem, err := w.Load(ctx)
+		require.NoError(t, err)
+		_, err = mem.Get(rindb.Bytes("key2"))
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
- add concurrency integration test exercising parallel Put/Get
- add transaction manager integration test covering commit and rollback

## Testing
- `make check` *(fails: internal error in staticcheck)*
- `go fmt ./...`
- `go vet -vettool=$(pwd)/bin/spanname ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `make test`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_68a9edc0e6b483258b5d172a63a58724