### PR TITLE
feat: expose active snapshot metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ for it.HasNext() {
 it.Close()
 ```
 
+### Runtime Statistics
+
+```go
+s := db.Stats()
+fmt.Println("Active snapshots:", s.ActiveSnapshots)
+```
+
+The `Stats` method reports metrics such as memtable size, sequence number,
+active snapshot count, per-level SSTable counts, WAL usage, and operation counters.
+
 ### Custom Configuration
 
 ```go

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,6 +87,7 @@ func main() {
 			s := db.Stats()
 			fmt.Printf("MemtableBytes: %d\n", s.MemtableBytes)
 			fmt.Printf("SequenceNumber: %d\n", s.SequenceNumber)
+			fmt.Printf("ActiveSnapshots: %d\n", s.ActiveSnapshots)
 			fmt.Printf("WALBytes: %d\n", s.WALBytes)
 			fmt.Printf("WALRecords: %d\n", s.WALRecords)
 			fmt.Printf("SSTablesPerLevel: %v\n", s.SSTablesPerLevel)

--- a/integration/compaction_snapshot_test.go
+++ b/integration/compaction_snapshot_test.go
@@ -24,6 +24,8 @@ func TestCompactionRespectsSnapshot(t *testing.T) {
 	require.NoError(t, db.Put(ctx, rindb.Bytes("k1"), rindb.Bytes("v1")))
 	snap, err := db.NewSnapshot(ctx)
 	require.NoError(t, err)
+	st := db.Stats()
+	require.Equal(t, 1, st.ActiveSnapshots)
 
 	// Two puts trigger a flush due to the small memtable size
 	require.NoError(t, db.Put(ctx, rindb.Bytes("k1"), rindb.Bytes("v2")))
@@ -48,6 +50,8 @@ func TestCompactionRespectsSnapshot(t *testing.T) {
 	require.Equal(t, rindb.Bytes("v1"), snapVal)
 
 	require.NoError(t, db.Release(ctx, snap))
+	st = db.Stats()
+	require.Zero(t, st.ActiveSnapshots)
 }
 
 func TestCompactionPreservesTombstoneForSnapshot(t *testing.T) {
@@ -61,6 +65,8 @@ func TestCompactionPreservesTombstoneForSnapshot(t *testing.T) {
 	require.NoError(t, db.Put(ctx, rindb.Bytes("k1"), rindb.Bytes("v1")))
 	snap, err := db.NewSnapshot(ctx)
 	require.NoError(t, err)
+	st := db.Stats()
+	require.Equal(t, 1, st.ActiveSnapshots)
 
 	require.NoError(t, db.Remove(ctx, rindb.Bytes("k1")))
 

--- a/rindb.go
+++ b/rindb.go
@@ -20,10 +20,11 @@ var ErrDatabaseClosed = errors.New("database is closed")
 // Stats represents runtime statistics of the database.
 //
 // It includes information about memtable size, sequence number,
-// per-level SSTable counts, WAL usage and operation counters.
+// active snapshot count, per-level SSTable counts, WAL usage and operation counters.
 type Stats struct {
 	MemtableBytes    int
 	SequenceNumber   uint64
+	ActiveSnapshots  int
 	SSTablesPerLevel []int
 	WALBytes         uint64
 	WALRecords       uint64
@@ -67,10 +68,11 @@ func (r *Rindb) Stats() Stats {
 		Flushes:     r.flushCount.Load(),
 	}
 
-	// Lock to get memtable stats and sequence number.
+	// Lock to get memtable stats, sequence number and snapshot count.
 	r.mu.RLock()
 	stats.MemtableBytes = r.memtable.ByteSize()
 	stats.SequenceNumber = r.sequenceNumber
+	stats.ActiveSnapshots = len(r.activeSnapshots)
 	r.mu.RUnlock()
 
 	// Lock separately for SSTable manager stats.

--- a/stats_test.go
+++ b/stats_test.go
@@ -70,7 +70,7 @@ func TestRindb_Stats(t *testing.T) {
 		assert.Equal(t, uint64(1), st.SequenceNumber)
 		assert.Equal(t, uint64(1), st.PutCalls)
 		assert.Equal(t, uint64(1), st.Flushes)
-		assert.Equal(t, 0, st.ActiveSnapshots)
+		assert.Zero(t, st.ActiveSnapshots)
 		assert.Equal(t, 0, st.MemtableBytes)
 		assert.Equal(t, uint64(0), st.WALRecords)
 		assert.Equal(t, uint64(0), st.WALBytes)

--- a/stats_test.go
+++ b/stats_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRindb_Stats(t *testing.T) {
@@ -16,6 +17,7 @@ func TestRindb_Stats(t *testing.T) {
 		st := ts.RinDB.Stats()
 		assert.Zero(t, st.MemtableBytes)
 		assert.Zero(t, st.SequenceNumber)
+		assert.Zero(t, st.ActiveSnapshots)
 		assert.Zero(t, st.WALBytes)
 		assert.Zero(t, st.WALRecords)
 		assert.Zero(t, st.GetCalls)
@@ -42,6 +44,7 @@ func TestRindb_Stats(t *testing.T) {
 		st = ts.RinDB.Stats()
 		assert.Equal(t, uint64(2), st.SequenceNumber)
 		assert.Greater(t, st.MemtableBytes, 0)
+		assert.Zero(t, st.ActiveSnapshots)
 		assert.Equal(t, uint64(1), st.GetCalls)
 		assert.Equal(t, uint64(1), st.PutCalls)
 		assert.Equal(t, uint64(1), st.RemoveCalls)
@@ -67,11 +70,32 @@ func TestRindb_Stats(t *testing.T) {
 		assert.Equal(t, uint64(1), st.SequenceNumber)
 		assert.Equal(t, uint64(1), st.PutCalls)
 		assert.Equal(t, uint64(1), st.Flushes)
+		assert.Equal(t, 0, st.ActiveSnapshots)
 		assert.Equal(t, 0, st.MemtableBytes)
 		assert.Equal(t, uint64(0), st.WALRecords)
 		assert.Equal(t, uint64(0), st.WALBytes)
 		if assert.NotEmpty(t, st.SSTablesPerLevel) {
 			assert.Equal(t, 1, st.SSTablesPerLevel[0])
 		}
+	})
+
+	t.Run("Snapshot", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, nil)
+		defer ts.Cleanup()
+
+		st := ts.RinDB.Stats()
+		assert.Zero(t, st.ActiveSnapshots)
+
+		snap, err := ts.RinDB.NewSnapshot(ctx)
+		require.NoError(t, err)
+
+		st = ts.RinDB.Stats()
+		assert.Equal(t, 1, st.ActiveSnapshots)
+
+		require.NoError(t, ts.RinDB.Release(ctx, snap))
+
+		st = ts.RinDB.Stats()
+		assert.Zero(t, st.ActiveSnapshots)
 	})
 }


### PR DESCRIPTION
## Summary
- track active snapshots in runtime stats
- expose active snapshot count via CLI
- test snapshot metric and document stats API

## Testing
- `make check` *(fails: internal error in staticcheck unsupported version)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aee8f699848325b2378ceac5e22bca