### PR TITLE
feat: add snapshot-aware cleanup

### DIFF
--- a/integration/transaction_test.go
+++ b/integration/transaction_test.go
@@ -21,7 +21,7 @@ func TestTransactionManagerIntegration(t *testing.T) {
 	tm := rindb.NewTransactionManager()
 
 	t.Run("commit", func(t *testing.T) {
-		require.NoError(t, w.Clean())
+		require.NoError(t, w.Clean(ctx, ^uint64(0)))
 		txn := tm.Begin()
 		rec := rindb.RecordImpl{Key: rindb.Bytes("key"), Value: rindb.Bytes("value"), SequenceNumber: 1}
 		require.NoError(t, rindb.WriteRecord(txn, rec))
@@ -36,7 +36,7 @@ func TestTransactionManagerIntegration(t *testing.T) {
 	})
 
 	t.Run("rollback", func(t *testing.T) {
-		require.NoError(t, w.Clean())
+		require.NoError(t, w.Clean(ctx, ^uint64(0)))
 		txn := tm.Begin()
 		rec := rindb.RecordImpl{Key: rindb.Bytes("key2"), Value: rindb.Bytes("value2"), SequenceNumber: 1}
 		require.NoError(t, rindb.WriteRecord(txn, rec))

--- a/rindb.go
+++ b/rindb.go
@@ -68,6 +68,35 @@ type Rindb struct {
 	flushCount  atomic.Uint64
 }
 
+// minSnapshotSeq returns the minimum sequence number among active snapshots.
+//
+// r.mu must be held before calling this method.
+func (r *Rindb) minSnapshotSeq() uint64 {
+	if len(r.activeSnapshots) == 0 {
+		return r.sequenceNumber
+	}
+	minSeq := r.activeSnapshots[0]
+	for _, s := range r.activeSnapshots[1:] {
+		if s < minSeq {
+			minSeq = s
+		}
+	}
+	return minSeq
+}
+
+// cleanupObsoleteLocked removes memtable entries and WAL segments older than
+// the minimum active snapshot sequence. r.mu must be held when calling.
+func (r *Rindb) cleanupObsoleteLocked(ctx context.Context) error {
+	minSeq := r.minSnapshotSeq()
+	r.memtable.Cleanup(minSeq)
+
+	r.ssTableManager.mu.Lock()
+	r.ssTableManager.minSnapshotSeq = minSeq
+	r.ssTableManager.mu.Unlock()
+
+	return r.wal.Clean(ctx, minSeq)
+}
+
 // Stats returns current statistics of the database.
 func (r *Rindb) Stats() Stats {
 	// Read atomic stats without locking first.
@@ -198,6 +227,13 @@ func (r *Rindb) NewSnapshot(ctx context.Context) (*Snapshot, error) {
 
 	snap := &Snapshot{sequence: r.sequenceNumber}
 	r.activeSnapshots = append(r.activeSnapshots, snap.sequence)
+
+	r.ssTableManager.mu.Lock()
+	if snap.sequence < r.ssTableManager.minSnapshotSeq {
+		r.ssTableManager.minSnapshotSeq = snap.sequence
+	}
+	r.ssTableManager.mu.Unlock()
+
 	return snap, nil
 }
 
@@ -219,7 +255,7 @@ func (r *Rindb) Release(ctx context.Context, snap *Snapshot) error {
 			break
 		}
 	}
-	return nil
+	return r.cleanupObsoleteLocked(ctx)
 }
 
 // Get retrieves the value associated with the given key from the database.
@@ -393,10 +429,17 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 
 		// Clear the memtable and clean the WAL *after* successful flush and registration
 		r.memtable.Clear()
-		if err := r.wal.Clean(); err != nil {
+		minSeq := r.minSnapshotSeq()
+		if len(r.activeSnapshots) == 0 {
+			minSeq = r.sequenceNumber + 1
+		}
+		if err := r.wal.Clean(ctx, minSeq); err != nil {
 			ERROR(ctx, "Failed to clean WAL after memtable flush: %v", err)
 			return fmt.Errorf("failed to clean WAL: %w", err)
 		}
+		r.ssTableManager.mu.Lock()
+		r.ssTableManager.minSnapshotSeq = r.minSnapshotSeq()
+		r.ssTableManager.mu.Unlock()
 
 		// Trigger compaction in a goroutine *after* flushing
 		INFO(ctx, "Triggering background compaction check.")
@@ -410,6 +453,11 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			} else {
 				INFO(ctx, "Background compaction goroutine finished.")
 			}
+			r.mu.Lock()
+			if err := r.cleanupObsoleteLocked(ctx); err != nil {
+				ERROR(ctx, "Post-compaction cleanup failed: %v", err)
+			}
+			r.mu.Unlock()
 		}(compactionCtx)
 	}
 

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -85,6 +85,58 @@ func TestRindb_Snapshot(t *testing.T) {
 	rin.mu.RUnlock()
 }
 
+func TestMemtableCleanupAfterSnapshotRelease(t *testing.T) {
+	ctx := context.Background()
+	rin, cleanup := initRinDBWithCleanup(t, WithDatabaseDir(t.TempDir()), WithMaxMemtableSize(1<<20))
+	defer cleanup()
+
+	key := Bytes("k")
+	assert.NoError(t, rin.Put(ctx, key, Bytes("v1")))
+	snap, err := rin.NewSnapshot(ctx)
+	assert.NoError(t, err)
+
+	assert.NoError(t, rin.Put(ctx, key, Bytes("v2")))
+
+	v, err := rin.memtable.GetAt(key, snap.Sequence())
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("v1"), v)
+
+	assert.NoError(t, rin.Release(ctx, snap))
+
+	_, err = rin.memtable.GetAt(key, snap.Sequence())
+	assert.Error(t, err)
+
+	val, err := rin.Get(ctx, key)
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("v2"), val)
+}
+
+func TestWALSegmentsRespectSnapshots(t *testing.T) {
+	ctx := context.Background()
+	const maxSize = uint(128)
+	rin, cleanup := initRinDBWithCleanup(t, WithDatabaseDir(t.TempDir()), WithMaxMemtableSize(maxSize))
+	defer cleanup()
+
+	assert.NoError(t, rin.Put(ctx, Bytes("k"), Bytes("v1")))
+	snap, err := rin.NewSnapshot(ctx)
+	assert.NoError(t, err)
+
+	assert.NoError(t, rin.Put(ctx, Bytes("k"), Bytes("v2")))
+
+	big := make(Bytes, maxSize)
+	assert.NoError(t, rin.Put(ctx, Bytes("big"), big))
+
+	mem, err := rin.wal.Load(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(3), mem.data.Len())
+
+	assert.NoError(t, rin.Release(ctx, snap))
+
+	mem, err = rin.wal.Load(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(1), mem.data.Len())
+}
+
 func TestRindb_IRange(t *testing.T) {
 	ctx := context.Background()
 	cfg := testConfig()
@@ -248,7 +300,7 @@ func TestRindb_FlushMemtable(t *testing.T) {
 	defer func() { _ = newSSTableFS.Close() }() // Ensure the FS used for flushing is closed
 	newSStable, err := flush(ctx, rin.config, rin.memtable, newSSTableFS)
 	assert.NoError(t, err)
-	err = rin.wal.Clean()
+	err = rin.wal.Clean(ctx, ^uint64(0))
 	assert.NoError(t, err)
 	value, err := newSStable.GetValue(ctx, Bytes("rm-key"))
 	assert.ErrorIs(t, err, ErrTombstoneFound)

--- a/wal.go
+++ b/wal.go
@@ -140,11 +140,70 @@ func (w *WAL) AppendMany(ctx context.Context, records []Record) error {
 	return nil
 }
 
-func (w *WAL) Clean() error {
+// Clean removes WAL records with sequence numbers lower than minSeq.
+//
+// It rewrites the WAL preserving only the records with sequence numbers >= minSeq.
+// The method resets internal counters based on the remaining records.
+func (w *WAL) Clean(ctx context.Context, minSeq uint64) error {
+	ctx, span := walTracer.Start(ctx, "WAL.Clean")
+	defer span.End()
+
+	// Read all records and keep those with sequence >= minSeq.
+	if _, err := w.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("failed to seek WAL start: %w", err)
+	}
+
+	var records []Record
+	for {
+		rec, err := ReadRecord(w)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("failed to read WAL record: %w", err)
+		}
+		if rec.GetSequenceNumber() >= minSeq {
+			records = append(records, rec)
+		}
+	}
+
 	if err := w.FileSystem.Clean(); err != nil {
 		return err
 	}
 	w.records.Store(0)
 	w.bytes.Store(0)
+
+	if len(records) == 0 {
+		return nil
+	}
+
+	tx := w.tm.Begin()
+	defer tx.Rollback(ctx)
+
+	if _, err := w.Seek(0, io.SeekEnd); err != nil {
+		return fmt.Errorf("failed to seek WAL end: %w", err)
+	}
+
+	var totalBytes int
+	for i, rec := range records {
+		if err := WriteRecord(tx, rec); err != nil {
+			return fmt.Errorf("failed to write record %d to WAL transaction: %w", i, err)
+		}
+		totalBytes += CalOnDiskSize(rec)
+	}
+
+	if err := tx.Commit(ctx, w.FileSystem); err != nil {
+		return fmt.Errorf("failed to commit WAL transaction: %w", err)
+	}
+
+	if err := w.Sync(); err != nil {
+		return fmt.Errorf("failed to sync WAL: %w", err)
+	}
+
+	walRecordsCounter.Add(ctx, int64(len(records)))
+	walBytesCounter.Add(ctx, int64(totalBytes))
+	w.records.Add(uint64(len(records)))
+	w.bytes.Add(uint64(totalBytes))
+
 	return nil
 }

--- a/wal_test.go
+++ b/wal_test.go
@@ -42,7 +42,7 @@ func TestWAL_Clean(t *testing.T) {
 	w := NewWAL(cfg, fs)
 	err := w.Append(context.Background(), newRecord(Bytes("key"), Bytes("value"), 0)) // SequenceNumber can be 0 if not relevant for the test
 	assert.NoError(t, err)
-	err = w.Clean()
+	err = w.Clean(context.Background(), 1)
 	assert.NoError(t, err)
 	b2 := make(Bytes, 5)
 	_, err = fs.Read(b2)


### PR DESCRIPTION
## Summary
- track minimum snapshot sequence and cleanup memtable and WAL accordingly
- allow WAL to truncate records below a sequence threshold
- test that snapshots preserve memtable entries and WAL segments until release

## Testing
- `make check` *(fails: internal error in staticcheck)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adcba38994832591b4676c07cd5d48