### PR TITLE
test: add WAL recovery integration test

### DIFF
--- a/integration/wal_recovery_test.go
+++ b/integration/wal_recovery_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+var walRecoveryKVs = []struct{ key, val string }{
+	{"k1", "v1"},
+	{"k2", "v2"},
+	{"k3", "v3"},
+}
+
+func TestWALRecovery(t *testing.T) {
+	dir := os.Getenv("WAL_RECOVERY_TEST_DIR")
+	if dir != "" {
+		walRecoveryHelper(t, dir)
+		return
+	}
+
+	dir = t.TempDir()
+
+	cmd := exec.Command(os.Args[0], "-test.run", "TestWALRecovery", "-test.v")
+	cmd.Env = append(os.Environ(), "WAL_RECOVERY_TEST_DIR="+dir)
+	require.NoError(t, cmd.Run())
+
+	ctx := context.Background()
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	for _, kv := range walRecoveryKVs {
+		got, err := db.Get(ctx, rindb.Bytes(kv.key))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes(kv.val), got)
+	}
+}
+
+func walRecoveryHelper(t *testing.T, dir string) {
+	ctx := context.Background()
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir))
+	require.NoError(t, err)
+
+	for _, kv := range walRecoveryKVs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+
+	os.Exit(0)
+}

--- a/integration/wal_recovery_test.go
+++ b/integration/wal_recovery_test.go
@@ -23,12 +23,16 @@ func TestWALRecovery(t *testing.T) {
 	dir := os.Getenv("WAL_RECOVERY_TEST_DIR")
 	if dir != "" {
 		walRecoveryHelper(t, dir)
-		return
+		os.Exit(0)
 	}
 
 	dir = t.TempDir()
 
-	cmd := exec.Command(os.Args[0], "-test.run", "TestWALRecovery", "-test.v")
+	args := []string{"-test.run", "TestWALRecovery"}
+	if testing.Verbose() {
+		args = append(args, "-test.v")
+	}
+	cmd := exec.Command(os.Args[0], args...)
 	cmd.Env = append(os.Environ(), "WAL_RECOVERY_TEST_DIR="+dir)
 	require.NoError(t, cmd.Run())
 
@@ -45,6 +49,7 @@ func TestWALRecovery(t *testing.T) {
 }
 
 func walRecoveryHelper(t *testing.T, dir string) {
+	t.Helper()
 	ctx := context.Background()
 	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir))
 	require.NoError(t, err)
@@ -52,6 +57,4 @@ func walRecoveryHelper(t *testing.T, dir string) {
 	for _, kv := range walRecoveryKVs {
 		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
 	}
-
-	os.Exit(0)
 }


### PR DESCRIPTION
## Summary
- add WAL recovery integration test to verify WAL replay after unclean shutdown
- invoke helper via env-gated path to avoid skip output

## Testing
- `make check` *(fails: internal error in importing "cmp" (unsupported version: 2))*
- `make test`
- `make test-integration`


------
https://chatgpt.com/codex/tasks/task_e_68aa6bb5e844832592e903869dc6fa04