### PR TITLE
feat: track snapshot sequences for compaction

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -198,6 +199,15 @@ func (r *Rindb) NewSnapshot(ctx context.Context) (*Snapshot, error) {
 
 	snap := &Snapshot{sequence: r.sequenceNumber}
 	r.activeSnapshots = append(r.activeSnapshots, snap.sequence)
+
+	minSeq := r.activeSnapshots[0]
+	for _, seq := range r.activeSnapshots[1:] {
+		if seq < minSeq {
+			minSeq = seq
+		}
+	}
+	r.ssTableManager.UpdateMinSnapshotSeq(minSeq)
+
 	return snap, nil
 }
 
@@ -219,6 +229,15 @@ func (r *Rindb) Release(ctx context.Context, snap *Snapshot) error {
 			break
 		}
 	}
+
+	minSeq := uint64(math.MaxUint64)
+	for _, seq := range r.activeSnapshots {
+		if seq < minSeq {
+			minSeq = seq
+		}
+	}
+	r.ssTableManager.UpdateMinSnapshotSeq(minSeq)
+
 	return nil
 }
 

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -530,3 +530,76 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 		assert.Equal(t, uint64(70), rin.sequenceNumber, "Expected sequence number to be the common max")
 	})
 }
+
+func TestCompactionRespectsSnapshots(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+
+	t.Run("retains tombstone with active snapshot", func(t *testing.T) {
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		ts.RinDB.mu.Lock()
+		ts.RinDB.sequenceNumber = 2
+		ts.RinDB.mu.Unlock()
+
+		snap, err := ts.RinDB.NewSnapshot(ctx)
+		assert.NoError(t, err)
+
+		mem1 := InitMemtable(*ts.Config)
+		mem1.Put(newRecord(Bytes("b"), Bytes("1"), 1))
+		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem2 := InitMemtable(*ts.Config)
+		mem2.Put(newRecord(Bytes("b"), nil, 3))
+		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		ts.Manager.mu.Lock()
+		err = ts.Manager.mergeSSTables(ctx, 1, []SStable{sst1, sst2})
+		ts.Manager.mu.Unlock()
+		assert.NoError(t, err)
+
+		fs, err := ts.Manager.levels[1].Iterator().Next()
+		assert.NoError(t, err)
+		merged, err := ts.Manager.openAndLoadSSTable(ctx, fs)
+		assert.NoError(t, err)
+
+		v, err := merged.GetValue(ctx, Bytes("b"))
+		assert.ErrorIs(t, err, ErrTombstoneFound)
+		assert.Nil(t, v)
+
+		_ = ts.RinDB.Release(ctx, snap)
+	})
+
+	t.Run("prunes after snapshot release", func(t *testing.T) {
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		ts.RinDB.mu.Lock()
+		ts.RinDB.sequenceNumber = 2
+		ts.RinDB.mu.Unlock()
+
+		snap, err := ts.RinDB.NewSnapshot(ctx)
+		assert.NoError(t, err)
+		assert.NoError(t, ts.RinDB.Release(ctx, snap))
+
+		mem1 := InitMemtable(*ts.Config)
+		mem1.Put(newRecord(Bytes("b"), Bytes("1"), 1))
+		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem2 := InitMemtable(*ts.Config)
+		mem2.Put(newRecord(Bytes("b"), nil, 3))
+		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		ts.Manager.mu.Lock()
+		err = ts.Manager.mergeSSTables(ctx, 1, []SStable{sst1, sst2})
+		ts.Manager.mu.Unlock()
+		assert.NoError(t, err)
+
+		assert.Equal(t, 0, ts.Manager.levels[1].Len())
+	})
+}

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -61,6 +61,17 @@ type SSTableManager struct {
 	diskSampler func() (uint64, error)
 }
 
+// UpdateMinSnapshotSeq updates the minimum active snapshot sequence number
+// tracked by the manager.
+//
+// It is expected that the caller provides the smallest sequence number of all
+// currently active snapshots or math.MaxUint64 when no snapshots are active.
+func (h *SSTableManager) UpdateMinSnapshotSeq(seq uint64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.minSnapshotSeq = seq
+}
+
 // openAndLoadSSTable opens a FileSystem, creates an SSTable object from it,
 // and adds the FileSystem to the manager's list of opened file systems.
 // It returns the created *SSTable or an error.


### PR DESCRIPTION
## Summary
- track smallest active snapshot sequence in SSTableManager
- update snapshot tracking on NewSnapshot and Release
- ensure compaction respects snapshots and prunes after release

## Testing
- `make check` *(fails: internal error in staticcheck: unsupported version: 2)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68adcb8452dc8325aceed26017b40036