### PR TITLE
test: add compaction integration test

### DIFF
--- a/integration/compaction_test.go
+++ b/integration/compaction_test.go
@@ -23,8 +23,8 @@ func TestCompactionMovesSSTablesToNextLevel(t *testing.T) {
 	kvs := []struct{ key, val string }{
 		{"k1", "v1"},
 		{"k2", "v2"},
+		{"k1", "v1_new"}, // update k1 to create multiple versions
 		{"k3", "v3"},
-		{"k4", "v4"},
 	}
 	for _, kv := range kvs {
 		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
@@ -38,9 +38,14 @@ func TestCompactionMovesSSTablesToNextLevel(t *testing.T) {
 		return st.SSTablesPerLevel[0] == 0 && st.SSTablesPerLevel[1] > 0
 	}, 5*time.Second, 100*time.Millisecond, "compaction did not move SSTables to next level")
 
-	for _, kv := range kvs {
-		got, err := db.Get(ctx, rindb.Bytes(kv.key))
+	expectedKVs := map[string]string{
+		"k1": "v1_new",
+		"k2": "v2",
+		"k3": "v3",
+	}
+	for key, val := range expectedKVs {
+		got, err := db.Get(ctx, rindb.Bytes(key))
 		require.NoError(t, err)
-		require.Equal(t, rindb.Bytes(kv.val), got)
+		require.Equal(t, rindb.Bytes(val), got, "key: %s", key)
 	}
 }

--- a/integration/compaction_test.go
+++ b/integration/compaction_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestCompactionMovesSSTablesToNextLevel(t *testing.T) {
+	db, cleanup := initTestDB(t,
+		rindb.WithLevel0CompactionThreshold(2),
+		rindb.WithMaxMemtableSize(1),
+	)
+	defer cleanup()
+	ctx := context.Background()
+
+	kvs := []struct{ key, val string }{
+		{"k1", "v1"},
+		{"k2", "v2"},
+		{"k3", "v3"},
+		{"k4", "v4"},
+	}
+	for _, kv := range kvs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+
+	require.Eventually(t, func() bool {
+		st := db.Stats()
+		if len(st.SSTablesPerLevel) < 2 {
+			return false
+		}
+		return st.SSTablesPerLevel[0] == 0 && st.SSTablesPerLevel[1] > 0
+	}, 5*time.Second, 100*time.Millisecond, "compaction did not move SSTables to next level")
+
+	for _, kv := range kvs {
+		got, err := db.Get(ctx, rindb.Bytes(kv.key))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes(kv.val), got)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test for SSTable compaction

## Testing
- `make check` *(fails: internal error in staticcheck with Go 1.24)*
- `make test`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_68aa6bb418ac8325a96df334342f0a9e