### PR TITLE
test: use WaitGroup in concurrency test

### DIFF
--- a/integration/concurrency_test.go
+++ b/integration/concurrency_test.go
@@ -5,6 +5,7 @@ package rindb_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,21 +15,26 @@ import (
 
 func TestConcurrentPutGet(t *testing.T) {
 	db, cleanup := initTestDB(t)
-	t.Cleanup(cleanup)
 	ctx := context.Background()
 
 	const goroutines = 100
 
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
 	for i := 0; i < goroutines; i++ {
 		i := i
-		t.Run(fmt.Sprintf("put-get-%d", i), func(t *testing.T) {
-			t.Parallel()
+		go func() {
+			defer wg.Done()
 			key := rindb.Bytes(fmt.Sprintf("key-%d", i))
 			val := rindb.Bytes(fmt.Sprintf("value-%d", i))
 			require.NoError(t, db.Put(ctx, key, val))
 			got, err := db.Get(ctx, key)
 			require.NoError(t, err)
 			require.Equal(t, val, got)
-		})
+		}()
 	}
+
+	wg.Wait()
+	cleanup()
 }


### PR DESCRIPTION
## Summary
- replace parallel subtests with a WaitGroup of goroutines in concurrency test
- delay cleanup until all goroutines complete to keep DB open

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68afbf899ef88325be8879d48f293942