### PR TITLE
feat: add snapshot-based read operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,35 @@ func main() {
 }
 ```
 
+### Snapshot-Based Reads
+
+```go
+ctx := context.Background()
+db, _ := rindb.InitRinDB(ctx)
+defer db.Close()
+
+// Write initial values
+_ = db.Put(ctx, []byte("k1"), []byte("v1"))
+_ = db.Put(ctx, []byte("k2"), []byte("v2"))
+
+snap, _ := db.NewSnapshot(ctx)
+defer db.Release(ctx, snap)
+
+// Mutations after snapshot do not affect reads through it
+_ = db.Put(ctx, []byte("k1"), []byte("v3"))
+_ = db.Remove(ctx, []byte("k2"))
+
+val, _ := snap.Get(ctx, []byte("k1"))
+fmt.Println(string(val)) // Output: v1
+
+it, _ := snap.IRange(ctx, []byte("k1"), []byte("k3"))
+for it.HasNext() {
+    rec, _ := it.Next()
+    fmt.Printf("%s => %s\n", rec.GetKey(), rec.GetValue())
+}
+it.Close()
+```
+
 ### Custom Configuration
 
 ```go

--- a/integration/compaction_snapshot_test.go
+++ b/integration/compaction_snapshot_test.go
@@ -42,7 +42,9 @@ func TestCompactionRespectsSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rindb.Bytes("v2"), got)
 
-	snapVal, err := db.Get(ctx, rindb.Bytes("k1"), snap.Sequence())
+	snapVal, err := snap.Get(ctx, rindb.Bytes("k1"))
 	require.NoError(t, err)
 	require.Equal(t, rindb.Bytes("v1"), snapVal)
+
+	require.NoError(t, db.Release(ctx, snap))
 }

--- a/memtable.go
+++ b/memtable.go
@@ -147,15 +147,23 @@ func (m *Memtable) Cleanup(minSeq uint64) {
 		key  InternalKey
 		vlen int
 	}
-	var obs []obsolete
+	var (
+		obs     []obsolete
+		lastKey Bytes
+	)
 	it := m.data.Iterator()
 	for it.HasNext() {
 		rec, err := it.Next()
 		if err != nil {
 			break
 		}
+		key := rec.GetKey()
+		if !bytes.Equal(lastKey, key) {
+			lastKey = key.Clone()
+			continue // keep latest version for this key
+		}
 		if rec.GetSequenceNumber() < minSeq {
-			ik := InternalKey{UserKey: rec.GetKey(), Seq: rec.GetSequenceNumber(), Type: rec.GetType()}
+			ik := InternalKey{UserKey: key, Seq: rec.GetSequenceNumber(), Type: rec.GetType()}
 			obs = append(obs, obsolete{key: ik, vlen: len(rec.GetValue())})
 		}
 	}

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -290,7 +290,7 @@ func TestMemtable_Cleanup(t *testing.T) {
 		assert.Equal(t, Bytes("v3"), v)
 	})
 
-	t.Run("RemovesAllRecords", func(t *testing.T) {
+	t.Run("KeepsLatestRecord", func(t *testing.T) {
 		mem := InitMemtable(cfg)
 		key := Bytes("k")
 		mem.Put(newRecord(key, Bytes("v1"), 1))
@@ -298,9 +298,9 @@ func TestMemtable_Cleanup(t *testing.T) {
 
 		mem.Cleanup(3)
 
-		assert.Equal(t, 0, mem.ByteSize())
-		_, err := mem.Get(key)
-		assert.ErrorIs(t, err, ErrKeyNotFound)
+		v, err := mem.Get(key)
+		assert.NoError(t, err)
+		assert.Equal(t, Bytes("v2"), v)
 	})
 }
 

--- a/rindb.go
+++ b/rindb.go
@@ -113,16 +113,16 @@ func (r *Rindb) cleanupObsoleteLocked(ctx context.Context) error {
 	r.ssTableManager.minSnapshotSeq = snapMin
 	r.ssTableManager.mu.Unlock()
 
-	walSeq := snapMin
-	if len(r.activeSnapshots) == 0 {
-		if r.memtable.ByteSize() == 0 {
-			walSeq = r.sequenceNumber
-		} else {
-			return nil
-		}
+	if len(r.activeSnapshots) == 0 && r.memtable.ByteSize() > 0 {
+		// Memtable has unflushed data that is only in the WAL.
+		// To prevent data loss on crash, we must not clean the WAL yet.
+		return nil
 	}
 
-	return r.wal.Clean(ctx, walSeq)
+	// When no snapshots, snapMin is r.sequenceNumber.
+	// When snapshots exist, snapMin is the minimum sequence.
+	// This correctly cleans the WAL in both cases.
+	return r.wal.Clean(ctx, snapMin)
 }
 
 // Stats returns current statistics of the database.

--- a/rindb.go
+++ b/rindb.go
@@ -36,16 +36,34 @@ type Stats struct {
 
 // Snapshot represents a point-in-time view of the database.
 //
-// It captures the sequence number at the time of creation, allowing callers
-// to perform read operations (e.g., Get, IRange) against a consistent view of
-// the data as it existed when the snapshot was taken.
+// It captures the sequence number at the time of creation and a reference to
+// the parent database, allowing callers to perform read operations (e.g., Get,
+// IRange) against a consistent view of the data as it existed when the
+// snapshot was taken.
 type Snapshot struct {
+	db       *Rindb
 	sequence uint64
 }
 
 // Sequence returns the captured sequence number for this snapshot.
 func (s Snapshot) Sequence() uint64 {
 	return s.sequence
+}
+
+// Get returns the value associated with the key as of the snapshot's
+// sequence.
+func (s *Snapshot) Get(ctx context.Context, key Bytes) (Bytes, error) {
+	_, span := tracer.Start(ctx, "Snapshot.Get")
+	defer span.End()
+	return s.db.Get(ctx, key, s.sequence)
+}
+
+// IRange returns an iterator over records with keys in [start, end] as of the
+// snapshot's sequence.
+func (s *Snapshot) IRange(ctx context.Context, start, end Bytes) (*RangeIterator, error) {
+	_, span := tracer.Start(ctx, "Snapshot.IRange")
+	defer span.End()
+	return s.db.IRange(ctx, start, end, s.sequence)
 }
 
 // Rindb is the main database structure
@@ -87,14 +105,24 @@ func (r *Rindb) minSnapshotSeq() uint64 {
 // cleanupObsoleteLocked removes memtable entries and WAL segments older than
 // the minimum active snapshot sequence. r.mu must be held when calling.
 func (r *Rindb) cleanupObsoleteLocked(ctx context.Context) error {
-	minSeq := r.minSnapshotSeq()
-	r.memtable.Cleanup(minSeq)
+	snapMin := r.minSnapshotSeq()
+
+	r.memtable.Cleanup(snapMin)
 
 	r.ssTableManager.mu.Lock()
-	r.ssTableManager.minSnapshotSeq = minSeq
+	r.ssTableManager.minSnapshotSeq = snapMin
 	r.ssTableManager.mu.Unlock()
 
-	return r.wal.Clean(ctx, minSeq)
+	walSeq := snapMin
+	if len(r.activeSnapshots) == 0 {
+		if r.memtable.ByteSize() == 0 {
+			walSeq = r.sequenceNumber
+		} else {
+			return nil
+		}
+	}
+
+	return r.wal.Clean(ctx, walSeq)
 }
 
 // Stats returns current statistics of the database.
@@ -225,7 +253,7 @@ func (r *Rindb) NewSnapshot(ctx context.Context) (*Snapshot, error) {
 		return nil, ErrDatabaseClosed
 	}
 
-	snap := &Snapshot{sequence: r.sequenceNumber}
+	snap := &Snapshot{db: r, sequence: r.sequenceNumber}
 	prev := len(r.activeSnapshots)
 	r.activeSnapshots = append(r.activeSnapshots, snap.sequence)
 

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -76,7 +76,7 @@ func TestRindb_Snapshot(t *testing.T) {
 
 	assert.NoError(t, rin.Put(ctx, key, Bytes("v2")))
 
-	val, err := rin.Get(ctx, key, snap.Sequence())
+	val, err := snap.Get(ctx, key)
 	assert.NoError(t, err)
 	assert.Equal(t, Bytes("v1"), val)
 
@@ -84,6 +84,30 @@ func TestRindb_Snapshot(t *testing.T) {
 	rin.mu.RLock()
 	assert.Len(t, rin.activeSnapshots, 0)
 	rin.mu.RUnlock()
+}
+
+func TestSnapshot_IRange(t *testing.T) {
+	ctx := context.Background()
+	rin, cleanup := initRinDBWithCleanup(t, WithDatabaseDir(t.TempDir()))
+	defer cleanup()
+
+	assert.NoError(t, rin.Put(ctx, Bytes("a"), Bytes("v1")))
+	assert.NoError(t, rin.Put(ctx, Bytes("b"), Bytes("v2")))
+	snap, err := rin.NewSnapshot(ctx)
+	assert.NoError(t, err)
+
+	assert.NoError(t, rin.Put(ctx, Bytes("a"), Bytes("v3")))
+	assert.NoError(t, rin.Remove(ctx, Bytes("b")))
+
+	iter, err := snap.IRange(ctx, Bytes("a"), Bytes("z"))
+	assert.NoError(t, err)
+	expected := []Record{
+		newRecord(Bytes("a"), Bytes("v1"), 1),
+		newRecord(Bytes("b"), Bytes("v2"), 2),
+	}
+	assertIteratorRecords(t, iter, expected)
+
+	assert.NoError(t, rin.Release(ctx, snap))
 }
 
 func TestMemtableCleanupAfterSnapshotRelease(t *testing.T) {


### PR DESCRIPTION
## Summary
- track parent DB in `Snapshot`
- add `Snapshot.Get` and `Snapshot.IRange` to read at captured sequence
- document snapshot usage in README and add tests
- prevent cleanup from dropping unflushed memtable records

## Testing
- `make check` *(fails: internal error in staticcheck: unsupported version 2)*
- `make test`
- `make test-integration-smoke`

------
https://chatgpt.com/codex/tasks/task_e_68ae61cac3c483259531b522090cd58e