### PR TITLE
test: add integration test for range queries

### DIFF
--- a/integration/range_query_test.go
+++ b/integration/range_query_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func countOpenFiles(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	return len(entries)
+}
+
+func TestIRangeRangeQuery(t *testing.T) {
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(50))
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	large1 := strings.Repeat("a", 30)
+	large2 := strings.Repeat("b", 30)
+
+	require.NoError(t, db.Put(ctx, rindb.Bytes("old"), rindb.Bytes(large1)))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("sst"), rindb.Bytes(large2)))
+
+	require.NoError(t, db.Remove(ctx, rindb.Bytes("old")))
+
+	require.NoError(t, db.Put(ctx, rindb.Bytes("mem1"), rindb.Bytes("1")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("mem2"), rindb.Bytes("2")))
+
+	filesBefore := countOpenFiles(t)
+
+	iter, err := db.IRange(ctx, rindb.Bytes("a"), rindb.Bytes("z"))
+	require.NoError(t, err)
+
+	var keys []string
+	for iter.HasNext() {
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		keys = append(keys, string(rec.GetKey()))
+	}
+
+	require.True(t, sort.StringsAreSorted(keys))
+	require.Equal(t, []string{"mem1", "mem2", "sst"}, keys)
+	require.NotContains(t, keys, "old")
+
+	require.NoError(t, iter.Close())
+	filesAfter := countOpenFiles(t)
+	require.Less(t, filesAfter, filesBefore)
+}

--- a/integration/range_query_test.go
+++ b/integration/range_query_test.go
@@ -5,6 +5,7 @@ package rindb_test
 import (
 	"context"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -16,24 +17,34 @@ import (
 
 func countOpenFiles(t *testing.T) int {
 	t.Helper()
-	entries, err := os.ReadDir("/proc/self/fd")
+
+	dir := "/proc/self/fd"
+	if runtime.GOOS == "darwin" {
+		dir = "/dev/fd"
+	}
+
+	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	return len(entries)
 }
 
 func TestIRangeRangeQuery(t *testing.T) {
-	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(50))
+	// Increase maxMemtableSize so some records remain unflushed.
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(300))
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 
 	large1 := strings.Repeat("a", 30)
 	large2 := strings.Repeat("b", 30)
 
+	// These entries will be flushed to an SSTable.
 	require.NoError(t, db.Put(ctx, rindb.Bytes("old"), rindb.Bytes(large1)))
 	require.NoError(t, db.Put(ctx, rindb.Bytes("sst"), rindb.Bytes(large2)))
+	// Write outside the query range to trigger the flush.
+	require.NoError(t, db.Put(ctx, rindb.Bytes("0_trigger_flush"), rindb.Bytes("d")))
 
+	// These operations remain in the memtable.
 	require.NoError(t, db.Remove(ctx, rindb.Bytes("old")))
-
 	require.NoError(t, db.Put(ctx, rindb.Bytes("mem1"), rindb.Bytes("1")))
 	require.NoError(t, db.Put(ctx, rindb.Bytes("mem2"), rindb.Bytes("2")))
 


### PR DESCRIPTION
## Summary
- add integration test exercising IRange across memtable, flushed SSTable, and tombstoned keys

## Testing
- `make check` *(fails: staticcheck internal error: unsupported version)*
- `make test`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_68aa658d7de88325be27272272c2fdd5