### PR TITLE
refactor: centralize minSnapshotSeq updates

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -113,9 +113,7 @@ func (r *Rindb) cleanupObsoleteLocked(ctx context.Context, maxSeq uint64) error 
 
 	r.memtable.Cleanup(cutoff)
 
-	r.ssTableManager.mu.Lock()
-	r.ssTableManager.minSnapshotSeq = cutoff
-	r.ssTableManager.mu.Unlock()
+	r.ssTableManager.setMinSnapshotSeq(cutoff)
 
 	if len(r.activeSnapshots) == 0 && r.memtable.ByteSize() > 0 {
 		// Memtable has unflushed data that is only in the WAL.
@@ -262,9 +260,7 @@ func (r *Rindb) NewSnapshot(ctx context.Context) (*Snapshot, error) {
 	r.activeSnapshots = append(r.activeSnapshots, snap.sequence)
 
 	if prev == 0 {
-		r.ssTableManager.mu.Lock()
-		r.ssTableManager.minSnapshotSeq = snap.sequence
-		r.ssTableManager.mu.Unlock()
+		r.ssTableManager.setMinSnapshotSeq(snap.sequence)
 	}
 
 	return snap, nil
@@ -471,9 +467,7 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			ERROR(ctx, "Failed to clean WAL after memtable flush: %v", err)
 			return fmt.Errorf("failed to clean WAL: %w", err)
 		}
-		r.ssTableManager.mu.Lock()
-		r.ssTableManager.minSnapshotSeq = snapMin
-		r.ssTableManager.mu.Unlock()
+		r.ssTableManager.setMinSnapshotSeq(snapMin)
 
 		// Capture the sequence number at flush time for later cleanup.
 		flushSeq := r.sequenceNumber

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -110,6 +110,14 @@ func InitSSTableManager(ctx context.Context, config Config) (*SSTableManager, er
 	return h, nil
 }
 
+// setMinSnapshotSeq updates the minimum snapshot sequence number
+// in a thread-safe manner.
+func (h *SSTableManager) setMinSnapshotSeq(seq uint64) {
+	h.mu.Lock()
+	h.minSnapshotSeq = seq
+	h.mu.Unlock()
+}
+
 // recordWrite increments the write counter and, once a second has elapsed,
 // updates the moving average of writes per second using an exponential moving
 // average. It is called for every `Put`.


### PR DESCRIPTION
## Summary
- add SSTableManager.setMinSnapshotSeq helper
- use helper in Rindb to update snapshot sequence

## Testing
- `make test`
- `make check` *(fails: staticcheck internal error unsupported version)*

------
https://chatgpt.com/codex/tasks/task_e_68aec80ae6908325a0d6684fdb971b17