### PR TITLE
test: verify memtable flush persistence

### DIFF
--- a/integration/flush_test.go
+++ b/integration/flush_test.go
@@ -13,21 +13,33 @@ import (
 
 func TestFlushPersistsDataToSSTables(t *testing.T) {
 	dir := t.TempDir()
-	db, cleanup := initTestDB(t, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
 	ctx := context.Background()
+
+	// An entry with a small key/value has an estimated size of ~87 bytes (key + value + node overhead).
+	// To trigger a flush once the memtable is full with 2 entries, we set the max size
+	// to a value that will be exceeded by the 3rd entry.
+	const maxMemtableSize = 175
+	opts := []rindb.Option{
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(maxMemtableSize),
+	}
+
+	// Phase 1: Create DB, write data to trigger a flush, then close.
+	db, err := rindb.InitRinDB(ctx, opts...)
+	require.NoError(t, err)
 
 	kvs := []struct{ key, val string }{
 		{"k1", "v1"},
 		{"k2", "v2"},
-		{"k3", "v3"},
+		{"k3", "v3"}, // This 3rd entry should trigger the flush.
 	}
 	for _, kv := range kvs {
 		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
 	}
+	require.NoError(t, db.Close())
 
-	cleanup()
-
-	reopened, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
+	// Phase 2: Reopen DB and verify all data was persisted.
+	reopened, err := rindb.InitRinDB(ctx, opts...)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
 

--- a/integration/flush_test.go
+++ b/integration/flush_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestFlushPersistsDataToSSTables(t *testing.T) {
+	dir := t.TempDir()
+	db, cleanup := initTestDB(t, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
+	ctx := context.Background()
+
+	kvs := []struct{ key, val string }{
+		{"k1", "v1"},
+		{"k2", "v2"},
+		{"k3", "v3"},
+	}
+	for _, kv := range kvs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+
+	cleanup()
+
+	reopened, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+
+	for _, kv := range kvs {
+		got, err := reopened.Get(ctx, rindb.Bytes(kv.key))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes(kv.val), got)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration test verifying memtable flush writes data to SSTables

## Testing
- `make check` *(fails: check-spanname interrupt)*
- `go vet ./...`
- `staticcheck ./...`
- `make test`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_68aa6b5ccc108325b736908d12e32d2e