### PR TITLE
fix: serialize filesystem access for concurrent reads

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 )
 
 const fileSystemPermission = 0o600
@@ -18,6 +19,7 @@ var (
 )
 
 type FileSystem struct {
+	mu       sync.RWMutex
 	filePath string
 	file     *os.File
 }
@@ -35,11 +37,16 @@ func NewFS(file *os.File) *FileSystem {
 }
 
 func (fs *FileSystem) IsOpened() bool {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
 	return fs.file != nil
 }
 
 func (fs *FileSystem) Open(ctx context.Context) error {
-	if fs.IsOpened() {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file != nil {
 		WARN(ctx, "File %s is already opened. Consider close and re-open again", fs.Path())
 		return nil
 	}
@@ -57,19 +64,24 @@ func (fs *FileSystem) Path() string {
 }
 
 func (fs *FileSystem) Sync() error {
-	if !fs.IsOpened() {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if fs.file == nil {
 		return ErrFileNotOpened
 	}
 	return fs.file.Sync()
 }
 
 func (fs *FileSystem) Close() error {
-	if !fs.IsOpened() {
-		return ErrFileNotOpened
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file == nil {
+		return nil
 	}
 
-	err := fs.file.Close()
-	if err != nil {
+	if err := fs.file.Close(); err != nil {
 		return err
 	}
 	fs.file = nil
@@ -77,20 +89,26 @@ func (fs *FileSystem) Close() error {
 }
 
 func (fs *FileSystem) Clean() error {
-	if err := fs.Close(); err != nil {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file == nil {
+		return ErrFileNotOpened
+	}
+
+	if err := fs.file.Close(); err != nil {
 		return fmt.Errorf("failed to close file %s before cleaning: %w", fs.Path(), err)
 	}
 
-	// Open with truncation
 	cleanFile, err := os.OpenFile(fs.Path(), os.O_RDWR|os.O_CREATE|os.O_TRUNC, fileSystemPermission)
 	if err != nil {
 		return fmt.Errorf("failed to open/truncate file %s for cleaning: %w", fs.Path(), err)
 	}
-	fs.file = cleanFile // Assign the new file handle
+	fs.file = cleanFile
 
-	if err := fs.Sync(); err != nil {
-		// Close the newly opened file before returning error
-		_ = fs.Close() // Ignore close error here as we're returning the sync error
+	if err := fs.file.Sync(); err != nil {
+		_ = fs.file.Close()
+		fs.file = nil
 		return fmt.Errorf("failed to sync file %s after cleaning: %w", fs.Path(), err)
 	}
 
@@ -99,7 +117,10 @@ func (fs *FileSystem) Clean() error {
 
 // CursorPos get current cursor position in file system
 func (fs *FileSystem) CursorPos() (int64, error) {
-	if !fs.IsOpened() {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if fs.file == nil {
 		return 0, ErrFileNotOpened
 	}
 
@@ -107,19 +128,34 @@ func (fs *FileSystem) CursorPos() (int64, error) {
 }
 
 func (fs *FileSystem) Write(p []byte) (int, error) {
-	if !fs.IsOpened() {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file == nil {
 		return 0, ErrFileNotOpened
 	}
 
-	// TODO: add lock
 	return fs.file.Write(p)
 }
 
 func (fs *FileSystem) Read(p []byte) (int, error) {
-	if !fs.IsOpened() {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file == nil {
 		return 0, ErrFileNotOpened
 	}
 
-	// TODO: add lock
 	return fs.file.Read(p)
+}
+
+func (fs *FileSystem) Seek(offset int64, whence int) (int64, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file == nil {
+		return 0, ErrFileNotOpened
+	}
+
+	return fs.file.Seek(offset, whence)
 }

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -40,7 +40,7 @@ func TestFileSystem(t *testing.T) {
 		assert.ErrorIs(t, err, ErrFileNotOpened)
 
 		assert.NoError(t, fs.Close())
-		assert.ErrorIs(t, emptyFs.Close(), ErrFileNotOpened)
+		assert.NoError(t, emptyFs.Close())
 	})
 }
 
@@ -114,7 +114,7 @@ func TestFileSystem_CursorPos(t *testing.T) {
 		err = fs.Sync()
 		assert.NoError(t, err)
 
-		_, err = fs.file.Seek(-3, io.SeekEnd)
+		_, err = fs.Seek(-3, io.SeekEnd)
 		assert.NoError(t, err)
 
 		position, err := fs.CursorPos()

--- a/sstable.go
+++ b/sstable.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"time"
 )
@@ -94,6 +95,18 @@ func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes,
 
 	maxSeq := getMaxSeq(seq...)
 
+	fs := s.FileSystem
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file == nil {
+		file, err := os.OpenFile(filepath.Clean(fs.filePath), os.O_RDWR|os.O_CREATE, fileSystemPermission)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open sstable %s: %w", fs.Path(), err)
+		}
+		fs.file = file
+	}
+
 	if !s.Bloom.Lookup(key) {
 		return nil, ErrKeyNotFound
 	}
@@ -103,13 +116,13 @@ func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes,
 		return nil, err
 	}
 
-	if _, err := s.file.Seek(offset, io.SeekStart); err != nil {
+	if _, err := fs.file.Seek(offset, io.SeekStart); err != nil {
 		ERROR(ctx, "Failed to seek to offset %d in %s: %v", offset, s.Path(), err)
 		return nil, fmt.Errorf("failed to seek to offset %d: %w", offset, err)
 	}
 
 	for {
-		record, err := ReadRecord(s)
+		record, err := ReadRecord(fs.file)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				ERROR(ctx, "Unexpected EOF after seeking to offset %d in %s", offset, s.Path())
@@ -189,26 +202,32 @@ func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, er
 
 	// Seek to the beginning of the file
 	// Support testing assertions
-	fs.file.Seek(0, io.SeekStart)
+	fs.Seek(0, io.SeekStart)
 	INFO(ctx, "Successfully created SSTable at %s with %d sparse index entries", fs.Path(), len(sparseIndex))
 	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom}, nil
 }
 
 func readTailSSTable(fs *FileSystem) (int64, error) {
-	tailSSTableOffset, err := fs.file.Seek(-1*mdByteSize, io.SeekEnd)
-	if err != nil {
-		return 0, err
+	if fs.file == nil {
+		return 0, ErrFileNotOpened
 	}
-	return tailSSTableOffset, nil
+	return fs.file.Seek(-1*mdByteSize, io.SeekEnd)
 }
 
 func loadSparseIndex(fs *FileSystem) (SparseIndex, error) {
-	tailSSTableOffset, err := readTailSSTable(fs)
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file == nil {
+		return SparseIndex{}, ErrFileNotOpened
+	}
+
+	tailSSTableOffset, err := fs.file.Seek(-1*mdByteSize, io.SeekEnd)
 	if err != nil {
 		return SparseIndex{}, fmt.Errorf("failed to seek to tail of sstable %s: %w", fs.Path(), err)
 	}
 
-	sparseIndexOffset, err := ReadNumber(fs)
+	sparseIndexOffset, err := ReadNumber(fs.file)
 	if err != nil {
 		return SparseIndex{}, fmt.Errorf("failed to read sparse index offset from %s: %w", fs.Path(), err)
 	}
@@ -221,7 +240,7 @@ func loadSparseIndex(fs *FileSystem) (SparseIndex, error) {
 	sparseIndex := SparseIndex{}
 	// Read records until the calculated end of the sparse index data
 	for ret < tailSSTableOffset {
-		record, err := ReadRecord(fs)
+		record, err := ReadRecord(fs.file)
 		if err != nil {
 			// Check for EOF specifically, might indicate corruption
 			if errors.Is(err, io.EOF) {
@@ -231,7 +250,7 @@ func loadSparseIndex(fs *FileSystem) (SparseIndex, error) {
 		}
 		sparseIndex = append(sparseIndex, NewKeyOffset(record.GetKey(), record.GetValue()))
 
-		ret, err = fs.CursorPos()
+		ret, err = fs.file.Seek(0, io.SeekCurrent)
 		if err != nil {
 			return SparseIndex{}, fmt.Errorf("failed to get cursor position in %s: %w", fs.Path(), err)
 		}
@@ -358,8 +377,13 @@ func (s *sstableIterator) Next() (Record, error) {
 }
 
 func (s SStable) Iterator() (Iterator[Record], error) {
-	_, err := s.file.Seek(0, io.SeekStart)
-	if err != nil {
+	if !s.IsOpened() {
+		if err := s.Open(context.Background()); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := s.Seek(0, io.SeekStart); err != nil {
 		return nil, err
 	}
 
@@ -403,13 +427,18 @@ func (sri *sstableIRange) Next() (Record, error) {
 // numbers less than or equal to seq.
 func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], error) {
 	maxSeq := getMaxSeq(seq...)
+	if !s.IsOpened() {
+		if err := s.Open(context.Background()); err != nil {
+			return nil, err
+		}
+	}
 	startIdx := sort.Search(len(s.SparseIndex), func(i int) bool {
 		return s.SparseIndex[i].key.Compare(start) >= 0
 	})
 	if startIdx >= len(s.SparseIndex) {
 		return &sstableIRange{s: &s, current: startIdx, endKey: end, seq: maxSeq}, nil
 	}
-	if _, err := s.file.Seek(s.SparseIndex[startIdx].offset, io.SeekStart); err != nil {
+	if _, err := s.Seek(s.SparseIndex[startIdx].offset, io.SeekStart); err != nil {
 		return nil, err
 	}
 	return &sstableIRange{s: &s, current: startIdx, endKey: end, seq: maxSeq}, nil

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -52,7 +52,7 @@ func TestSStable(t *testing.T) {
 		sparseIndexOffset, err := ReadNumber(sstable)
 		assert.NoError(t, err)
 		assert.NotZero(t, sparseIndexOffset)
-		ret, err := sstable.file.Seek(0, io.SeekStart)
+		ret, err := sstable.Seek(0, io.SeekStart)
 		assert.NoError(t, err)
 		expectedSparseIndex := make(SparseIndex, 0)
 		idx := 0
@@ -112,7 +112,7 @@ func TestSStable(t *testing.T) {
 		sparseIndex := sstable.SparseIndex
 		for idx := len(sparseIndex) - 1; idx > -1; idx-- {
 			keyOffset := sparseIndex[idx]
-			_, err := sstable.file.Seek(keyOffset.offset, io.SeekStart)
+			_, err := sstable.Seek(keyOffset.offset, io.SeekStart)
 			assert.NoError(t, err)
 			record, err := ReadRecord(sstable)
 			assert.NoError(t, err)
@@ -315,7 +315,7 @@ func TestSStable(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				// Re-seek the file to the beginning for each test case
-				_, err := sstable.file.Seek(0, io.SeekStart)
+				_, err := sstable.Seek(0, io.SeekStart)
 				assert.NoError(t, err)
 
 				iterator, err := sstable.IRange(tt.startKey, tt.endKey)

--- a/utils_test.go
+++ b/utils_test.go
@@ -229,7 +229,7 @@ func initTempFileSystems(t *testing.T, n int, initialContents [][]byte) ([]*File
 		if initialContents != nil && initialContents[i] != nil {
 			_, writeErr := fs.Write(initialContents[i])
 			assert.NoError(t, writeErr, "Failed to write initial content to temp file %d", i)
-			_, seekErr := fs.file.Seek(0, io.SeekStart) // Reset cursor to beginning
+			_, seekErr := fs.Seek(0, io.SeekStart) // Reset cursor to beginning
 			assert.NoError(t, seekErr, "Failed to seek to start after writing initial content to temp file %d", i)
 		}
 

--- a/wal.go
+++ b/wal.go
@@ -45,13 +45,13 @@ func (w *WAL) Load(ctx context.Context) (Memtable, error) {
 		span.End()
 	}()
 
-	_, err := w.file.Seek(0, io.SeekStart)
-	if err != nil {
+	if _, err := w.Seek(0, io.SeekStart); err != nil {
 		return Memtable{}, fmt.Errorf("failed to seek to start of WAL file %s: %w", w.Path(), err)
 	}
+
 	mem := InitMemtable(w.config)
 	for {
-		record, err := ReadRecord(w.file)
+		record, err := ReadRecord(w)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break // Normal end of file
@@ -77,20 +77,19 @@ func (w *WAL) Append(ctx context.Context, record Record) error {
 	tx := w.tm.Begin()
 	defer tx.Rollback(ctx)
 
-	_, err := w.file.Seek(0, io.SeekEnd)
-	if err != nil {
+	if _, err := w.Seek(0, io.SeekEnd); err != nil {
 		return fmt.Errorf("failed to seek to end of WAL file %s: %w", w.Path(), err)
 	}
 
-	if err = WriteRecord(tx, record); err != nil {
+	if err := WriteRecord(tx, record); err != nil {
 		return fmt.Errorf("failed to write record to WAL transaction: %w", err)
 	}
 
-	if err = tx.Commit(ctx, w.file); err != nil {
+	if err := tx.Commit(ctx, w.FileSystem); err != nil {
 		return fmt.Errorf("failed to commit WAL transaction to %s: %w", w.Path(), err)
 	}
 
-	if err = w.Sync(); err != nil {
+	if err := w.Sync(); err != nil {
 		return fmt.Errorf("failed to sync WAL file %s: %w", w.Path(), err)
 	}
 
@@ -113,8 +112,7 @@ func (w *WAL) AppendMany(ctx context.Context, records []Record) error {
 	tx := w.tm.Begin()
 	defer tx.Rollback(ctx)
 
-	_, err := w.file.Seek(0, io.SeekEnd)
-	if err != nil {
+	if _, err := w.Seek(0, io.SeekEnd); err != nil {
 		return fmt.Errorf("failed to seek to end of WAL file %s: %w", w.Path(), err)
 	}
 
@@ -126,11 +124,11 @@ func (w *WAL) AppendMany(ctx context.Context, records []Record) error {
 		totalBytes += CalOnDiskSize(record)
 	}
 
-	if err = tx.Commit(ctx, w.file); err != nil {
+	if err := tx.Commit(ctx, w.FileSystem); err != nil {
 		return fmt.Errorf("failed to commit multi-record WAL transaction to %s: %w", w.Path(), err)
 	}
 
-	if err = w.Sync(); err != nil {
+	if err := w.Sync(); err != nil {
 		return fmt.Errorf("failed to sync WAL file %s after multi-record append: %w", w.Path(), err)
 	}
 


### PR DESCRIPTION
## Summary
- protect FileSystem with an RWMutex and expose a Seek helper
- wrap file offset operations with mutex guarding
- switch SSTable code to use FileSystem helpers instead of raw file seeks
- guard SSTable reads and sparse index loading with filesystem locks and reopen when needed
- make FileSystem.Close idempotent to avoid double-close errors

## Testing
- `make check` *(fails: internal error in importing "cmp" (unsupported version: 2))*
- `make test`
- `go test -tags=integration -run TestConcurrentPutGet -count=100 ./integration`


------
https://chatgpt.com/codex/tasks/task_e_68ad8f2001a08325ac80da79f5874b45