### PR TITLE
chore: add coverage report and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run checks
         run: make check
-      - name: Run tests
-        run: go test -v -coverprofile=coverage.txt ./...
+      - name: Run unit tests with coverage
+        run: make test-coverage
+      - name: Run smoke integration tests
+        run: make test-integration-smoke
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ testdata/*
 !testdata/.keep
 .aider*
 coverage.out
+coverage.txt
 
 # IDE-specific files
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,7 @@ test-integration: test-integration-full
 
 test-coverage: clean-testdata
 	@echo "Running tests with coverage..."
-	@go test -v -coverprofile=coverage.out ./...
-	@go tool cover -html=coverage.out
-	@rm coverage.out
+	@go test -v -coverprofile=coverage.txt ./...
 
 test-pprof:
 	@./scripts/run-pprof-tests.sh


### PR DESCRIPTION
## Summary
- generate coverage.txt via Makefile test-coverage target
- ignore coverage.txt in git and run smoke integration tests in CI

## Testing
- `GOTOOLCHAIN=go1.23.4 make check`
- `GOTOOLCHAIN=go1.23.4 make test`
- `GOTOOLCHAIN=go1.23.4 make test-coverage`
- `GOTOOLCHAIN=go1.23.4 make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68aab1b58f488325b82d65a50197e516