### PR TITLE
test: add smoke integration test targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@
 - `make check`: Formats (`go fmt`), builds `tool/spanname`, runs `go vet` with it, then `staticcheck`.
 - `make test`: Cleans `testdata/` and runs all tests verbosely.
 - `make test-coverage`: Runs tests with coverage and opens the HTML report.
-- `make test-integration`: Runs integration tests (requires the `integration` build tag).
+- `make test-integration-smoke`: Runs quick integration tests with `integration` and `smoke` build tags.
+- `make test-integration-full`: Runs full integration tests (requires the `integration` build tag).
+- `make test-integration`: Alias for `make test-integration-full`.
 - `go build -o rindb cmd/main.go`: Builds the sample CLI. Example: `./rindb` then `put key val`.
 
 ## Coding Style & Naming
@@ -24,7 +26,7 @@
 - Frameworks: Standard `testing` with `testify` for assertions.
 - Style: Prefer table‑driven tests; name tests `TestXxx` in `*_test.go`.
 - Data: Write temp files under `testdata/`. Tests clean this directory; do not commit generated artifacts.
-- Integration tests live in `integration/` and are gated by the `integration` build tag. Run them with `make test-integration`.
+- Integration tests live in `integration/` and use build tags. Run quick tests with `make test-integration-smoke` and the full suite with `make test-integration-full`.
 - Run: `make test` locally; use `t.Helper()` for helpers and avoid global state between tests.
 
 ## Commit & Pull Requests

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,26 @@ check:
 	@go run honnef.co/go/tools/cmd/staticcheck@v0.5.0 ./...
 	@echo "Done."
 
-
 check-spanname:
 	@go build -o ./bin/spanname ./tool/spanname
 	@go vet -vettool=$$(pwd)/bin/spanname ./...
-
 
 test:
 	@rm -rf testdata/*
 	@echo "Running tests..."
 	@go test -v ./...
 
-test-integration:
+test-integration-smoke:
 	@rm -rf testdata/*
-	@echo "Running integration tests..."
+	@echo "Running smoke integration tests..."
+	@go test -v -tags "integration smoke" ./integration
+
+test-integration-full:
+	@rm -rf testdata/*
+	@echo "Running full integration tests..."
 	@go test -v -tags integration ./integration
+
+test-integration: test-integration-full
 
 test-coverage:
 	@rm -rf testdata/*
@@ -27,7 +32,6 @@ test-coverage:
 	@go test -v -coverprofile=coverage.out ./...
 	@go tool cover -html=coverage.out
 	@rm coverage.out
-
 
 test-pprof:
 	@./scripts/run-pprof-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -9,25 +9,25 @@ check-spanname:
 	@go build -o ./bin/spanname ./tool/spanname
 	@go vet -vettool=$$(pwd)/bin/spanname ./...
 
-test:
+.PHONY: clean-testdata
+clean-testdata:
 	@rm -rf testdata/*
+
+test: clean-testdata
 	@echo "Running tests..."
 	@go test -v ./...
 
-test-integration-smoke:
-	@rm -rf testdata/*
+test-integration-smoke: clean-testdata
 	@echo "Running smoke integration tests..."
 	@go test -v -tags "integration smoke" ./integration
 
-test-integration-full:
-	@rm -rf testdata/*
+test-integration-full: clean-testdata
 	@echo "Running full integration tests..."
 	@go test -v -tags integration ./integration
 
 test-integration: test-integration-full
 
-test-coverage:
-	@rm -rf testdata/*
+test-coverage: clean-testdata
 	@echo "Running tests with coverage..."
 	@go test -v -coverprofile=coverage.out ./...
 	@go tool cover -html=coverage.out

--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ Run tests with coverage:
 make test-coverage
 ```
 
+Run smoke integration tests:
+
+```bash
+make test-integration-smoke
+```
+
+Run full integration tests:
+
+```bash
+make test-integration-full
+```
+
 Build the CLI:
 
 ```bash

--- a/integration/flush_test.go
+++ b/integration/flush_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/range_query_test.go
+++ b/integration/range_query_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/recovery_test.go
+++ b/integration/recovery_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/remove_persistence_test.go
+++ b/integration/remove_persistence_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/transaction_test.go
+++ b/integration/transaction_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 


### PR DESCRIPTION
## Summary
- mark quick integration tests with `integration && smoke`
- add `test-integration-smoke` and `test-integration-full` targets
- document integration test commands

## Testing
- `make check` *(fails: internal error in staticcheck import)*
- `make test`
- `make test-integration-smoke`
- `make test-integration-full`


------
https://chatgpt.com/codex/tasks/task_e_68aaab17c250832595a4e1733ed79e1d