### PR TITLE
refactor: embed sequence and type in internal key

### DIFF
--- a/io.go
+++ b/io.go
@@ -21,10 +21,34 @@ func ReadNumber(storage io.Reader) (uint64, error) {
 	return byteOrder.Uint64(numBytes[:]), nil
 }
 
+func encodeInternalKey(key Bytes, seq uint64, typ RecordType) []byte {
+	internalKey := make([]byte, len(key)+internalKeySuffixLen)
+	copy(internalKey, key)
+	var seqBuf [seqNumBytes]byte
+	byteOrder.PutUint64(seqBuf[:], ^seq)
+	copy(internalKey[len(key):], seqBuf[:])
+	internalKey[len(key)+seqNumBytes] = byte(typ)
+	return internalKey
+}
+
+func decodeInternalKey(ikey Bytes) (Bytes, uint64, RecordType, error) {
+	if len(ikey) < internalKeySuffixLen {
+		return nil, 0, 0, fmt.Errorf("internal key too short: %d", len(ikey))
+	}
+	userKeyEnd := len(ikey) - internalKeySuffixLen
+	seq := ^byteOrder.Uint64(ikey[userKeyEnd : userKeyEnd+seqNumBytes])
+	typ := RecordType(ikey[len(ikey)-1])
+	userKey := Bytes(ikey[:userKeyEnd])
+	if userKeyEnd == 0 {
+		userKey = nil
+	}
+	return userKey, seq, typ, nil
+}
+
 func ReadRecord(storage io.Reader) (Record, error) {
-	keyLen, err := ReadNumber(storage)
+	internalKeyLen, err := ReadNumber(storage)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read key length: %w", err)
+		return nil, fmt.Errorf("failed to read internal key length: %w", err)
 	}
 
 	valueLen, err := ReadNumber(storage)
@@ -32,28 +56,28 @@ func ReadRecord(storage io.Reader) (Record, error) {
 		return nil, fmt.Errorf("failed to read value length: %w", err)
 	}
 
-	sequenceNumber, err := ReadNumber(storage)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read sequence number: %w", err)
-	}
-
 	keyBytes := bytes.NewBuffer(nil)
 
 	const defaultReadStep = uint64(255)
 
-	for keyLen > 0 {
-		step := min(keyLen, defaultReadStep)
-		keyLen -= step
+	for internalKeyLen > 0 {
+		step := min(internalKeyLen, defaultReadStep)
+		internalKeyLen -= step
 
 		tempBytes := make(Bytes, step)
 
 		if _, err := io.ReadFull(storage, tempBytes); err != nil {
-			return nil, fmt.Errorf("failed to read key bytes: %w", err)
+			return nil, fmt.Errorf("failed to read internal key bytes: %w", err)
 		}
 
 		if _, err := keyBytes.Write(tempBytes); err != nil {
-			return nil, fmt.Errorf("failed to write key to buffer: %w", err)
+			return nil, fmt.Errorf("failed to write internal key to buffer: %w", err)
 		}
+	}
+
+	userKey, seq, typ, err := decodeInternalKey(keyBytes.Bytes())
+	if err != nil {
+		return nil, err
 	}
 
 	valueBytes := bytes.NewBuffer(nil)
@@ -73,9 +97,10 @@ func ReadRecord(storage io.Reader) (Record, error) {
 	}
 
 	return RecordImpl{
-		Key:            keyBytes.Bytes(),
+		Key:            userKey,
 		Value:          valueBytes.Bytes(),
-		SequenceNumber: sequenceNumber,
+		SequenceNumber: seq,
+		Type:           typ,
 	}, nil
 }
 
@@ -89,20 +114,18 @@ func WriteNumber(tx *Transaction, number uint64) error {
 }
 
 func WriteRecord(tx *Transaction, record Record) error {
-	if err := WriteNumber(tx, uint64(len(record.GetKey()))); err != nil {
-		return fmt.Errorf("failed to write key length: %w", err)
+	ikey := encodeInternalKey(record.GetKey(), record.GetSequenceNumber(), record.GetType())
+
+	if err := WriteNumber(tx, uint64(len(ikey))); err != nil {
+		return fmt.Errorf("failed to write internal key length: %w", err)
 	}
 
 	if err := WriteNumber(tx, uint64(len(record.GetValue()))); err != nil {
 		return fmt.Errorf("failed to write value length: %w", err)
 	}
 
-	if err := WriteNumber(tx, record.GetSequenceNumber()); err != nil {
-		return fmt.Errorf("failed to write sequence number: %w", err)
-	}
-
-	if _, err := tx.Write(record.GetKey()); err != nil {
-		return fmt.Errorf("failed to write key bytes: %w", err)
+	if _, err := tx.Write(ikey); err != nil {
+		return fmt.Errorf("failed to write internal key bytes: %w", err)
 	}
 
 	if _, err := tx.Write(record.GetValue()); err != nil {

--- a/io.go
+++ b/io.go
@@ -1,7 +1,6 @@
 package rindb
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -56,49 +55,30 @@ func ReadRecord(storage io.Reader) (Record, error) {
 		return nil, fmt.Errorf("failed to read value length: %w", err)
 	}
 
-	keyBytes := bytes.NewBuffer(nil)
-
-	const defaultReadStep = uint64(255)
-
-	for internalKeyLen > 0 {
-		step := min(internalKeyLen, defaultReadStep)
-		internalKeyLen -= step
-
-		tempBytes := make(Bytes, step)
-
-		if _, err := io.ReadFull(storage, tempBytes); err != nil {
+	var internalKeyBytes Bytes
+	if internalKeyLen > 0 {
+		internalKeyBytes = make(Bytes, internalKeyLen)
+		if _, err := io.ReadFull(storage, internalKeyBytes); err != nil {
 			return nil, fmt.Errorf("failed to read internal key bytes: %w", err)
-		}
-
-		if _, err := keyBytes.Write(tempBytes); err != nil {
-			return nil, fmt.Errorf("failed to write internal key to buffer: %w", err)
 		}
 	}
 
-	userKey, seq, typ, err := decodeInternalKey(keyBytes.Bytes())
+	userKey, seq, typ, err := decodeInternalKey(internalKeyBytes)
 	if err != nil {
 		return nil, err
 	}
 
-	valueBytes := bytes.NewBuffer(nil)
-	for valueLen > 0 {
-		step := min(valueLen, defaultReadStep)
-		valueLen -= step
-
-		tempBytes := make(Bytes, step)
-
-		if _, err := io.ReadFull(storage, tempBytes); err != nil {
+	var valueBytes Bytes
+	if valueLen > 0 {
+		valueBytes = make(Bytes, valueLen)
+		if _, err := io.ReadFull(storage, valueBytes); err != nil {
 			return nil, fmt.Errorf("failed to read value bytes: %w", err)
-		}
-
-		if _, err := valueBytes.Write(tempBytes); err != nil {
-			return nil, fmt.Errorf("failed to write value to buffer: %w", err)
 		}
 	}
 
 	return RecordImpl{
 		Key:            userKey,
-		Value:          valueBytes.Bytes(),
+		Value:          valueBytes,
 		SequenceNumber: seq,
 		Type:           typ,
 	}, nil

--- a/io_test.go
+++ b/io_test.go
@@ -84,64 +84,51 @@ func Test_rw(t *testing.T) {
 }
 
 func TestReadRecord_Errors(t *testing.T) {
-	t.Run("Error reading key length", func(t *testing.T) {
-		reader := &errorReader{err: errors.New("read key length failed")}
+	t.Run("Error reading internal key length", func(t *testing.T) {
+		reader := &errorReader{err: errors.New("read internal key length failed")}
 		_, err := ReadRecord(reader)
-		assert.ErrorContains(t, err, "failed to read key length")
-		assert.ErrorContains(t, err, "read key length failed")
+		assert.ErrorContains(t, err, "failed to read internal key length")
+		assert.ErrorContains(t, err, "read internal key length failed")
 	})
 
 	t.Run("Error reading value length", func(t *testing.T) {
-		// Provide valid key length bytes, then error
 		var buf bytes.Buffer
-		WriteNumber(&Transaction{buffer: &buf}, 5) // Write a dummy key length
-		reader := io.MultiReader(&buf, &errorReader{err: errors.New("read key length failed")})
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5) // Internal key length
+		reader := io.MultiReader(&buf, &errorReader{err: errors.New("read value length failed")})
 		_, err := ReadRecord(reader)
-		assert.ErrorContains(t, err, "failed to read key length")
-		assert.ErrorContains(t, err, "read key length failed")
-	})
-
-	t.Run("Error reading value length (EOF)", func(t *testing.T) {
-		var buf bytes.Buffer
-		WriteNumber(&Transaction{buffer: &buf}, 5) // Key length = 5
-		WriteNumber(&Transaction{buffer: &buf}, 5) // Value length = 5
-		buf.Write([]byte("key"))                   // Only 3 bytes of key data
-		_, err := ReadRecord(&buf)
 		assert.ErrorContains(t, err, "failed to read value length")
-		assert.ErrorIs(t, err, io.EOF)
+		assert.ErrorContains(t, err, "read value length failed")
 	})
 
-	t.Run("Error reading key length (iotest)", func(t *testing.T) {
+	t.Run("Error reading internal key bytes", func(t *testing.T) {
 		var buf bytes.Buffer
-		WriteNumber(&Transaction{buffer: &buf}, 5) // Key length = 5
-		WriteNumber(&Transaction{buffer: &buf}, 5) // Value length = 5
-		// Use iotest.ErrReader to simulate read error after header
-		reader := io.MultiReader(&buf, iotest.ErrReader(errors.New("read key length failed")))
-		_, err := ReadRecord(reader)
-		assert.ErrorContains(t, err, "failed to read key length")
-		assert.ErrorContains(t, err, "read key length failed")
-	})
-
-	t.Run("Error reading value length (EOF)", func(t *testing.T) {
-		var buf bytes.Buffer
-		WriteNumber(&Transaction{buffer: &buf}, 3) // Key length = 3
-		WriteNumber(&Transaction{buffer: &buf}, 5) // Value length = 5
-		buf.Write([]byte("key"))                   // Correct key bytes
-		buf.Write([]byte("val"))                   // Only 3 bytes of value data
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5) // Internal key length
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5) // Value length
+		buf.Write([]byte("key"))                                    // only 3 bytes of internal key
 		_, err := ReadRecord(&buf)
-		assert.ErrorContains(t, err, "failed to read value length")
-		assert.ErrorIs(t, err, io.EOF)
+		assert.ErrorContains(t, err, "failed to read internal key bytes")
+		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
+	t.Run("Error reading value bytes (EOF)", func(t *testing.T) {
+		var buf bytes.Buffer
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 3+internalKeySuffixLen) // Internal key length for "key"
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5)                      // Value length
+		buf.Write(encodeInternalKey(Bytes("key"), 0, TypeValue))
+		buf.Write([]byte("val")) // only 3 bytes of value
+		_, err := ReadRecord(&buf)
+		assert.ErrorContains(t, err, "failed to read value bytes")
+		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
 
 	t.Run("Error reading value bytes (iotest)", func(t *testing.T) {
 		var buf bytes.Buffer
-		WriteNumber(&Transaction{buffer: &buf}, 3) // Key length = 3
-		WriteNumber(&Transaction{buffer: &buf}, 5) // Value length = 5
-		buf.Write([]byte("key"))                   // Correct key bytes
-		// Use iotest.ErrReader to simulate read error after key
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 3+internalKeySuffixLen) // Internal key length
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5)                      // Value length
+		buf.Write(encodeInternalKey(Bytes("key"), 0, TypeValue))
 		reader := io.MultiReader(&buf, iotest.ErrReader(errors.New("read value bytes failed")))
 		_, err := ReadRecord(reader)
-		assert.ErrorContains(t, err, "failed to read value length")
+		assert.ErrorContains(t, err, "failed to read value bytes")
 		assert.ErrorContains(t, err, "read value bytes failed")
 	})
 }

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -117,7 +117,7 @@ func TestMemtable_ByteSize(t *testing.T) {
 		value := Bytes("value1")
 		expectedSize := len(key) + len(value) + entryOverhead
 
-		mem.Put(RecordImpl{Key: key, Value: value, SequenceNumber: 1})
+		mem.Put(NewRecord(key, value, 1))
 		assert.Equal(t, expectedSize, mem.ByteSize(), "Size mismatch after single entry")
 	})
 

--- a/record.go
+++ b/record.go
@@ -1,17 +1,32 @@
 package rindb
 
+type RecordType uint8
+
+const (
+	TypeValue RecordType = iota
+	TypeDeletion
+	TypeMerge
+)
+
+const (
+	seqNumBytes          = 8
+	internalKeySuffixLen = seqNumBytes + 1 // sequence number + type
+)
+
 type Record interface {
 	GetKey() Bytes
 	GetValue() Bytes
 	GetSize() int
 	GetSequenceNumber() uint64
+	GetType() RecordType
 }
 
 func CalOnDiskSize(r Record) int {
-	return (mdByteSize /* key len size */ +
+	return (mdByteSize /* internal key len size */ +
 		mdByteSize /* value len size */ +
-		mdByteSize /* seq num size */ +
-		r.GetSize() /* all key&value size */)
+		len(r.GetKey()) /* user key */ +
+		internalKeySuffixLen /* seq+type */ +
+		len(r.GetValue()))
 }
 
 var _ Record = RecordImpl{}
@@ -19,6 +34,7 @@ var _ Record = RecordImpl{}
 type RecordImpl struct {
 	Key, Value     Bytes
 	SequenceNumber uint64
+	Type           RecordType
 }
 
 // GetKey implements Record.
@@ -39,4 +55,9 @@ func (r RecordImpl) GetSize() int {
 // GetSequenceNumber implements Record.
 func (r RecordImpl) GetSequenceNumber() uint64 {
 	return r.SequenceNumber
+}
+
+// GetType implements Record.
+func (r RecordImpl) GetType() RecordType {
+	return r.Type
 }

--- a/record_test.go
+++ b/record_test.go
@@ -17,13 +17,13 @@ func TestCalOnDiskSize(t *testing.T) {
 	}{
 		{
 			name: "Key and value",
-			args: args{RecordImpl{Bytes("key"), Bytes("value"), 1}},
-			want: 32,
+			args: args{NewRecord(Bytes("key"), Bytes("value"), 1)},
+			want: 33,
 		},
 		{
 			name: "Empty key and value",
-			args: args{RecordImpl{Bytes(nil), Bytes(nil), 18446744073709551615}},
-			want: 24,
+			args: args{NewRecord(Bytes(nil), Bytes(nil), 18446744073709551615)},
+			want: 25,
 		},
 	}
 	for _, tt := range tests {

--- a/rindb.go
+++ b/rindb.go
@@ -295,7 +295,7 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 	}
 
 	r.sequenceNumber++
-	record := RecordImpl{Key: key, Value: value, SequenceNumber: r.sequenceNumber}
+	record := RecordImpl{Key: key, Value: value, SequenceNumber: r.sequenceNumber, Type: TypeValue}
 	if err := r.wal.Append(ctx, record); err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (r *Rindb) Remove(ctx context.Context, key Bytes) error {
 	}
 
 	r.sequenceNumber++
-	record := RecordImpl{Key: key, Value: nil, SequenceNumber: r.sequenceNumber}
+	record := RecordImpl{Key: key, Value: nil, SequenceNumber: r.sequenceNumber, Type: TypeDeletion}
 	if err := r.wal.Append(ctx, record); err != nil {
 		return err
 	}

--- a/sstable.go
+++ b/sstable.go
@@ -56,6 +56,11 @@ func (k KeyOffset) GetSequenceNumber() uint64 {
 	return 0
 }
 
+// GetType implements Record.
+func (k KeyOffset) GetType() RecordType {
+	return TypeValue
+}
+
 func (s SparseIndex) GetOffset(key Bytes) (int64, error) {
 	idx := sort.Search(len(s), func(i int) bool {
 		return Compare(s[i].key, key) >= 0

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -47,6 +47,7 @@ func TestSStable(t *testing.T) {
 				Key:            v.key,
 				Value:          v.value,
 				SequenceNumber: uint64(i),
+				Type:           TypeValue,
 			})
 		}
 		sstable, err := flush(ctx, cfg, mem, fs)
@@ -91,9 +92,9 @@ func TestSStable(t *testing.T) {
 		defer closer()
 		fs := fss[0]
 		mem := InitMemtable(cfg)
-		mem.Put(RecordImpl{Bytes("2"), Bytes("3"), 1})
-		mem.Put(RecordImpl{Bytes("1"), Bytes("2"), 2})
-		mem.Put(RecordImpl{Bytes("3"), Bytes("4"), 3})
+		mem.Put(NewRecord(Bytes("2"), Bytes("3"), 1))
+		mem.Put(NewRecord(Bytes("1"), Bytes("2"), 2))
+		mem.Put(NewRecord(Bytes("3"), Bytes("4"), 3))
 		sstable1, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
 		sstable2, err := NewSSTable(ctx, cfg, fs)
@@ -106,9 +107,9 @@ func TestSStable(t *testing.T) {
 		defer closer()
 		fs := fss[0]
 		mem := InitMemtable(cfg)
-		mem.Put(RecordImpl{Bytes("2"), Bytes("3"), 1})
-		mem.Put(RecordImpl{Bytes("1"), Bytes("2"), 2})
-		mem.Put(RecordImpl{Bytes("3"), Bytes("4"), 3})
+		mem.Put(NewRecord(Bytes("2"), Bytes("3"), 1))
+		mem.Put(NewRecord(Bytes("1"), Bytes("2"), 2))
+		mem.Put(NewRecord(Bytes("3"), Bytes("4"), 3))
 		_, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
 		sstable, err := NewSSTable(ctx, cfg, fs)
@@ -129,9 +130,9 @@ func TestSStable(t *testing.T) {
 		defer closer()
 		fs := fss[0]
 		mem := InitMemtable(cfg)
-		mem.Put(RecordImpl{Bytes("2"), Bytes("3"), 1})
-		mem.Put(RecordImpl{Bytes("1"), Bytes("2"), 2})
-		mem.Put(RecordImpl{Bytes("3"), Bytes("4"), 3})
+		mem.Put(NewRecord(Bytes("2"), Bytes("3"), 1))
+		mem.Put(NewRecord(Bytes("1"), Bytes("2"), 2))
+		mem.Put(NewRecord(Bytes("3"), Bytes("4"), 3))
 		assert.Equal(t, uint(3), mem.data.Len())
 		sstable, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
@@ -154,9 +155,9 @@ func TestSStable(t *testing.T) {
 		defer closer()
 		fs := fss[0]
 		mem := InitMemtable(cfg)
-		mem.Put(RecordImpl{Bytes("2"), Bytes("3"), 1})
-		mem.Put(RecordImpl{Bytes("1"), Bytes("2"), 2})
-		mem.Put(RecordImpl{Bytes("3"), Bytes("4"), 3})
+		mem.Put(NewRecord(Bytes("2"), Bytes("3"), 1))
+		mem.Put(NewRecord(Bytes("1"), Bytes("2"), 2))
+		mem.Put(NewRecord(Bytes("3"), Bytes("4"), 3))
 		sstable, err := flush(context.Background(), cfg, mem, fs)
 		assert.NoError(t, err)
 		iterator, err := sstable.Iterator()
@@ -205,6 +206,7 @@ func TestSStable(t *testing.T) {
 				Key:            v.key,
 				Value:          v.value,
 				SequenceNumber: uint64(i),
+				Type:           TypeValue,
 			})
 		}
 		sstable, err := flush(context.Background(), cfg, mem, fs)
@@ -339,16 +341,16 @@ func TestSStable(t *testing.T) {
 func Test_genSparseIndex(t *testing.T) {
 	cfg := testConfig()
 	mem := InitMemtable(cfg)
-	mem.Put(RecordImpl{Bytes("1"), Bytes("2"), 1})
-	mem.Put(RecordImpl{Bytes("2"), Bytes("3"), 2})
-	mem.Put(RecordImpl{Bytes("3"), Bytes("4"), 3})
+	mem.Put(NewRecord(Bytes("1"), Bytes("2"), 1))
+	mem.Put(NewRecord(Bytes("2"), Bytes("3"), 2))
+	mem.Put(NewRecord(Bytes("3"), Bytes("4"), 3))
 	index := genSparseIndex(mem)
 	assert.Equal(t, Bytes("1"), index[0].key)
 	assert.Equal(t, int64(0), index[0].offset)
 	assert.Equal(t, Bytes("2"), index[1].key)
-	assert.Equal(t, int64(26), index[1].offset)
+	assert.Equal(t, int64(27), index[1].offset)
 	assert.Equal(t, Bytes("3"), index[2].key)
-	assert.Equal(t, int64(52), index[2].offset)
+	assert.Equal(t, int64(54), index[2].offset)
 }
 
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.
@@ -483,8 +485,8 @@ func TestFlushWithTombstones(t *testing.T) {
 	k1 := randStringBytes(10)
 	k2 := randStringBytes(10)
 	mem := InitMemtable(cfg)
-	mem.Put(RecordImpl{k1, Bytes("v1"), 1})
-	mem.Put(RecordImpl{k2, nil, 2})
+	mem.Put(NewRecord(k1, Bytes("v1"), 1))
+	mem.Put(NewRecord(k2, nil, 2))
 	sstable, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
 	v1, err := sstable.GetValue(ctx, k1)
@@ -503,7 +505,7 @@ func TestBloomFilterSkipsReads(t *testing.T) {
 	defer closer()
 	fs := fss[0]
 	mem := InitMemtable(cfg)
-	mem.Put(RecordImpl{Bytes("k1"), Bytes("v1"), 2})
+	mem.Put(NewRecord(Bytes("k1"), Bytes("v1"), 2))
 	sstable, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
 	_, err = sstable.GetValue(ctx, Bytes("k2"))

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -335,11 +335,11 @@ func TestSSTableManager_MergeSSTables(t *testing.T) {
 		assert.NoError(t, err, "Failed to get iterator for merged SSTable")
 
 		expectedRecords := []Record{
-			RecordImpl{Key: Bytes("1"), Value: Bytes("3")}, // sstable2 value
-			RecordImpl{Key: Bytes("2"), Value: nil},        // sstable2 tombstone
-			RecordImpl{Key: Bytes("3"), Value: Bytes("4")}, // sstable1 value
-			RecordImpl{Key: Bytes("4"), Value: Bytes("5")}, // sstable2 value
-			RecordImpl{Key: Bytes("5"), Value: Bytes("6")}, // sstable3 value
+			RecordImpl{Key: Bytes("1"), Value: Bytes("3"), Type: TypeValue}, // sstable2 value
+			RecordImpl{Key: Bytes("2"), Value: nil, Type: TypeDeletion},     // sstable2 tombstone
+			RecordImpl{Key: Bytes("3"), Value: Bytes("4"), Type: TypeValue}, // sstable1 value
+			RecordImpl{Key: Bytes("4"), Value: Bytes("5"), Type: TypeValue}, // sstable2 value
+			RecordImpl{Key: Bytes("5"), Value: Bytes("6"), Type: TypeValue}, // sstable3 value
 		}
 		assertIteratorRecords(t, sstableIterator, expectedRecords)
 	})

--- a/utils_test.go
+++ b/utils_test.go
@@ -271,7 +271,7 @@ func populateMemtable(cfg Config, pairs ...[2]Bytes) Memtable {
 	var seqNum uint64 = 0
 	for _, pair := range pairs {
 		seqNum++
-		mem.Put(RecordImpl{Key: pair[0], Value: pair[1], SequenceNumber: seqNum})
+		mem.Put(NewRecord(pair[0], pair[1], seqNum))
 	}
 	return mem
 }
@@ -418,5 +418,9 @@ func assertLinkedListContents[T comparable](t *testing.T, l *LinkedList[T], expe
 
 // NewRecord is a helper function to create a RecordImpl instance for tests.
 func NewRecord(key, value Bytes, seq uint64) RecordImpl {
-	return RecordImpl{Key: key, Value: value, SequenceNumber: seq}
+	typ := TypeValue
+	if value == nil {
+		typ = TypeDeletion
+	}
+	return RecordImpl{Key: key, Value: value, SequenceNumber: seq, Type: typ}
 }

--- a/wal_test.go
+++ b/wal_test.go
@@ -26,11 +26,6 @@ func validateWALFormat(t *testing.T, file io.ReadSeeker) {
 		_, err = file.Read(valueLenBytes[:])
 		assert.NoError(t, err)
 
-		// Skip sequence number bytes
-		seqNumBytes := [mdByteSize]byte{}
-		_, err = file.Read(seqNumBytes[:])
-		assert.NoError(t, err)
-
 		keyLen := byteOrder.Uint64(keyLenBytes[:])
 		valueLen := byteOrder.Uint64(valueLenBytes[:])
 		_, err = file.Seek(int64(keyLen+valueLen), io.SeekCurrent)
@@ -153,8 +148,8 @@ func TestWALCrashRecovery_PartialWrite(t *testing.T) {
 	tx := w.tm.Begin()
 	defer tx.Rollback(context.Background())
 
-	// Write only the key length and value length of the third record
-	assert.NoError(t, WriteNumber(tx, uint64(len(record3.GetKey()))))
+	// Write only the internal key length and value length of the third record
+	assert.NoError(t, WriteNumber(tx, uint64(len(record3.GetKey())+internalKeySuffixLen)))
 	assert.NoError(t, WriteNumber(tx, uint64(len(record3.GetValue()))))
 
 	// Commit the partial transaction to the file


### PR DESCRIPTION
## Summary
- encode records using internal key = user key + descending sequence number + type
- add record type constants and update read/write paths
- tag Put and Remove records with appropriate type

## Testing
- `make check` *(fails: internal error in staticcheck: unsupported version)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ab2faf3690832583b1dff9b9ce14ad