### PR TITLE
refactor: centralize internal key logic

### DIFF
--- a/internal_key.go
+++ b/internal_key.go
@@ -1,6 +1,9 @@
 package rindb
 
-import "bytes"
+import (
+	"bytes"
+	"fmt"
+)
 
 // InternalKey represents a user key combined with sequence number and type.
 type InternalKey struct {
@@ -8,6 +11,11 @@ type InternalKey struct {
 	Seq     uint64
 	Type    RecordType
 }
+
+const (
+	seqNumBytes          = 8
+	internalKeySuffixLen = seqNumBytes + 1 // sequence number + type
+)
 
 // Compare implements CmpType for InternalKey.
 // Order is by user key ascending, sequence descending, type ascending.
@@ -29,4 +37,28 @@ func (k InternalKey) Compare(other any) int {
 		return CmpGreater
 	}
 	return CmpEqual
+}
+
+func EncodeInternalKey(key Bytes, seq uint64, typ RecordType) []byte {
+	internalKey := make([]byte, len(key)+internalKeySuffixLen)
+	copy(internalKey, key)
+	var seqBuf [seqNumBytes]byte
+	byteOrder.PutUint64(seqBuf[:], ^seq)
+	copy(internalKey[len(key):], seqBuf[:])
+	internalKey[len(key)+seqNumBytes] = byte(typ)
+	return internalKey
+}
+
+func DecodeInternalKey(ikey Bytes) (Bytes, uint64, RecordType, error) {
+	if len(ikey) < internalKeySuffixLen {
+		return nil, 0, 0, fmt.Errorf("internal key too short: %d", len(ikey))
+	}
+	userKeyEnd := len(ikey) - internalKeySuffixLen
+	seq := ^byteOrder.Uint64(ikey[userKeyEnd : userKeyEnd+seqNumBytes])
+	typ := RecordType(ikey[len(ikey)-1])
+	userKey := Bytes(ikey[:userKeyEnd])
+	if userKeyEnd == 0 {
+		userKey = nil
+	}
+	return userKey, seq, typ, nil
 }

--- a/internal_key.go
+++ b/internal_key.go
@@ -56,9 +56,9 @@ func DecodeInternalKey(ikey Bytes) (Bytes, uint64, RecordType, error) {
 	userKeyEnd := len(ikey) - internalKeySuffixLen
 	seq := ^byteOrder.Uint64(ikey[userKeyEnd : userKeyEnd+seqNumBytes])
 	typ := RecordType(ikey[len(ikey)-1])
-	userKey := Bytes(ikey[:userKeyEnd])
-	if userKeyEnd == 0 {
-		userKey = nil
+	var userKey Bytes
+	if userKeyEnd > 0 {
+		userKey = append(Bytes(nil), ikey[:userKeyEnd]...)
 	}
 	return userKey, seq, typ, nil
 }

--- a/io.go
+++ b/io.go
@@ -19,30 +19,6 @@ func ReadNumber(storage io.Reader) (uint64, error) {
 	return byteOrder.Uint64(numBytes[:]), nil
 }
 
-func encodeInternalKey(key Bytes, seq uint64, typ RecordType) []byte {
-	internalKey := make([]byte, len(key)+internalKeySuffixLen)
-	copy(internalKey, key)
-	var seqBuf [seqNumBytes]byte
-	byteOrder.PutUint64(seqBuf[:], ^seq)
-	copy(internalKey[len(key):], seqBuf[:])
-	internalKey[len(key)+seqNumBytes] = byte(typ)
-	return internalKey
-}
-
-func decodeInternalKey(ikey Bytes) (Bytes, uint64, RecordType, error) {
-	if len(ikey) < internalKeySuffixLen {
-		return nil, 0, 0, fmt.Errorf("internal key too short: %d", len(ikey))
-	}
-	userKeyEnd := len(ikey) - internalKeySuffixLen
-	seq := ^byteOrder.Uint64(ikey[userKeyEnd : userKeyEnd+seqNumBytes])
-	typ := RecordType(ikey[len(ikey)-1])
-	userKey := Bytes(ikey[:userKeyEnd])
-	if userKeyEnd == 0 {
-		userKey = nil
-	}
-	return userKey, seq, typ, nil
-}
-
 func ReadRecord(storage io.Reader) (Record, error) {
 	internalKeyLen, err := ReadNumber(storage)
 	if err != nil {
@@ -62,7 +38,7 @@ func ReadRecord(storage io.Reader) (Record, error) {
 		}
 	}
 
-	userKey, seq, typ, err := decodeInternalKey(internalKeyBytes)
+	userKey, seq, typ, err := DecodeInternalKey(internalKeyBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +69,7 @@ func WriteNumber(tx *Transaction, number uint64) error {
 }
 
 func WriteRecord(tx *Transaction, record Record) error {
-	ikey := encodeInternalKey(record.GetKey(), record.GetSequenceNumber(), record.GetType())
+	ikey := EncodeInternalKey(record.GetKey(), record.GetSequenceNumber(), record.GetType())
 
 	if err := WriteNumber(tx, uint64(len(ikey))); err != nil {
 		return fmt.Errorf("failed to write internal key length: %w", err)

--- a/io_test.go
+++ b/io_test.go
@@ -114,7 +114,7 @@ func TestReadRecord_Errors(t *testing.T) {
 		var buf bytes.Buffer
 		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 3+internalKeySuffixLen) // Internal key length for "key"
 		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5)                      // Value length
-		buf.Write(encodeInternalKey(Bytes("key"), 0, TypeValue))
+		buf.Write(EncodeInternalKey(Bytes("key"), 0, TypeValue))
 		buf.Write([]byte("val")) // only 3 bytes of value
 		_, err := ReadRecord(&buf)
 		assert.ErrorContains(t, err, "failed to read value bytes")
@@ -125,7 +125,7 @@ func TestReadRecord_Errors(t *testing.T) {
 		var buf bytes.Buffer
 		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 3+internalKeySuffixLen) // Internal key length
 		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5)                      // Value length
-		buf.Write(encodeInternalKey(Bytes("key"), 0, TypeValue))
+		buf.Write(EncodeInternalKey(Bytes("key"), 0, TypeValue))
 		reader := io.MultiReader(&buf, iotest.ErrReader(errors.New("read value bytes failed")))
 		_, err := ReadRecord(reader)
 		assert.ErrorContains(t, err, "failed to read value bytes")

--- a/record.go
+++ b/record.go
@@ -8,11 +8,6 @@ const (
 	TypeMerge
 )
 
-const (
-	seqNumBytes          = 8
-	internalKeySuffixLen = seqNumBytes + 1 // sequence number + type
-)
-
 type Record interface {
 	GetKey() Bytes
 	GetValue() Bytes


### PR DESCRIPTION
## Summary
- centralize internal key constants and encoding helpers in internal_key module
- update record I/O to use centralized internal key API

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68afbbb2c0e883259d0bf46ff85628ec