### PR TITLE
test: add integration test for remove persistence

### DIFF
--- a/integration/remove_persistence_test.go
+++ b/integration/remove_persistence_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestRemovePersistsTombstone(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	const maxMemtableSize = uint(64)
+
+	db, err := rindb.InitRinDB(ctx,
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(maxMemtableSize),
+	)
+	require.NoError(t, err)
+
+	key := rindb.Bytes("k1")
+	val := rindb.Bytes("v1")
+	require.NoError(t, db.Put(ctx, key, val))
+	require.NoError(t, db.Remove(ctx, key))
+
+	bigVal := make([]byte, maxMemtableSize)
+	require.NoError(t, db.Put(ctx, rindb.Bytes("other"), bigVal))
+
+	require.NoError(t, db.Close())
+
+	db, err = rindb.InitRinDB(ctx,
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(maxMemtableSize),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	_, err = db.Get(ctx, key)
+	require.ErrorIs(t, err, rindb.ErrKeyNotFound)
+}


### PR DESCRIPTION
## Summary
- add integration test ensuring Remove tombstones persist across flushes and restarts

## Testing
- `make check` *(fails: internal error in staticcheck about unsupported version)*
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `make test`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_68aa6bbf09848325ae0eb540e1e9a014