### PR TITLE
test: ensure tombstones survive compaction with snapshots

### DIFF
--- a/integration/compaction_snapshot_test.go
+++ b/integration/compaction_snapshot_test.go
@@ -74,7 +74,10 @@ func TestCompactionPreservesTombstoneForSnapshot(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	st := db.Stats()
-	require.GreaterOrEqual(t, st.Flushes, uint64(1))
+	require.Equal(t, uint64(1), st.Flushes)
+	require.GreaterOrEqual(t, len(st.SSTablesPerLevel), 2)
+	require.Equal(t, 0, st.SSTablesPerLevel[0])
+	require.Equal(t, 1, st.SSTablesPerLevel[1])
 
 	_, err = db.Get(ctx, rindb.Bytes("k1"))
 	require.ErrorIs(t, err, rindb.ErrKeyNotFound)

--- a/integration/compaction_snapshot_test.go
+++ b/integration/compaction_snapshot_test.go
@@ -4,6 +4,7 @@ package rindb_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,6 +42,42 @@ func TestCompactionRespectsSnapshot(t *testing.T) {
 	got, err := db.Get(ctx, rindb.Bytes("k1"))
 	require.NoError(t, err)
 	require.Equal(t, rindb.Bytes("v2"), got)
+
+	snapVal, err := db.Get(ctx, rindb.Bytes("k1"), snap.Sequence())
+	require.NoError(t, err)
+	require.Equal(t, rindb.Bytes("v1"), snapVal)
+}
+
+func TestCompactionPreservesTombstoneForSnapshot(t *testing.T) {
+	db, cleanup := initTestDB(t,
+		rindb.WithLevel0CompactionThreshold(1),
+		rindb.WithMaxMemtableSize(200),
+	)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, db.Put(ctx, rindb.Bytes("k1"), rindb.Bytes("v1")))
+	snap, err := db.NewSnapshot(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, db.Remove(ctx, rindb.Bytes("k1")))
+
+	largeVal := rindb.Bytes(strings.Repeat("x", 200))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("k2"), largeVal))
+
+	require.Eventually(t, func() bool {
+		st := db.Stats()
+		if len(st.SSTablesPerLevel) < 2 {
+			return false
+		}
+		return st.SSTablesPerLevel[0] == 0 && st.SSTablesPerLevel[1] > 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	st := db.Stats()
+	require.GreaterOrEqual(t, st.Flushes, uint64(1))
+
+	_, err = db.Get(ctx, rindb.Bytes("k1"))
+	require.ErrorIs(t, err, rindb.ErrKeyNotFound)
 
 	snapVal, err := db.Get(ctx, rindb.Bytes("k1"), snap.Sequence())
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- add integration test to verify snapshots see deleted values even after flush and compaction

## Testing
- `make check` *(fails: unsupported version: 2 when running staticcheck)*
- `make test`
- `make test-integration`

------
https://chatgpt.com/codex/tasks/task_e_68ae6220f20083259f32a4fc878e1e92