### PR TITLE
feat: add merging iterator and user range filtering

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -1,0 +1,99 @@
+package rindb
+
+import "errors"
+
+type pqItem struct {
+	rec  Record
+	iter Iterator[Record]
+}
+
+// MergingIterator merges multiple iterators without deduplication. It yields
+// records ordered by key and sequence number (descending).
+type MergingIterator struct {
+	pq       *PriorityQueue[pqItem]
+	next     Record
+	prepared bool
+	cleanup  func()
+	err      error
+}
+
+// NewMergingIterator constructs a MergingIterator over provided iterators.
+// The optional cleanup function is called when Close is invoked.
+func NewMergingIterator(iterators []Iterator[Record], cleanup func()) (*MergingIterator, error) {
+	less := func(a, b pqItem) bool {
+		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
+		if cmp == CmpEqual {
+			return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
+		}
+		return cmp == CmpLess
+	}
+
+	pq := NewPriorityQueue(less)
+	for _, it := range iterators {
+		if it.HasNext() {
+			rec, err := it.Next()
+			if err != nil {
+				if !errors.Is(err, EOI) {
+					if cleanup != nil {
+						cleanup()
+					}
+					return nil, err
+				}
+				continue
+			}
+			pq.PushItem(pqItem{rec: rec, iter: it})
+		}
+	}
+
+	return &MergingIterator{pq: pq, cleanup: cleanup}, nil
+}
+
+func (m *MergingIterator) prepare() {
+	if m.prepared || m.err != nil || m.pq.Len() == 0 {
+		return
+	}
+
+	item := m.pq.PopItem()
+	m.next = item.rec
+	m.prepared = true
+
+	if item.iter.HasNext() {
+		rec, err := item.iter.Next()
+		if err != nil {
+			if !errors.Is(err, EOI) {
+				m.err = err
+			}
+		} else {
+			m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
+		}
+	}
+}
+
+// HasNext implements Iterator[Record].
+func (m *MergingIterator) HasNext() bool {
+	m.prepare()
+	return m.prepared
+}
+
+// Next implements Iterator[Record].
+func (m *MergingIterator) Next() (Record, error) {
+	if !m.HasNext() {
+		var empty Record
+		if m.err != nil {
+			return empty, m.err
+		}
+		return empty, EOI
+	}
+	m.prepared = false
+	return m.next, nil
+}
+
+// Close releases any resources held by the iterator. It is safe to call
+// multiple times.
+func (m *MergingIterator) Close() error {
+	if m.cleanup != nil {
+		m.cleanup()
+		m.cleanup = nil
+	}
+	return m.err
+}

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -1,0 +1,86 @@
+package rindb
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// errIterator injects an error at a specified index.
+type errIterator struct {
+	records []Record
+	idx     int
+	failIdx int
+}
+
+func (e *errIterator) HasNext() bool { return e.idx < len(e.records) }
+
+func (e *errIterator) Next() (Record, error) {
+	if e.idx == e.failIdx {
+		e.idx++
+		var empty Record
+		return empty, errors.New("boom")
+	}
+	rec := e.records[e.idx]
+	e.idx++
+	return rec, nil
+}
+
+func TestMergingIterator(t *testing.T) {
+	rec := func(k, v string, seq uint64, typ RecordType) Record {
+		var nv Bytes = nil
+		if v != "" {
+			nv = Bytes(v)
+		}
+		return RecordImpl{Key: Bytes(k), Value: nv, SequenceNumber: seq, Type: typ}
+	}
+
+	tests := []struct {
+		name  string
+		iters [][]Record
+		want  []Record
+	}{
+		{
+			name: "includes duplicates and tombstones",
+			iters: [][]Record{
+				{rec("a", "v2", 2, TypeValue), rec("b", "vb", 1, TypeValue)},
+				{rec("a", "", 3, TypeDeletion), rec("a", "v1", 1, TypeValue)},
+			},
+			want: []Record{
+				rec("a", "", 3, TypeDeletion),
+				rec("a", "v2", 2, TypeValue),
+				rec("a", "v1", 1, TypeValue),
+				rec("b", "vb", 1, TypeValue),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var iterators []Iterator[Record]
+			for _, recs := range tt.iters {
+				iterators = append(iterators, &errIterator{records: recs, failIdx: -1})
+			}
+
+			mi, err := NewMergingIterator(iterators, nil)
+			assert.NoError(t, err)
+
+			var got []Record
+			for mi.HasNext() {
+				r, err := mi.Next()
+				assert.NoError(t, err)
+				got = append(got, r)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMergingIteratorInitialError(t *testing.T) {
+	r := newRecord(Bytes("a"), Bytes("1"), 1)
+	it := &errIterator{records: []Record{r}, failIdx: 0}
+	mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
+	assert.Nil(t, mi)
+	assert.EqualError(t, err, "boom")
+}

--- a/range.go
+++ b/range.go
@@ -2,100 +2,66 @@ package rindb
 
 import "errors"
 
-type pqItem struct {
-	rec  Record
-	iter Iterator[Record]
-}
-
-func buildRangePQ(iterators []Iterator[Record]) (*PriorityQueue[pqItem], error) {
-	less := func(a, b pqItem) bool {
-		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
-		if cmp == CmpEqual {
-			return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
-		}
-		return cmp == CmpLess
-	}
-
-	pq := NewPriorityQueue(less)
-	for _, it := range iterators {
-		if it.HasNext() {
-			rec, err := it.Next()
-			if err != nil {
-				if !errors.Is(err, EOI) {
-					return nil, err
-				}
-				continue
-			}
-			pq.PushItem(pqItem{rec: rec, iter: it})
-		}
-	}
-	return pq, nil
-}
-
-// RangeIterator merges multiple iterators and iterates over them in order.
-// It implements Iterator[Record] and provides a Close method for resource
-// cleanup.
+// RangeIterator is a user-facing iterator that hides tombstones and
+// duplicates. It wraps a MergingIterator which provides all records in key and
+// sequence order.
 type RangeIterator struct {
-	pq         *PriorityQueue[pqItem]
+	mi         *MergingIterator
 	lastKey    Bytes
 	lastKeySet bool
 	next       Record
 	prepared   bool
-	cleanup    func()
 	err        error
 }
 
-func (m *RangeIterator) prepare() {
-	for !m.prepared && m.err == nil && m.pq.Len() > 0 {
-		item := m.pq.PopItem()
-		key := item.rec.GetKey()
+// NewRangeIterator creates a new RangeIterator from a MergingIterator.
+func NewRangeIterator(mi *MergingIterator) *RangeIterator {
+	return &RangeIterator{mi: mi}
+}
 
-		if !m.lastKeySet || key.Compare(m.lastKey) != CmpEqual {
-			// Emit the newest record for this user_key, regardless deleted or not.
-			m.next = item.rec
-			m.prepared = true
-
-			m.lastKey = key.Clone()
-			m.lastKeySet = true
-		}
-
-		if item.iter.HasNext() {
-			rec, err := item.iter.Next()
-			if err != nil {
-				if !errors.Is(err, EOI) {
-					m.err = err
-				}
-			} else {
-				m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
+func (r *RangeIterator) prepare() {
+	for !r.prepared && r.err == nil {
+		rec, err := r.mi.Next()
+		if err != nil {
+			if errors.Is(err, EOI) {
+				return
 			}
+			r.err = err
+			return
 		}
+		if r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual {
+			continue
+		}
+		r.lastKey = rec.GetKey().Clone()
+		r.lastKeySet = true
+		if rec.GetType() == TypeDeletion {
+			continue
+		}
+		r.next = rec
+		r.prepared = true
 	}
 }
 
 // HasNext implements Iterator[Record].
-func (m *RangeIterator) HasNext() bool {
-	m.prepare()
-	return m.prepared
+func (r *RangeIterator) HasNext() bool {
+	r.prepare()
+	return r.prepared
 }
 
 // Next implements Iterator[Record].
-func (m *RangeIterator) Next() (Record, error) {
-	if !m.HasNext() {
+func (r *RangeIterator) Next() (Record, error) {
+	if !r.HasNext() {
 		var empty Record
-		if m.err != nil {
-			return empty, m.err
+		if r.err != nil {
+			return empty, r.err
 		}
 		return empty, EOI
 	}
-	m.prepared = false
-	return m.next, nil
+	r.prepared = false
+	return r.next, nil
 }
 
-// Close releases any resources held by the iterator. It is safe to call multiple times.
-func (m *RangeIterator) Close() error {
-	if m.cleanup != nil {
-		m.cleanup()
-		m.cleanup = nil
-	}
-	return m.err
+// Close releases any resources held by the iterator.
+func (r *RangeIterator) Close() error {
+	return r.mi.Close()
 }

--- a/range_test.go
+++ b/range_test.go
@@ -2,39 +2,18 @@ package rindb
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// errIterator injects an error at a specified index.
-type errIterator struct {
-	records []Record
-	idx     int
-	failIdx int
-}
-
-func (e *errIterator) HasNext() bool { return e.idx < len(e.records) }
-
-func (e *errIterator) Next() (Record, error) {
-	if e.idx == e.failIdx {
-		e.idx++
-		var empty Record
-		return empty, errors.New("boom")
-	}
-	rec := e.records[e.idx]
-	e.idx++
-	return rec, nil
-}
-
 func TestRangeIterator(t *testing.T) {
-	rec := func(k, v string, seq uint64) Record {
+	rec := func(k, v string, seq uint64, typ RecordType) Record {
 		var nv Bytes = nil
 		if v != "" {
 			nv = Bytes(v)
 		}
-		return newRecord(Bytes(k), nv, seq)
+		return RecordImpl{Key: Bytes(k), Value: nv, SequenceNumber: seq, Type: typ}
 	}
 
 	type iterSpec struct {
@@ -53,33 +32,18 @@ func TestRangeIterator(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "basic order",
+			name: "filters tombstones and duplicates",
 			iters: []iterSpec{
-				{records: []Record{rec("a", "1", 1)}, failIdx: -1},
-				{records: []Record{rec("b", "2", 1)}, failIdx: -1},
+				{records: []Record{rec("a", "v2", 2, TypeValue), rec("c", "c2", 2, TypeValue)}, failIdx: -1},
+				{records: []Record{rec("a", "v1", 1, TypeValue)}, failIdx: -1},
+				{records: []Record{rec("b", "", 3, TypeDeletion), rec("b", "vb", 1, TypeValue)}, failIdx: -1},
 			},
-			want: []exp{{"a", "1"}, {"b", "2"}},
-		},
-		{
-			name: "skip duplicates",
-			iters: []iterSpec{
-				{records: []Record{rec("a", "v2", 2), rec("b", "vb", 1)}, failIdx: -1},
-				{records: []Record{rec("a", "v1", 1)}, failIdx: -1},
-			},
-			want: []exp{{"a", "v2"}, {"b", "vb"}},
-		},
-		{
-			name: "has tombstones",
-			iters: []iterSpec{
-				{records: []Record{rec("a", "", 2), rec("b", "2", 1)}, failIdx: -1},
-				{records: []Record{rec("a", "1", 1)}, failIdx: -1},
-			},
-			want: []exp{{"a", ""}, {"b", "2"}},
+			want: []exp{{"a", "v2"}, {"c", "c2"}},
 		},
 		{
 			name: "iterator error",
 			iters: []iterSpec{
-				{records: []Record{rec("a", "1", 1), rec("b", "2", 2), rec("c", "3", 3)}, failIdx: 2},
+				{records: []Record{rec("a", "1", 1, TypeValue), rec("b", "2", 2, TypeValue), rec("c", "3", 3, TypeValue)}, failIdx: 2},
 			},
 			want:    []exp{{"a", "1"}, {"b", "2"}},
 			wantErr: "boom",
@@ -92,9 +56,9 @@ func TestRangeIterator(t *testing.T) {
 			for _, spec := range tt.iters {
 				iterators = append(iterators, &errIterator{records: spec.records, failIdx: spec.failIdx})
 			}
-			pq, err := buildRangePQ(iterators)
+			mi, err := NewMergingIterator(iterators, nil)
 			assert.NoError(t, err)
-			iter := &RangeIterator{pq: pq}
+			iter := NewRangeIterator(mi)
 
 			var got []exp
 			for iter.HasNext() {
@@ -112,14 +76,6 @@ func TestRangeIterator(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestBuildRangePQInitialError(t *testing.T) {
-	r := newRecord(Bytes("a"), Bytes("1"), 1)
-	it := &errIterator{records: []Record{r}, failIdx: 0}
-	pq, err := buildRangePQ([]Iterator[Record]{it})
-	assert.Nil(t, pq)
-	assert.EqualError(t, err, "boom")
 }
 
 func TestIRangeCloseReleasesSSTables(t *testing.T) {
@@ -164,10 +120,10 @@ func TestRangeIteratorPrepare(t *testing.T) {
 			},
 			failIdx: -1,
 		}
-		pq, err := buildRangePQ([]Iterator[Record]{it})
+		mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
 		assert.NoError(t, err)
 
-		iter := &RangeIterator{pq: pq}
+		iter := NewRangeIterator(mi)
 		iter.prepare()
 		_, err = iter.Next()
 		assert.NoError(t, err)
@@ -186,10 +142,14 @@ func TestRangeIteratorPrepare(t *testing.T) {
 			},
 			failIdx: 1,
 		}
-		pq, err := buildRangePQ([]Iterator[Record]{it})
+		mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
 		assert.NoError(t, err)
 
-		iter := &RangeIterator{pq: pq}
+		iter := NewRangeIterator(mi)
+		iter.prepare()
+		_, err = iter.Next()
+		assert.NoError(t, err)
+
 		iter.prepare()
 		assert.EqualError(t, iter.err, "boom")
 

--- a/rindb.go
+++ b/rindb.go
@@ -254,13 +254,13 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (*RangeIterator, e
 		iterators = append(iterators, rangeIter)
 	}
 
-	pq, err := buildRangePQ(iterators)
+	mergeIter, err := NewMergingIterator(iterators, cleanup)
 	if err != nil {
 		cleanup()
 		return nil, err
 	}
 
-	return &RangeIterator{pq: pq, cleanup: cleanup}, nil
+	return NewRangeIterator(mergeIter), nil
 }
 
 // Put inserts or updates a key-value pair in the database.

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -77,7 +77,6 @@ func TestRindb_IRange(t *testing.T) {
 	mem.Put(newRecord(Bytes("k"), Bytes("memK"), 7))
 
 	recA := newRecord(Bytes("a"), Bytes("memA"), 5)
-	recB_tombstone := newRecord(Bytes("b"), nil, 6) // Tombstone for 'b'
 	recK := newRecord(Bytes("k"), Bytes("memK"), 7)
 	recZ := newRecord(Bytes("z"), Bytes("sstZ"), 4)
 
@@ -91,19 +90,19 @@ func TestRindb_IRange(t *testing.T) {
 			name:     "full range",
 			start:    Bytes("a"),
 			end:      Bytes("z"),
-			expected: []Record{recA, recB_tombstone, recK, recZ},
+			expected: []Record{recA, recK, recZ},
 		},
 		{
 			name:     "range excludes deleted key",
 			start:    Bytes("a"),
 			end:      Bytes("b"),
-			expected: []Record{recA, recB_tombstone},
+			expected: []Record{recA},
 		},
 		{
 			name:     "range after deletion",
 			start:    Bytes("b"),
 			end:      Bytes("z"),
-			expected: []Record{recB_tombstone, recK, recZ},
+			expected: []Record{recK, recZ},
 		},
 		{
 			name:     "middle range",
@@ -121,7 +120,7 @@ func TestRindb_IRange(t *testing.T) {
 			name:     "tombstoned key only",
 			start:    Bytes("b"),
 			end:      Bytes("b"),
-			expected: []Record{recB_tombstone},
+			expected: nil,
 		},
 		{
 			name:     "range before first key",

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -844,7 +844,7 @@ func mergeSSTables(ctx context.Context, config Config, target *FileSystem, sourc
 	return sstable, nil
 }
 
-func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sources []SStable, bottommost bool) (*SStable, error) {
+func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sources []SStable, bottommost bool) (_ *SStable, err error) {
 	if len(sources) == 0 {
 		return nil, nil
 	}
@@ -862,6 +862,11 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if cerr := mergeIter.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 
 	var (
 		wrote      int
@@ -889,10 +894,6 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 
 		memtable.Put(rec)
 		wrote++
-	}
-
-	if err := mergeIter.Close(); err != nil {
-		return nil, err
 	}
 
 	if wrote == 0 {

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -858,28 +858,30 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 		iterators = append(iterators, iter)
 	}
 
-	pq, err := buildRangePQ(iterators)
+	mergeIter, err := NewMergingIterator(iterators, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var (
-		wrote int
-
-		memtable = InitMemtable(config)
-		// cleanup from RangeIterator will be empty
-		// because closing sstables is caller's responsibility
-		// because it's managing sources' lifecycle
-		rangeIterator = &RangeIterator{pq: pq}
+		wrote      int
+		lastKey    Bytes
+		lastKeySet bool
+		memtable   = InitMemtable(config)
 	)
-	for rangeIterator.HasNext() {
+	for mergeIter.HasNext() {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		rec, err := rangeIterator.Next()
+		rec, err := mergeIter.Next()
 		if err != nil {
 			return nil, err
 		}
+		if lastKeySet && rec.GetKey().Compare(lastKey) == CmpEqual {
+			continue
+		}
+		lastKey = rec.GetKey().Clone()
+		lastKeySet = true
 
 		if rec.GetType() == TypeDeletion && bottommost {
 			continue // GC tombstone only at bottommost
@@ -887,6 +889,10 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 
 		memtable.Put(rec)
 		wrote++
+	}
+
+	if err := mergeIter.Close(); err != nil {
+		return nil, err
 	}
 
 	if wrote == 0 {

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1640,6 +1640,41 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		}
 	})
 
+	t.Run("handles multiple versions of a key", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		mem1 := InitMemtable(*ts.Config)
+		mem1.Put(newRecord(Bytes("b"), Bytes("v1"), 1))
+		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem2 := InitMemtable(*ts.Config)
+		mem2.Put(newRecord(Bytes("b"), Bytes("v2"), 2))
+		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem3 := InitMemtable(*ts.Config)
+		mem3.Put(newRecord(Bytes("b"), nil, 3))
+		sst3, err := flush(ctx, *ts.Config, mem3, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		target := ts.newSSTableFS(1)
+		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2, sst3}, false)
+		assert.NoError(t, err)
+		assert.NotNil(t, merged)
+
+		v, err := merged.GetValue(ctx, Bytes("b"))
+		assert.NoError(t, err)
+		assert.Nil(t, v)
+
+		target2 := ts.newSSTableFS(1)
+		merged2, err := mergeSSTablesV2(ctx, *ts.Config, target2, []SStable{sst1, sst2, sst3}, true)
+		assert.NoError(t, err)
+		assert.Nil(t, merged2)
+	})
+
 	t.Run("returns nil on empty sources", func(t *testing.T) {
 		ctx := context.Background()
 		ts := newTestRindbSetup(t, ctx, &cfg)


### PR DESCRIPTION
## Summary
- add MergingIterator to merge record iterators without deduplication
- filter tombstones and duplicates for user ranges
- refactor compaction to merge using MergingIterator

## Testing
- `make check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68acf51821388325be9298daa1a16b96