### PR TITLE
fix: limit cleanup to flushed sequence

### DIFF
--- a/integration/range_query_regression_test.go
+++ b/integration/range_query_regression_test.go
@@ -1,0 +1,16 @@
+//go:build integration && smoke
+
+package rindb_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestIRangeRangeQueryDeterministic runs TestIRangeRangeQuery multiple times
+// to ensure deterministic results across runs.
+func TestIRangeRangeQueryDeterministic(t *testing.T) {
+	for i := 0; i < 5; i++ {
+		t.Run(fmt.Sprintf("run-%d", i), TestIRangeRangeQuery)
+	}
+}

--- a/rindb.go
+++ b/rindb.go
@@ -103,14 +103,19 @@ func (r *Rindb) minSnapshotSeq() uint64 {
 }
 
 // cleanupObsoleteLocked removes memtable entries and WAL segments older than
-// the minimum active snapshot sequence. r.mu must be held when calling.
-func (r *Rindb) cleanupObsoleteLocked(ctx context.Context) error {
+// the minimum active snapshot sequence up to maxSeq. r.mu must be held when
+// calling.
+func (r *Rindb) cleanupObsoleteLocked(ctx context.Context, maxSeq uint64) error {
 	snapMin := r.minSnapshotSeq()
+	cutoff := snapMin
+	if maxSeq < cutoff {
+		cutoff = maxSeq
+	}
 
-	r.memtable.Cleanup(snapMin)
+	r.memtable.Cleanup(cutoff)
 
 	r.ssTableManager.mu.Lock()
-	r.ssTableManager.minSnapshotSeq = snapMin
+	r.ssTableManager.minSnapshotSeq = cutoff
 	r.ssTableManager.mu.Unlock()
 
 	if len(r.activeSnapshots) == 0 && r.memtable.ByteSize() > 0 {
@@ -284,7 +289,7 @@ func (r *Rindb) Release(ctx context.Context, snap *Snapshot) error {
 			break
 		}
 	}
-	return r.cleanupObsoleteLocked(ctx)
+	return r.cleanupObsoleteLocked(ctx, r.sequenceNumber)
 }
 
 // Get retrieves the value associated with the given key from the database.
@@ -471,6 +476,9 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 		r.ssTableManager.minSnapshotSeq = snapMin
 		r.ssTableManager.mu.Unlock()
 
+		// Capture the sequence number at flush time for later cleanup.
+		flushSeq := r.sequenceNumber
+
 		// Trigger compaction in a goroutine *after* flushing
 		INFO(ctx, "Triggering background compaction check.")
 		r.wg.Add(1)
@@ -484,7 +492,7 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 				INFO(ctx, "Background compaction goroutine finished.")
 			}
 			r.mu.Lock()
-			if err := r.cleanupObsoleteLocked(ctx); err != nil {
+			if err := r.cleanupObsoleteLocked(ctx, flushSeq); err != nil {
 				ERROR(ctx, "Post-compaction cleanup failed: %v", err)
 			}
 			r.mu.Unlock()


### PR DESCRIPTION
## Summary
- capture `flushSeq` and bound compaction cleanup to that sequence
- ensure cleanup respects max sequence number
- add regression test running `TestIRangeRangeQuery` multiple times

## Testing
- `make test`
- `make test-integration-smoke`
- `make check` *(fails: internal error in staticcheck)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9eb6f5a883258d25acaad404d2c4