### PR TITLE
feat: honor snapshots during SSTable merge

### DIFF
--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -34,6 +34,11 @@ type SSTableManager struct {
 	config   Config
 	mu       sync.RWMutex
 
+	// minSnapshotSeq is the smallest sequence number of any active
+	// snapshot. When no snapshots are active it is set to
+	// math.MaxUint64, allowing tombstone GC at the bottommost level.
+	minSnapshotSeq uint64
+
 	// writeRate is the moving average of writes per second.
 	writeRate float64
 
@@ -78,6 +83,7 @@ func InitSSTableManager(ctx context.Context, config Config) (*SSTableManager, er
 		config:            config,
 		stopIOLoadSampler: make(chan struct{}),
 		now:               time.Now,
+		minSnapshotSeq:    math.MaxUint64,
 		// diskSampler aggregates the IoTime from all available disk
 		// counters. IoTime is the number of milliseconds the disk has
 		// been busy since boot.
@@ -588,7 +594,7 @@ func (h *SSTableManager) mergeSSTables(ctx context.Context, newLevelNumb int, pi
 		}
 	}
 
-	merged, err := mergeSSTablesV2(ctx, h.config, newLevelSSTable, pickedUpSSTable, bottommost)
+	merged, err := mergeSSTablesV2(ctx, h.config, newLevelSSTable, pickedUpSSTable, bottommost, h.minSnapshotSeq)
 	// close and remove merged sstables even if there is an error
 	h.closeSSTables(pickedUpSSTable)
 	if err != nil || merged == nil {
@@ -856,7 +862,7 @@ func mergeSSTables(ctx context.Context, config Config, target *FileSystem, sourc
 	return sstable, nil
 }
 
-func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sources []SStable, bottommost bool) (_ *SStable, err error) {
+func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sources []SStable, bottommost bool, minSeq uint64) (_ *SStable, err error) {
 	if len(sources) == 0 {
 		return nil, nil
 	}
@@ -884,6 +890,7 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 		wrote      int
 		lastKey    Bytes
 		lastKeySet bool
+		lastSeq    uint64
 		memtable   = InitMemtable(config)
 	)
 	for mergeIter.HasNext() {
@@ -894,14 +901,17 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 		if err != nil {
 			return nil, err
 		}
-		if lastKeySet && rec.GetKey().Compare(lastKey) == CmpEqual {
+		if lastKeySet && rec.GetKey().Compare(lastKey) == CmpEqual && lastSeq <= minSeq {
 			continue
 		}
-		lastKey = rec.GetKey().Clone()
-		lastKeySet = true
+		if !lastKeySet || rec.GetKey().Compare(lastKey) != CmpEqual {
+			lastKey = rec.GetKey().Clone()
+			lastKeySet = true
+		}
+		lastSeq = rec.GetSequenceNumber()
 
-		if rec.GetType() == TypeDeletion && bottommost {
-			continue // GC tombstone only at bottommost
+		if rec.GetType() == TypeDeletion && bottommost && rec.GetSequenceNumber() < minSeq {
+			continue // GC tombstone only at bottommost when older than snapshots
 		}
 
 		memtable.Put(rec)

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1393,11 +1393,12 @@ func TestSSTableManager_DynamicShouldCompact(t *testing.T) {
 			ioVal := uint64(0)
 
 			sm := &SSTableManager{
-				openedFs:    list.New(),
-				levels:      []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()},
-				config:      cfg,
-				now:         func() time.Time { return current },
-				diskSampler: func() (uint64, error) { return ioVal, nil },
+				openedFs:       list.New(),
+				levels:         []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()},
+				config:         cfg,
+				now:            func() time.Time { return current },
+				diskSampler:    func() (uint64, error) { return ioVal, nil },
+				minSnapshotSeq: math.MaxUint64,
 			}
 			sm.levels[0].PushBack(&FileSystem{filePath: "dummy"})
 
@@ -1584,7 +1585,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
-		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2}, false)
+		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2}, false, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.NotNil(t, merged)
 
@@ -1619,7 +1620,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
-		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2}, true)
+		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2}, true, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.NotNil(t, merged)
 
@@ -1638,6 +1639,50 @@ func Test_mergeSSTablesV2(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotEqual(t, Bytes("b"), rec.GetKey())
 		}
+	})
+
+	t.Run("preserves records for active snapshot", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		mem1 := InitMemtable(*ts.Config)
+		mem1.Put(newRecord(Bytes("b"), Bytes("v1"), 1))
+		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem2 := InitMemtable(*ts.Config)
+		mem2.Put(newRecord(Bytes("b"), Bytes("v2"), 2))
+		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem3 := InitMemtable(*ts.Config)
+		mem3.Put(newRecord(Bytes("b"), nil, 3))
+		sst3, err := flush(ctx, *ts.Config, mem3, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		target := ts.newSSTableFS(1)
+		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2, sst3}, true, 2)
+		assert.NoError(t, err)
+		assert.NotNil(t, merged)
+
+		v, err := merged.GetValue(ctx, Bytes("b"))
+		assert.ErrorIs(t, err, ErrTombstoneFound)
+		assert.Nil(t, v)
+
+		iter, err := merged.Iterator()
+		assert.NoError(t, err)
+		var recs []Record
+		for iter.HasNext() {
+			rec, err := iter.Next()
+			assert.NoError(t, err)
+			recs = append(recs, rec)
+		}
+		assert.Equal(t, 2, len(recs))
+		assert.Equal(t, uint64(3), recs[0].GetSequenceNumber())
+		assert.Equal(t, TypeDeletion, recs[0].GetType())
+		assert.Equal(t, uint64(2), recs[1].GetSequenceNumber())
+		assert.Equal(t, TypeValue, recs[1].GetType())
 	})
 
 	t.Run("handles multiple versions of a key", func(t *testing.T) {
@@ -1661,7 +1706,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
-		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2, sst3}, false)
+		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2, sst3}, false, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.NotNil(t, merged)
 
@@ -1670,7 +1715,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.Nil(t, v)
 
 		target2 := ts.newSSTableFS(1)
-		merged2, err := mergeSSTablesV2(ctx, *ts.Config, target2, []SStable{sst1, sst2, sst3}, true)
+		merged2, err := mergeSSTablesV2(ctx, *ts.Config, target2, []SStable{sst1, sst2, sst3}, true, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.Nil(t, merged2)
 	})
@@ -1681,7 +1726,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		defer ts.Cleanup()
 
 		target := ts.newSSTableFS(1)
-		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{}, false)
+		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{}, false, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.Nil(t, merged)
 	})
@@ -1697,7 +1742,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
-		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst}, true)
+		merged, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst}, true, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.Nil(t, merged)
 	})
@@ -1715,7 +1760,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		target := ts.newSSTableFS(1)
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		cancel()
-		merged, err := mergeSSTablesV2(cancelCtx, *ts.Config, target, []SStable{sst}, false)
+		merged, err := mergeSSTablesV2(cancelCtx, *ts.Config, target, []SStable{sst}, false, math.MaxUint64)
 		assert.ErrorIs(t, err, context.Canceled)
 		assert.Nil(t, merged)
 	})
@@ -1777,6 +1822,52 @@ func TestSSTableManager_mergeSSTables(t *testing.T) {
 		assert.Error(t, err)
 		_, err = os.Stat(sst2.Path())
 		assert.Error(t, err)
+	})
+
+	t.Run("keeps tombstone with active snapshot", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		ts.Manager.minSnapshotSeq = 2
+
+		mem1 := InitMemtable(*ts.Config)
+		mem1.Put(newRecord(Bytes("b"), Bytes("1"), 1))
+		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem2 := InitMemtable(*ts.Config)
+		mem2.Put(newRecord(Bytes("b"), nil, 3))
+		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		ts.Manager.mu.Lock()
+		err = ts.Manager.mergeSSTables(ctx, 1, []SStable{sst1, sst2})
+		ts.Manager.mu.Unlock()
+		assert.NoError(t, err)
+
+		fs, err := ts.Manager.levels[1].Iterator().Next()
+		assert.NoError(t, err)
+		merged, err := ts.Manager.openAndLoadSSTable(ctx, fs)
+		assert.NoError(t, err)
+
+		v, err := merged.GetValue(ctx, Bytes("b"))
+		assert.ErrorIs(t, err, ErrTombstoneFound)
+		assert.Nil(t, v)
+
+		iter, err := merged.Iterator()
+		assert.NoError(t, err)
+		var recs []Record
+		for iter.HasNext() {
+			rec, err := iter.Next()
+			assert.NoError(t, err)
+			recs = append(recs, rec)
+		}
+		assert.Equal(t, 2, len(recs))
+		assert.Equal(t, uint64(3), recs[0].GetSequenceNumber())
+		assert.Equal(t, TypeDeletion, recs[0].GetType())
+		assert.Equal(t, uint64(1), recs[1].GetSequenceNumber())
+		assert.Equal(t, TypeValue, recs[1].GetType())
 	})
 
 	t.Run("no-op on empty sources", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- track minimum active snapshot sequence in SSTableManager
- preserve snapshot-visible records during SSTable merges and only drop tombstones older than snapshots
- add tests covering compaction while a snapshot is active

## Testing
- `make check` *(fails: internal error in staticcheck unsupported version)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8e2d8ad0832593e4a20b452eedc2