### PR TITLE
fix: aggregate merge iterator close errors

### DIFF
--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -902,8 +902,8 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 		return nil, err
 	}
 	defer func() {
-		if cerr := mergeIter.Close(); err == nil && cerr != nil {
-			err = cerr
+		if cerr := mergeIter.Close(); cerr != nil {
+			err = errors.Join(err, cerr)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- aggregate merge iterator close errors using `errors.Join`

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b100ad7994832592f866dd9f6cf9d2