### PR TITLE
feat: Add comprehensive integration tests for RinDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
             ${{ runner.os }}-go-
       - name: Run checks
         run: make check
-      - name: Run tests
-        run: go test -v -coverprofile=coverage.txt ./...
+      - name: Run unit tests with coverage
+        run: make test-coverage
+      - name: Run smoke integration tests
+        run: make test-integration-smoke
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ testdata/*
 !testdata/.keep
 .aider*
 coverage.out
+coverage.txt
 
 # IDE-specific files
 .vscode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - `make check`: Formats (`go fmt`), builds `tool/spanname`, runs `go vet` with it, then `staticcheck`.
 - `make test`: Cleans `testdata/` and runs all tests verbosely.
 - `make test-coverage`: Runs tests with coverage and opens the HTML report.
+- `make test-integration`: Runs integration tests (requires the `integration` build tag).
 - `go build -o rindb cmd/main.go`: Builds the sample CLI. Example: `./rindb` then `put key val`.
 
 ## Coding Style & Naming
@@ -23,7 +24,7 @@
 - Frameworks: Standard `testing` with `testify` for assertions.
 - Style: Prefer table‑driven tests; name tests `TestXxx` in `*_test.go`.
 - Data: Write temp files under `testdata/`. Tests clean this directory; do not commit generated artifacts.
-- Integration tests live in `integration/` and are gated by the `integration` build tag. Run them with `go test -tags integration ./integration` using the `initTestDB` helper.
+- Integration tests live in `integration/` and are gated by the `integration` build tag. Run them with `make test-integration`.
 - Run: `make test` locally; use `t.Helper()` for helpers and avoid global state between tests.
 
 ## Commit & Pull Requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@
 - `make check`: Formats (`go fmt`), builds `tool/spanname`, runs `go vet` with it, then `staticcheck`.
 - `make test`: Cleans `testdata/` and runs all tests verbosely.
 - `make test-coverage`: Runs tests with coverage and opens the HTML report.
-- `make test-integration`: Runs integration tests (requires the `integration` build tag).
+- `make test-integration-smoke`: Runs quick integration tests with `integration` and `smoke` build tags.
+- `make test-integration-full`: Runs full integration tests (requires the `integration` build tag).
+- `make test-integration`: Alias for `make test-integration-full`.
 - `go build -o rindb cmd/main.go`: Builds the sample CLI. Example: `./rindb` then `put key val`.
 
 ## Coding Style & Naming
@@ -24,7 +26,7 @@
 - Frameworks: Standard `testing` with `testify` for assertions.
 - Style: Prefer table‑driven tests; name tests `TestXxx` in `*_test.go`.
 - Data: Write temp files under `testdata/`. Tests clean this directory; do not commit generated artifacts.
-- Integration tests live in `integration/` and are gated by the `integration` build tag. Run them with `make test-integration`.
+- Integration tests live in `integration/` and use build tags. Run quick tests with `make test-integration-smoke` and the full suite with `make test-integration-full`.
 - Run: `make test` locally; use `t.Helper()` for helpers and avoid global state between tests.
 
 ## Commit & Pull Requests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Frameworks: Standard `testing` with `testify` for assertions.
 - Style: Prefer table‑driven tests; name tests `TestXxx` in `*_test.go`.
 - Data: Write temp files under `testdata/`. Tests clean this directory; do not commit generated artifacts.
+- Integration tests live in `integration/` and are gated by the `integration` build tag. Run them with `go test -tags integration ./integration` using the `initTestDB` helper.
 - Run: `make test` locally; use `t.Helper()` for helpers and avoid global state between tests.
 
 ## Commit & Pull Requests

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test:
 	@echo "Running tests..."
 	@go test -v ./...
 
+test-integration:
+	@rm -rf testdata/*
+	@echo "Running integration tests..."
+	@go test -v -tags integration ./integration
 
 test-coverage:
 	@rm -rf testdata/*

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,26 @@ check:
 	@go run honnef.co/go/tools/cmd/staticcheck@v0.5.0 ./...
 	@echo "Done."
 
-
 check-spanname:
 	@go build -o ./bin/spanname ./tool/spanname
 	@go vet -vettool=$$(pwd)/bin/spanname ./...
-
 
 test:
 	@rm -rf testdata/*
 	@echo "Running tests..."
 	@go test -v ./...
 
-test-integration:
+test-integration-smoke:
 	@rm -rf testdata/*
-	@echo "Running integration tests..."
+	@echo "Running smoke integration tests..."
+	@go test -v -tags "integration smoke" ./integration
+
+test-integration-full:
+	@rm -rf testdata/*
+	@echo "Running full integration tests..."
 	@go test -v -tags integration ./integration
+
+test-integration: test-integration-full
 
 test-coverage:
 	@rm -rf testdata/*
@@ -27,7 +32,6 @@ test-coverage:
 	@go test -v -coverprofile=coverage.out ./...
 	@go tool cover -html=coverage.out
 	@rm coverage.out
-
 
 test-pprof:
 	@./scripts/run-pprof-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -9,25 +9,25 @@ check-spanname:
 	@go build -o ./bin/spanname ./tool/spanname
 	@go vet -vettool=$$(pwd)/bin/spanname ./...
 
-test:
+.PHONY: clean-testdata
+clean-testdata:
 	@rm -rf testdata/*
+
+test: clean-testdata
 	@echo "Running tests..."
 	@go test -v ./...
 
-test-integration-smoke:
-	@rm -rf testdata/*
+test-integration-smoke: clean-testdata
 	@echo "Running smoke integration tests..."
 	@go test -v -tags "integration smoke" ./integration
 
-test-integration-full:
-	@rm -rf testdata/*
+test-integration-full: clean-testdata
 	@echo "Running full integration tests..."
 	@go test -v -tags integration ./integration
 
 test-integration: test-integration-full
 
-test-coverage:
-	@rm -rf testdata/*
+test-coverage: clean-testdata
 	@echo "Running tests with coverage..."
 	@go test -v -coverprofile=coverage.out ./...
 	@go tool cover -html=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,7 @@ test-integration: test-integration-full
 
 test-coverage: clean-testdata
 	@echo "Running tests with coverage..."
-	@go test -v -coverprofile=coverage.out ./...
-	@go tool cover -html=coverage.out
-	@rm coverage.out
+	@go test -v -coverprofile=coverage.txt ./...
 
 test-pprof:
 	@./scripts/run-pprof-tests.sh

--- a/README.md
+++ b/README.md
@@ -119,6 +119,18 @@ Run tests with coverage:
 make test-coverage
 ```
 
+Run smoke integration tests:
+
+```bash
+make test-integration-smoke
+```
+
+Run full integration tests:
+
+```bash
+make test-integration-full
+```
+
 Build the CLI:
 
 ```bash

--- a/integration/compaction_test.go
+++ b/integration/compaction_test.go
@@ -23,8 +23,8 @@ func TestCompactionMovesSSTablesToNextLevel(t *testing.T) {
 	kvs := []struct{ key, val string }{
 		{"k1", "v1"},
 		{"k2", "v2"},
+		{"k1", "v1_new"}, // update k1 to create multiple versions
 		{"k3", "v3"},
-		{"k4", "v4"},
 	}
 	for _, kv := range kvs {
 		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
@@ -38,9 +38,14 @@ func TestCompactionMovesSSTablesToNextLevel(t *testing.T) {
 		return st.SSTablesPerLevel[0] == 0 && st.SSTablesPerLevel[1] > 0
 	}, 5*time.Second, 100*time.Millisecond, "compaction did not move SSTables to next level")
 
-	for _, kv := range kvs {
-		got, err := db.Get(ctx, rindb.Bytes(kv.key))
+	expectedKVs := map[string]string{
+		"k1": "v1_new",
+		"k2": "v2",
+		"k3": "v3",
+	}
+	for key, val := range expectedKVs {
+		got, err := db.Get(ctx, rindb.Bytes(key))
 		require.NoError(t, err)
-		require.Equal(t, rindb.Bytes(kv.val), got)
+		require.Equal(t, rindb.Bytes(val), got, "key: %s", key)
 	}
 }

--- a/integration/compaction_test.go
+++ b/integration/compaction_test.go
@@ -1,0 +1,46 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestCompactionMovesSSTablesToNextLevel(t *testing.T) {
+	db, cleanup := initTestDB(t,
+		rindb.WithLevel0CompactionThreshold(2),
+		rindb.WithMaxMemtableSize(1),
+	)
+	defer cleanup()
+	ctx := context.Background()
+
+	kvs := []struct{ key, val string }{
+		{"k1", "v1"},
+		{"k2", "v2"},
+		{"k3", "v3"},
+		{"k4", "v4"},
+	}
+	for _, kv := range kvs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+
+	require.Eventually(t, func() bool {
+		st := db.Stats()
+		if len(st.SSTablesPerLevel) < 2 {
+			return false
+		}
+		return st.SSTablesPerLevel[0] == 0 && st.SSTablesPerLevel[1] > 0
+	}, 5*time.Second, 100*time.Millisecond, "compaction did not move SSTables to next level")
+
+	for _, kv := range kvs {
+		got, err := db.Get(ctx, rindb.Bytes(kv.key))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes(kv.val), got)
+	}
+}

--- a/integration/concurrency_test.go
+++ b/integration/concurrency_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestConcurrentPutGet(t *testing.T) {
+	db, cleanup := initTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			key := rindb.Bytes(fmt.Sprintf("key-%d", i))
+			val := rindb.Bytes(fmt.Sprintf("value-%d", i))
+			require.NoError(t, db.Put(ctx, key, val))
+			got, err := db.Get(ctx, key)
+			require.NoError(t, err)
+			require.Equal(t, val, got)
+		}()
+	}
+
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		key := rindb.Bytes(fmt.Sprintf("key-%d", i))
+		val := rindb.Bytes(fmt.Sprintf("value-%d", i))
+		got, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.Equal(t, val, got)
+	}
+}

--- a/integration/concurrency_test.go
+++ b/integration/concurrency_test.go
@@ -5,7 +5,6 @@ package rindb_test
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,33 +14,21 @@ import (
 
 func TestConcurrentPutGet(t *testing.T) {
 	db, cleanup := initTestDB(t)
-	defer cleanup()
+	t.Cleanup(cleanup)
 	ctx := context.Background()
 
 	const goroutines = 50
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
 
 	for i := 0; i < goroutines; i++ {
 		i := i
-		go func() {
-			defer wg.Done()
+		t.Run(fmt.Sprintf("put-get-%d", i), func(t *testing.T) {
+			t.Parallel()
 			key := rindb.Bytes(fmt.Sprintf("key-%d", i))
 			val := rindb.Bytes(fmt.Sprintf("value-%d", i))
 			require.NoError(t, db.Put(ctx, key, val))
 			got, err := db.Get(ctx, key)
 			require.NoError(t, err)
 			require.Equal(t, val, got)
-		}()
-	}
-
-	wg.Wait()
-
-	for i := 0; i < goroutines; i++ {
-		key := rindb.Bytes(fmt.Sprintf("key-%d", i))
-		val := rindb.Bytes(fmt.Sprintf("value-%d", i))
-		got, err := db.Get(ctx, key)
-		require.NoError(t, err)
-		require.Equal(t, val, got)
+		})
 	}
 }

--- a/integration/flush_test.go
+++ b/integration/flush_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/flush_test.go
+++ b/integration/flush_test.go
@@ -13,21 +13,33 @@ import (
 
 func TestFlushPersistsDataToSSTables(t *testing.T) {
 	dir := t.TempDir()
-	db, cleanup := initTestDB(t, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
 	ctx := context.Background()
+
+	// An entry with a small key/value has an estimated size of ~87 bytes (key + value + node overhead).
+	// To trigger a flush once the memtable is full with 2 entries, we set the max size
+	// to a value that will be exceeded by the 3rd entry.
+	const maxMemtableSize = 175
+	opts := []rindb.Option{
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(maxMemtableSize),
+	}
+
+	// Phase 1: Create DB, write data to trigger a flush, then close.
+	db, err := rindb.InitRinDB(ctx, opts...)
+	require.NoError(t, err)
 
 	kvs := []struct{ key, val string }{
 		{"k1", "v1"},
 		{"k2", "v2"},
-		{"k3", "v3"},
+		{"k3", "v3"}, // This 3rd entry should trigger the flush.
 	}
 	for _, kv := range kvs {
 		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
 	}
+	require.NoError(t, db.Close())
 
-	cleanup()
-
-	reopened, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
+	// Phase 2: Reopen DB and verify all data was persisted.
+	reopened, err := rindb.InitRinDB(ctx, opts...)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
 

--- a/integration/flush_test.go
+++ b/integration/flush_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestFlushPersistsDataToSSTables(t *testing.T) {
+	dir := t.TempDir()
+	db, cleanup := initTestDB(t, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
+	ctx := context.Background()
+
+	kvs := []struct{ key, val string }{
+		{"k1", "v1"},
+		{"k2", "v2"},
+		{"k3", "v3"},
+	}
+	for _, kv := range kvs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+
+	cleanup()
+
+	reopened, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir), rindb.WithMaxMemtableSize(2))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+
+	for _, kv := range kvs {
+		got, err := reopened.Get(ctx, rindb.Bytes(kv.key))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes(kv.val), got)
+	}
+}

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -1,0 +1,26 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func initTestDB(t *testing.T, opts ...rindb.Option) (*rindb.Rindb, func()) {
+	t.Helper()
+
+	dir := t.TempDir()
+	opts = append([]rindb.Option{rindb.WithDatabaseDir(dir)}, opts...)
+
+	db, err := rindb.InitRinDB(context.Background(), opts...)
+	require.NoError(t, err)
+
+	cleanup := func() { require.NoError(t, db.Close()) }
+
+	return &db, cleanup
+}

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -4,6 +4,9 @@ package rindb_test
 
 import (
 	"context"
+	"os"
+	"runtime"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,4 +26,47 @@ func initTestDB(t *testing.T, opts ...rindb.Option) (*rindb.Rindb, func()) {
 	cleanup := func() { require.NoError(t, db.Close()) }
 
 	return db, cleanup
+}
+
+// countNumericEntriesInFDDirectory counts the number of numeric entries in the file descriptor directory for the current process.
+// This function is specifically designed to avoid `lstat` calls on macOS,
+// which can sometimes result in "bad file descriptor" errors when iterating /dev/fd.
+//
+// On Linux, it reads from /proc/self/fd.
+// On macOS, it reads from /dev/fd.
+//
+// Note: The os.Open(dir) operation itself consumes a file descriptor that is included in the returned count.
+// This function subtracts 1 from the count to exclude its own file descriptor, providing a more accurate measure of external FDs.
+func countNumericEntriesInFDDirectory(t *testing.T) int {
+	t.Helper()
+
+	// Determine the appropriate directory for file descriptors based on the OS.
+	dir := "/proc/self/fd"
+	if runtime.GOOS == "darwin" {
+		dir = "/dev/fd"
+	}
+
+	// Open the directory containing file descriptors.
+	f, err := os.Open(dir)
+	require.NoError(t, err)
+	defer f.Close() // Ensure the directory handle is closed.
+
+	// Read the names of the entries in the directory.
+	// Using Readdirnames(-1) reads all entries and avoids lstat calls,
+	// which is crucial for robustness on macOS.
+	names, err := f.Readdirnames(-1)
+	require.NoError(t, err)
+
+	count := 0
+	// Iterate through the entry names and count only those that are numeric.
+	// This counts entries whose names are numeric strings, which are typically file descriptors.
+	// It does not verify the existence, validity, or actual open status of a file descriptor.
+	// This approach is used to avoid `lstat` calls on macOS, which can cause "bad file descriptor" errors.
+	for _, n := range names {
+		if _, err := strconv.Atoi(n); err == nil {
+			count++ // Only count numeric entries (actual FDs).
+		}
+	}
+	// Subtract 1 to exclude the file descriptor opened by os.Open(dir) itself.
+	return count - 1
 }

--- a/integration/helpers_test.go
+++ b/integration/helpers_test.go
@@ -22,5 +22,5 @@ func initTestDB(t *testing.T, opts ...rindb.Option) (*rindb.Rindb, func()) {
 
 	cleanup := func() { require.NoError(t, db.Close()) }
 
-	return &db, cleanup
+	return db, cleanup
 }

--- a/integration/range_query_test.go
+++ b/integration/range_query_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func countOpenFiles(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	return len(entries)
+}
+
+func TestIRangeRangeQuery(t *testing.T) {
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(50))
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	large1 := strings.Repeat("a", 30)
+	large2 := strings.Repeat("b", 30)
+
+	require.NoError(t, db.Put(ctx, rindb.Bytes("old"), rindb.Bytes(large1)))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("sst"), rindb.Bytes(large2)))
+
+	require.NoError(t, db.Remove(ctx, rindb.Bytes("old")))
+
+	require.NoError(t, db.Put(ctx, rindb.Bytes("mem1"), rindb.Bytes("1")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("mem2"), rindb.Bytes("2")))
+
+	filesBefore := countOpenFiles(t)
+
+	iter, err := db.IRange(ctx, rindb.Bytes("a"), rindb.Bytes("z"))
+	require.NoError(t, err)
+
+	var keys []string
+	for iter.HasNext() {
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		keys = append(keys, string(rec.GetKey()))
+	}
+
+	require.True(t, sort.StringsAreSorted(keys))
+	require.Equal(t, []string{"mem1", "mem2", "sst"}, keys)
+	require.NotContains(t, keys, "old")
+
+	require.NoError(t, iter.Close())
+	filesAfter := countOpenFiles(t)
+	require.Less(t, filesAfter, filesBefore)
+}

--- a/integration/range_query_test.go
+++ b/integration/range_query_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/range_query_test.go
+++ b/integration/range_query_test.go
@@ -5,6 +5,7 @@ package rindb_test
 import (
 	"context"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -16,24 +17,34 @@ import (
 
 func countOpenFiles(t *testing.T) int {
 	t.Helper()
-	entries, err := os.ReadDir("/proc/self/fd")
+
+	dir := "/proc/self/fd"
+	if runtime.GOOS == "darwin" {
+		dir = "/dev/fd"
+	}
+
+	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	return len(entries)
 }
 
 func TestIRangeRangeQuery(t *testing.T) {
-	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(50))
+	// Increase maxMemtableSize so some records remain unflushed.
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(300))
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 
 	large1 := strings.Repeat("a", 30)
 	large2 := strings.Repeat("b", 30)
 
+	// These entries will be flushed to an SSTable.
 	require.NoError(t, db.Put(ctx, rindb.Bytes("old"), rindb.Bytes(large1)))
 	require.NoError(t, db.Put(ctx, rindb.Bytes("sst"), rindb.Bytes(large2)))
+	// Write outside the query range to trigger the flush.
+	require.NoError(t, db.Put(ctx, rindb.Bytes("0_trigger_flush"), rindb.Bytes("d")))
 
+	// These operations remain in the memtable.
 	require.NoError(t, db.Remove(ctx, rindb.Bytes("old")))
-
 	require.NoError(t, db.Put(ctx, rindb.Bytes("mem1"), rindb.Bytes("1")))
 	require.NoError(t, db.Put(ctx, rindb.Bytes("mem2"), rindb.Bytes("2")))
 

--- a/integration/range_query_test.go
+++ b/integration/range_query_test.go
@@ -4,8 +4,6 @@ package rindb_test
 
 import (
 	"context"
-	"os"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -14,19 +12,6 @@ import (
 
 	"github.com/metailurini/rindb"
 )
-
-func countOpenFiles(t *testing.T) int {
-	t.Helper()
-
-	dir := "/proc/self/fd"
-	if runtime.GOOS == "darwin" {
-		dir = "/dev/fd"
-	}
-
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	return len(entries)
-}
 
 func TestIRangeRangeQuery(t *testing.T) {
 	// Increase maxMemtableSize so some records remain unflushed.
@@ -48,7 +33,7 @@ func TestIRangeRangeQuery(t *testing.T) {
 	require.NoError(t, db.Put(ctx, rindb.Bytes("mem1"), rindb.Bytes("1")))
 	require.NoError(t, db.Put(ctx, rindb.Bytes("mem2"), rindb.Bytes("2")))
 
-	filesBefore := countOpenFiles(t)
+	filesBefore := countNumericEntriesInFDDirectory(t)
 
 	iter, err := db.IRange(ctx, rindb.Bytes("a"), rindb.Bytes("z"))
 	require.NoError(t, err)
@@ -65,6 +50,6 @@ func TestIRangeRangeQuery(t *testing.T) {
 	require.NotContains(t, keys, "old")
 
 	require.NoError(t, iter.Close())
-	filesAfter := countOpenFiles(t)
+	filesAfter := countNumericEntriesInFDDirectory(t)
 	require.Less(t, filesAfter, filesBefore)
 }

--- a/integration/recovery_test.go
+++ b/integration/recovery_test.go
@@ -1,0 +1,37 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestRecovery(t *testing.T) {
+	dir := t.TempDir()
+
+	db, cleanup := initTestDB(t, rindb.WithDatabaseDir(dir))
+	ctx := context.Background()
+	kvs := []struct{ key, val string }{
+		{"k1", "v1"},
+		{"k2", "v2"},
+		{"k3", "v3"},
+	}
+	for _, kv := range kvs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+	cleanup()
+
+	db, cleanup = initTestDB(t, rindb.WithDatabaseDir(dir))
+	defer cleanup()
+
+	for _, kv := range kvs {
+		got, err := db.Get(ctx, rindb.Bytes(kv.key))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes(kv.val), got)
+	}
+}

--- a/integration/recovery_test.go
+++ b/integration/recovery_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/recovery_test.go
+++ b/integration/recovery_test.go
@@ -11,11 +11,14 @@ import (
 	"github.com/metailurini/rindb"
 )
 
-func TestRecovery(t *testing.T) {
+func TestDataPersistenceOnReopen(t *testing.T) {
 	dir := t.TempDir()
-
-	db, cleanup := initTestDB(t, rindb.WithDatabaseDir(dir))
 	ctx := context.Background()
+	dbOpt := rindb.WithDatabaseDir(dir)
+
+	db, err := rindb.InitRinDB(ctx, dbOpt)
+	require.NoError(t, err)
+
 	kvs := []struct{ key, val string }{
 		{"k1", "v1"},
 		{"k2", "v2"},
@@ -24,10 +27,11 @@ func TestRecovery(t *testing.T) {
 	for _, kv := range kvs {
 		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
 	}
-	cleanup()
+	require.NoError(t, db.Close())
 
-	db, cleanup = initTestDB(t, rindb.WithDatabaseDir(dir))
-	defer cleanup()
+	db, err = rindb.InitRinDB(ctx, dbOpt)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
 
 	for _, kv := range kvs {
 		got, err := db.Get(ctx, rindb.Bytes(kv.key))

--- a/integration/remove_persistence_test.go
+++ b/integration/remove_persistence_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/remove_persistence_test.go
+++ b/integration/remove_persistence_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestRemovePersistsTombstone(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	const maxMemtableSize = uint(64)
+
+	db, err := rindb.InitRinDB(ctx,
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(maxMemtableSize),
+	)
+	require.NoError(t, err)
+
+	key := rindb.Bytes("k1")
+	val := rindb.Bytes("v1")
+	require.NoError(t, db.Put(ctx, key, val))
+	require.NoError(t, db.Remove(ctx, key))
+
+	bigVal := make([]byte, maxMemtableSize)
+	require.NoError(t, db.Put(ctx, rindb.Bytes("other"), bigVal))
+
+	require.NoError(t, db.Close())
+
+	db, err = rindb.InitRinDB(ctx,
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(maxMemtableSize),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	_, err = db.Get(ctx, key)
+	require.ErrorIs(t, err, rindb.ErrKeyNotFound)
+}

--- a/integration/remove_persistence_test.go
+++ b/integration/remove_persistence_test.go
@@ -15,24 +15,26 @@ func TestRemovePersistsTombstone(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	const maxMemtableSize = uint(64)
+	key := rindb.Bytes("k1")
+
+	func() {
+		db, err := rindb.InitRinDB(ctx,
+			rindb.WithDatabaseDir(dir),
+			rindb.WithMaxMemtableSize(maxMemtableSize),
+		)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, db.Close()) }()
+
+		val := rindb.Bytes("v1")
+		require.NoError(t, db.Put(ctx, key, val))
+		require.NoError(t, db.Remove(ctx, key))
+
+		// This Put should trigger a flush including the tombstone for key.
+		bigVal := make([]byte, maxMemtableSize)
+		require.NoError(t, db.Put(ctx, rindb.Bytes("other"), bigVal))
+	}()
 
 	db, err := rindb.InitRinDB(ctx,
-		rindb.WithDatabaseDir(dir),
-		rindb.WithMaxMemtableSize(maxMemtableSize),
-	)
-	require.NoError(t, err)
-
-	key := rindb.Bytes("k1")
-	val := rindb.Bytes("v1")
-	require.NoError(t, db.Put(ctx, key, val))
-	require.NoError(t, db.Remove(ctx, key))
-
-	bigVal := make([]byte, maxMemtableSize)
-	require.NoError(t, db.Put(ctx, rindb.Bytes("other"), bigVal))
-
-	require.NoError(t, db.Close())
-
-	db, err = rindb.InitRinDB(ctx,
 		rindb.WithDatabaseDir(dir),
 		rindb.WithMaxMemtableSize(maxMemtableSize),
 	)

--- a/integration/transaction_concurrency_test.go
+++ b/integration/transaction_concurrency_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestTransactionCommitRollbackConcurrency(t *testing.T) {
+	ctx := context.Background()
+	cfg := rindb.NewConfig(rindb.WithDatabaseDir(t.TempDir()))
+	w, err := rindb.DefaultNewWALFunc(ctx, cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, w.Close()) })
+
+	tm := rindb.NewTransactionManager()
+
+	txnCommit := tm.Begin()
+	txnRollback := tm.Begin()
+
+	recCommit := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("commit"), SequenceNumber: 1}
+	recRollback := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("rollback"), SequenceNumber: 1}
+
+	require.NoError(t, rindb.WriteRecord(txnCommit, recCommit))
+	require.NoError(t, rindb.WriteRecord(txnRollback, recRollback))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		require.NoError(t, txnCommit.Commit(ctx, w))
+	}()
+
+	go func() {
+		defer wg.Done()
+		require.NoError(t, txnRollback.Rollback(ctx))
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, w.Sync())
+
+	mem, err := w.Load(ctx)
+	require.NoError(t, err)
+
+	val, err := mem.Get(rindb.Bytes("key"))
+	require.NoError(t, err)
+	require.Equal(t, rindb.Bytes("commit"), val)
+}

--- a/integration/transaction_concurrency_test.go
+++ b/integration/transaction_concurrency_test.go
@@ -24,8 +24,10 @@ func TestTransactionCommitRollbackConcurrency(t *testing.T) {
 	txnCommit := tm.Begin()
 	txnRollback := tm.Begin()
 
-	recCommit := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("commit"), SequenceNumber: 1}
-	recRollback := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("rollback"), SequenceNumber: 1}
+	seq := uint64(1)
+	recCommit := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("commit"), SequenceNumber: seq}
+	seq++
+	recRollback := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("rollback"), SequenceNumber: seq}
 
 	require.NoError(t, rindb.WriteRecord(txnCommit, recCommit))
 	require.NoError(t, rindb.WriteRecord(txnRollback, recRollback))

--- a/integration/transaction_test.go
+++ b/integration/transaction_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestTransactionManagerIntegration(t *testing.T) {
+	ctx := context.Background()
+	cfg := rindb.NewConfig(rindb.WithDatabaseDir(t.TempDir()))
+	w, err := rindb.DefaultNewWALFunc(ctx, cfg)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, w.Close()) }()
+
+	tm := rindb.NewTransactionManager()
+
+	t.Run("commit", func(t *testing.T) {
+		require.NoError(t, w.Clean())
+		txn := tm.Begin()
+		rec := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("value"), SequenceNumber: 1}
+		require.NoError(t, rindb.WriteRecord(txn, rec))
+		require.NoError(t, txn.Commit(ctx, w))
+		require.NoError(t, w.Sync())
+
+		mem, err := w.Load(ctx)
+		require.NoError(t, err)
+		got, err := mem.Get(rindb.Bytes("key"))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes("value"), got)
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		require.NoError(t, w.Clean())
+		txn := tm.Begin()
+		rec := rindb.RecordImpl{Key: rindb.Bytes("key2"), Value: rindb.Bytes("value2"), SequenceNumber: 1}
+		require.NoError(t, rindb.WriteRecord(txn, rec))
+		require.NoError(t, txn.Rollback(ctx))
+		require.NoError(t, w.Sync())
+
+		mem, err := w.Load(ctx)
+		require.NoError(t, err)
+		_, err = mem.Get(rindb.Bytes("key2"))
+		require.Error(t, err)
+	})
+}

--- a/integration/transaction_test.go
+++ b/integration/transaction_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && smoke
 
 package rindb_test
 

--- a/integration/wal_recovery_test.go
+++ b/integration/wal_recovery_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+
+package rindb_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+var walRecoveryKVs = []struct{ key, val string }{
+	{"k1", "v1"},
+	{"k2", "v2"},
+	{"k3", "v3"},
+}
+
+func TestWALRecovery(t *testing.T) {
+	dir := os.Getenv("WAL_RECOVERY_TEST_DIR")
+	if dir != "" {
+		walRecoveryHelper(t, dir)
+		return
+	}
+
+	dir = t.TempDir()
+
+	cmd := exec.Command(os.Args[0], "-test.run", "TestWALRecovery", "-test.v")
+	cmd.Env = append(os.Environ(), "WAL_RECOVERY_TEST_DIR="+dir)
+	require.NoError(t, cmd.Run())
+
+	ctx := context.Background()
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	for _, kv := range walRecoveryKVs {
+		got, err := db.Get(ctx, rindb.Bytes(kv.key))
+		require.NoError(t, err)
+		require.Equal(t, rindb.Bytes(kv.val), got)
+	}
+}
+
+func walRecoveryHelper(t *testing.T, dir string) {
+	ctx := context.Background()
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir))
+	require.NoError(t, err)
+
+	for _, kv := range walRecoveryKVs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+
+	os.Exit(0)
+}

--- a/integration/wal_recovery_test.go
+++ b/integration/wal_recovery_test.go
@@ -23,12 +23,16 @@ func TestWALRecovery(t *testing.T) {
 	dir := os.Getenv("WAL_RECOVERY_TEST_DIR")
 	if dir != "" {
 		walRecoveryHelper(t, dir)
-		return
+		os.Exit(0)
 	}
 
 	dir = t.TempDir()
 
-	cmd := exec.Command(os.Args[0], "-test.run", "TestWALRecovery", "-test.v")
+	args := []string{"-test.run", "TestWALRecovery"}
+	if testing.Verbose() {
+		args = append(args, "-test.v")
+	}
+	cmd := exec.Command(os.Args[0], args...)
 	cmd.Env = append(os.Environ(), "WAL_RECOVERY_TEST_DIR="+dir)
 	require.NoError(t, cmd.Run())
 
@@ -45,6 +49,7 @@ func TestWALRecovery(t *testing.T) {
 }
 
 func walRecoveryHelper(t *testing.T, dir string) {
+	t.Helper()
 	ctx := context.Background()
 	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir))
 	require.NoError(t, err)
@@ -52,6 +57,4 @@ func walRecoveryHelper(t *testing.T, dir string) {
 	for _, kv := range walRecoveryKVs {
 		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
 	}
-
-	os.Exit(0)
 }

--- a/rindb.go
+++ b/rindb.go
@@ -92,8 +92,8 @@ func (r *Rindb) Stats() Stats {
 //
 // Returns:
 //
-//	Rindb - Initialized database instance
-//	error - Any initialization error encountered
+//	*Rindb - Initialized database instance
+//	error  - Any initialization error encountered
 //
 // Errors:
 //   - Filesystem errors during directory creation
@@ -105,22 +105,22 @@ func (r *Rindb) Stats() Stats {
 // 2. Initialize Write-Ahead Log (WAL)
 // 3. Load existing memtable from WAL
 // 4. Initialize SSTable storage manager
-func InitRinDB(ctx context.Context, opts ...Option) (_ Rindb, err error) {
+func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 	cfg := NewConfig(opts...)
 
 	shutdownTelemetry, err := OtelInit(ctx, cfg.enableTelemetry, cfg.exporterEndpoint, cfg.exporterInsecure, cfg.telemetrySamplingRate)
 	if err != nil {
-		return Rindb{}, fmt.Errorf("failed to initialize telemetry: %w", err)
+		return nil, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
 
 	// Create database directory with secure permissions (0750 = owner RWX, group RX, others none)
 	if err := os.MkdirAll(cfg.databaseDir, 0750); err != nil {
-		return Rindb{}, fmt.Errorf("failed to create database directory %s: %w", cfg.databaseDir, err)
+		return nil, fmt.Errorf("failed to create database directory %s: %w", cfg.databaseDir, err)
 	}
 
 	wal, err := cfg.newWALFunc(ctx, cfg)
 	if err != nil {
-		return Rindb{}, err
+		return nil, err
 	}
 	defer func() {
 		if err != nil {
@@ -131,7 +131,7 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ Rindb, err error) {
 
 	memtable, err := wal.Load(ctx)
 	if err != nil {
-		return Rindb{}, err
+		return nil, err
 	}
 
 	// Set default is 0, while inserting new record, it will automatically increase
@@ -140,25 +140,25 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ Rindb, err error) {
 
 	memMaxSeqNum, err := getMaxSequenceNumberFromMemtable(memtable)
 	if err != nil {
-		return Rindb{}, err
+		return nil, err
 	}
 	maxSeqNum = max(maxSeqNum, memMaxSeqNum)
 
 	ssTableManager, err := cfg.newSSTableManagerFunc(ctx, cfg)
 	if err != nil {
-		return Rindb{}, fmt.Errorf("failed to initialize SSTable manager: %w", err)
+		return nil, fmt.Errorf("failed to initialize SSTable manager: %w", err)
 	}
 
 	// Only scan L0 SSTables for max sequence number during initialization.
 	// L0 SSTables contain the most recent data after the memtable.
 	sstMaxSeqNum, err := getMaxSequenceNumberFromSSTables(ctx, ssTableManager)
 	if err != nil {
-		return Rindb{}, err
+		return nil, err
 	}
 	maxSeqNum = max(maxSeqNum, sstMaxSeqNum)
 
 	INFO(ctx, "Initialized RinDB with database directory %s", cfg.databaseDir)
-	return Rindb{
+	return &Rindb{
 		wal:               wal,
 		memtable:          memtable,
 		ssTableManager:    ssTableManager,

--- a/utils_test.go
+++ b/utils_test.go
@@ -137,7 +137,7 @@ func newTestRindbSetup(t *testing.T, ctx context.Context, cfg *Config) *testRind
 	return &testRindbSetup{
 		T:            t,
 		Config:       &finalCfg,
-		RinDB:        &db,
+		RinDB:        db,
 		Manager:      manager,
 		TempDir:      tempDir,
 		Levels:       manager.levels,
@@ -333,7 +333,7 @@ func initRinDBWithCleanup(t *testing.T, opts ...Option) (*Rindb, func()) {
 
 	}
 
-	return &rin, cleanup
+	return rin, cleanup
 }
 
 // assertFileExists checks if a file exists at the given path and fails the test if not.


### PR DESCRIPTION
This PR introduces a comprehensive suite of integration tests for the RinDB database. These tests cover various critical aspects of the database's functionality, including:

- Compaction: Verifies that SSTables are correctly moved between levels during compaction.
- Concurrency: Ensures thread-safe Put and Get operations under concurrent access.
- Flush: Confirms that data is persisted to SSTables after memtable flushes.
- Range Query: Validates the correctness of range queries across memtables and SSTables.
- Recovery: Tests data persistence and recovery mechanisms after database restarts.
- Remove Persistence: Verifies that tombstone records for removed keys are correctly persisted.
- Transaction Concurrency: Assesses concurrent commit and rollback operations for transactions.
- Transaction Manager: Tests the basic commit and rollback functionality of the transaction manager.
- WAL Recovery: Ensures data integrity and recovery from the Write-Ahead Log (WAL) after unexpected shutdowns.

To support these integration tests, the following changes were made:
- Updated `AGENTS.md` to document the new `make test-integration` command and the location of integration tests.
- Added a `test-integration` target to the `Makefile` to run these tests using the `integration` build tag.
- Refactored `InitRinDB` in `rindb.go` and related test helper functions in `utils_test.go` to return `*Rindb` (a pointer) instead of `Rindb` (a value). This is a minor API change that aligns with Go best practices for returning structs that might contain internal state or require specific initialization/cleanup.

Motivation:
The addition of integration tests significantly improves the robustness and reliability of RinDB by testing the system as a whole, rather than just individual components. This helps catch issues that might arise from interactions between different parts of the database.

Testing Instructions:
To run the integration tests, execute `make test-integration` from the project root.
