### PR TITLE
feat: add sequence-aware reads

### DIFF
--- a/range.go
+++ b/range.go
@@ -1,6 +1,9 @@
 package rindb
 
-import "errors"
+import (
+	"errors"
+	"math"
+)
 
 // RangeIterator is a user-facing iterator that hides tombstones and
 // duplicates. It wraps a MergingIterator which provides all records in key and
@@ -12,11 +15,16 @@ type RangeIterator struct {
 	next       Record
 	prepared   bool
 	err        error
+	maxSeq     uint64
 }
 
 // NewRangeIterator creates a new RangeIterator from a MergingIterator.
-func NewRangeIterator(mi *MergingIterator) *RangeIterator {
-	return &RangeIterator{mi: mi}
+func NewRangeIterator(mi *MergingIterator, seq ...uint64) *RangeIterator {
+	maxSeq := uint64(math.MaxUint64)
+	if len(seq) > 0 {
+		maxSeq = seq[0]
+	}
+	return &RangeIterator{mi: mi, maxSeq: maxSeq}
 }
 
 func (r *RangeIterator) prepare() {
@@ -28,6 +36,9 @@ func (r *RangeIterator) prepare() {
 			}
 			r.err = err
 			return
+		}
+		if rec.GetSequenceNumber() > r.maxSeq {
+			continue
 		}
 		if r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual {
 			continue

--- a/range_test.go
+++ b/range_test.go
@@ -158,3 +158,26 @@ func TestRangeIteratorPrepare(t *testing.T) {
 		assert.False(t, iter.prepared)
 	})
 }
+
+func TestRangeIteratorSequence(t *testing.T) {
+	rec := func(k, v string, seq uint64) Record {
+		var nv Bytes = nil
+		if v != "" {
+			nv = Bytes(v)
+		}
+		return newRecord(Bytes(k), nv, seq)
+	}
+
+	it1 := &errIterator{records: []Record{rec("a", "v3", 3), rec("a", "v2", 2)}, failIdx: -1}
+	it2 := &errIterator{records: []Record{rec("a", "v1", 1)}, failIdx: -1}
+
+	mi, err := NewMergingIterator([]Iterator[Record]{it1, it2}, nil)
+	assert.NoError(t, err)
+
+	iter := NewRangeIterator(mi, 2)
+	assert.True(t, iter.HasNext())
+	r, err := iter.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, "v2", string(r.GetValue()))
+	assert.False(t, iter.HasNext())
+}

--- a/rindb.go
+++ b/rindb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -178,7 +179,7 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 //
 //	Bytes - The value associated with the key, or nil if the key is not found.
 //	error - An error if the database is closed, or if an error occurs during lookup in memtable or SSTables.
-func (r *Rindb) Get(ctx context.Context, key Bytes) (Bytes, error) {
+func (r *Rindb) Get(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
 	ctx, span := tracer.Start(ctx, "Rindb.Get")
 	defer span.End()
 	getCalls.Add(ctx, 1)
@@ -194,14 +195,19 @@ func (r *Rindb) Get(ctx context.Context, key Bytes) (Bytes, error) {
 		return nil, ErrDatabaseClosed
 	}
 
-	value, err := r.memtable.Get(key)
+	var maxSeq = uint64(math.MaxUint64)
+	if len(seq) > 0 {
+		maxSeq = seq[0]
+	}
+
+	value, err := r.memtable.GetAt(key, maxSeq)
 	if err == nil {
 		return value, nil
 	}
 	if !errors.Is(err, ErrKeyNotFound) {
 		return nil, err
 	}
-	return r.ssTableManager.searchKey(ctx, key)
+	return r.ssTableManager.searchKey(ctx, key, maxSeq)
 }
 
 // IRange returns an iterator over records with keys in [start, end],
@@ -209,7 +215,7 @@ func (r *Rindb) Get(ctx context.Context, key Bytes) (Bytes, error) {
 //
 // The returned iterator must be closed when no longer needed to release
 // any associated resources.
-func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (*RangeIterator, error) {
+func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*RangeIterator, error) {
 	ctx, span := tracer.Start(ctx, "Rindb.IRange")
 	defer span.End()
 	iRangeCalls.Add(ctx, 1)
@@ -226,6 +232,11 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (*RangeIterator, e
 
 	if r.closed {
 		return nil, ErrDatabaseClosed
+	}
+
+	var maxSeq = uint64(math.MaxUint64)
+	if len(seq) > 0 {
+		maxSeq = seq[0]
 	}
 
 	iterators := []Iterator[Record]{r.memtable.IRange(start, end)}
@@ -246,7 +257,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (*RangeIterator, e
 	it := sstables.Iterator()
 	for it.HasNext() {
 		sst, _ := it.Next()
-		rangeIter, err := sst.IRange(start, end)
+		rangeIter, err := sst.IRange(start, end, maxSeq)
 		if err != nil {
 			cleanup()
 			return nil, err
@@ -260,7 +271,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes) (*RangeIterator, e
 		return nil, err
 	}
 
-	return NewRangeIterator(mergeIter), nil
+	return NewRangeIterator(mergeIter, maxSeq), nil
 }
 
 // Put inserts or updates a key-value pair in the database.

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -43,7 +43,14 @@ func TestRindb_Get(t *testing.T) {
 	key := Bytes("key")
 	err := rin.Put(ctx, key, Bytes("value"))
 	assert.NoError(t, err)
+	err = rin.Put(ctx, key, Bytes("value2"))
+	assert.NoError(t, err)
+
 	value, err := rin.Get(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("value2"), value)
+
+	value, err = rin.Get(ctx, key, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, Bytes("value"), value)
 }

--- a/sstable.go
+++ b/sstable.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"sort"
 	"time"
@@ -79,7 +80,7 @@ type SStable struct {
 	Bloom       *BloomFilter
 }
 
-func (s SStable) GetValue(ctx context.Context, key Bytes) (Bytes, error) {
+func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
 	ctx, span := sstableTracer.Start(ctx, "SStable.GetValue")
 	start := time.Now()
 	var bytesRead int
@@ -95,6 +96,11 @@ func (s SStable) GetValue(ctx context.Context, key Bytes) (Bytes, error) {
 		return nil, ErrKeyNotFound
 	}
 
+	var maxSeq = uint64(math.MaxUint64)
+	if len(seq) > 0 {
+		maxSeq = seq[0]
+	}
+
 	offset, err := s.SparseIndex.GetOffset(key)
 	if err != nil {
 		return nil, err
@@ -105,18 +111,31 @@ func (s SStable) GetValue(ctx context.Context, key Bytes) (Bytes, error) {
 		return nil, fmt.Errorf("failed to seek to offset %d: %w", offset, err)
 	}
 
-	record, err := ReadRecord(s)
-	if err != nil {
-		// Check for EOF specifically, might indicate corruption if seeking led here
-		if errors.Is(err, io.EOF) {
-			ERROR(ctx, "Unexpected EOF after seeking to offset %d in %s", offset, s.Path())
-			return nil, fmt.Errorf("unexpected EOF after seeking to offset %d: %w", offset, ErrMalFormedSSTable)
+	for {
+		record, err := ReadRecord(s)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			ERROR(ctx, "Failed to read record in %s: %v", s.Path(), err)
+			return nil, fmt.Errorf("failed to read record: %w", err)
 		}
-		ERROR(ctx, "Failed to read record at offset %d in %s: %v", offset, s.Path(), err)
-		return nil, fmt.Errorf("failed to read record at offset %d: %w", offset, err)
+		bytesRead += CalOnDiskSize(record)
+
+		cmp := record.GetKey().Compare(key)
+		if cmp != CmpEqual {
+			break
+		}
+		if record.GetSequenceNumber() > maxSeq {
+			continue
+		}
+		if record.GetType() == TypeDeletion {
+			return nil, nil
+		}
+		return record.GetValue(), nil
 	}
-	bytesRead = CalOnDiskSize(record)
-	return record.GetValue(), nil
+
+	return nil, ErrKeyNotFound
 }
 
 // GetKeyRange returns the minimum and maximum keys in the SStable.
@@ -363,6 +382,7 @@ type sstableIRange struct {
 	s       *SStable
 	current int
 	endKey  Bytes
+	maxSeq  uint64
 }
 
 // HasNext implements Iterator.
@@ -372,27 +392,38 @@ func (sri *sstableIRange) HasNext() bool {
 
 // Next implements Iterator.
 func (sri *sstableIRange) Next() (Record, error) {
-	if !sri.HasNext() {
-		return nil, EOI
+	for sri.current < len(sri.s.SparseIndex) && sri.s.SparseIndex[sri.current].key.Compare(sri.endKey) <= 0 {
+		rec, err := ReadRecord(sri.s)
+		if err != nil {
+			return nil, err
+		}
+		sri.current++
+		if rec.GetSequenceNumber() > sri.maxSeq {
+			continue
+		}
+		return rec, nil
 	}
-	rec, err := ReadRecord(sri.s)
-	if err != nil {
-		return nil, err
-	}
-	sri.current++
-	return rec, nil
+	return nil, EOI
 }
 
 // IRange returns an iterator over records with keys in [start, end].
-func (s SStable) IRange(start, end Bytes) (Iterator[Record], error) {
+func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], error) {
 	startIdx := sort.Search(len(s.SparseIndex), func(i int) bool {
 		return s.SparseIndex[i].key.Compare(start) >= 0
 	})
 	if startIdx >= len(s.SparseIndex) {
-		return &sstableIRange{s: &s, current: startIdx, endKey: end}, nil
+		var maxSeq = uint64(math.MaxUint64)
+		if len(seq) > 0 {
+			maxSeq = seq[0]
+		}
+		return &sstableIRange{s: &s, current: startIdx, endKey: end, maxSeq: maxSeq}, nil
 	}
 	if _, err := s.file.Seek(s.SparseIndex[startIdx].offset, io.SeekStart); err != nil {
 		return nil, err
 	}
-	return &sstableIRange{s: &s, current: startIdx, endKey: end}, nil
+	var maxSeq = uint64(math.MaxUint64)
+	if len(seq) > 0 {
+		maxSeq = seq[0]
+	}
+	return &sstableIRange{s: &s, current: startIdx, endKey: end, maxSeq: maxSeq}, nil
 }

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -504,3 +504,26 @@ func TestBloomFilterSkipsReads(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), pos, "File should not be read due to Bloom filter")
 }
+
+func TestSStable_GetValueSequence(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("k"), Bytes("v1"), 1))
+	mem.Put(newRecord(Bytes("k"), Bytes("v2"), 2))
+
+	sstable, err := flush(ctx, cfg, mem, fs)
+	assert.NoError(t, err)
+
+	v, err := sstable.GetValue(ctx, Bytes("k"), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("v1"), v)
+
+	v, err = sstable.GetValue(ctx, Bytes("k"), 2)
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("v2"), v)
+}

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -694,7 +694,7 @@ func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 	return relevantSSTables, nil
 }
 
-func (h *SSTableManager) searchKey(ctx context.Context, key Bytes) (Bytes, error) {
+func (h *SSTableManager) searchKey(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
@@ -723,7 +723,7 @@ func (h *SSTableManager) searchKey(ctx context.Context, key Bytes) (Bytes, error
 				return nil, err
 			}
 
-			value, err := sstable.GetValue(ctx, key)
+			value, err := sstable.GetValue(ctx, key, seq...)
 			closeErr := fs.Close()
 			h.removeOpenedFS(fs)
 			if err == nil {


### PR DESCRIPTION
## Summary
- allow Get and IRange to specify a sequence snapshot
- filter SSTable and iterator results by sequence numbers
- exercise sequence-aware reads in unit tests

## Testing
- `make check` *(fails: internal error in staticcheck: unsupported version)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad5c8ed6608325807037c35569db3c