### PR TITLE
feat: add checksum verification

### DIFF
--- a/io.go
+++ b/io.go
@@ -2,14 +2,21 @@ package rindb
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 )
 
 // Use BigEndian for consistent cross-platform encoding/decoding
 var byteOrder = binary.BigEndian
 
-const mdByteSize = 8
+const (
+	mdByteSize   = 8
+	checksumSize = 4
+)
+
+var ErrChecksumMismatch = errors.New("checksum mismatch")
 
 func ReadNumber(storage io.Reader) (uint64, error) {
 	numBytes := [mdByteSize]byte{}
@@ -51,6 +58,19 @@ func ReadRecord(storage io.Reader) (Record, error) {
 		}
 	}
 
+	var checksumBytes [checksumSize]byte
+	if _, err := io.ReadFull(storage, checksumBytes[:]); err != nil {
+		return nil, fmt.Errorf("failed to read checksum: %w", err)
+	}
+	expected := byteOrder.Uint32(checksumBytes[:])
+	buf := make([]byte, len(internalKeyBytes)+len(valueBytes))
+	copy(buf, internalKeyBytes)
+	copy(buf[len(internalKeyBytes):], valueBytes)
+	actual := crc32.ChecksumIEEE(buf)
+	if actual != expected {
+		return nil, ErrChecksumMismatch
+	}
+
 	return RecordImpl{
 		Key:            userKey,
 		Value:          valueBytes,
@@ -70,12 +90,18 @@ func WriteNumber(tx *Transaction, number uint64) error {
 
 func WriteRecord(tx *Transaction, record Record) error {
 	ikey := EncodeInternalKey(record.GetKey(), record.GetSequenceNumber(), record.GetType())
+	val := record.GetValue()
+
+	buf := make([]byte, len(ikey)+len(val))
+	copy(buf, ikey)
+	copy(buf[len(ikey):], val)
+	checksum := crc32.ChecksumIEEE(buf)
 
 	if err := WriteNumber(tx, uint64(len(ikey))); err != nil {
 		return fmt.Errorf("failed to write internal key length: %w", err)
 	}
 
-	if err := WriteNumber(tx, uint64(len(record.GetValue()))); err != nil {
+	if err := WriteNumber(tx, uint64(len(val))); err != nil {
 		return fmt.Errorf("failed to write value length: %w", err)
 	}
 
@@ -83,8 +109,14 @@ func WriteRecord(tx *Transaction, record Record) error {
 		return fmt.Errorf("failed to write internal key bytes: %w", err)
 	}
 
-	if _, err := tx.Write(record.GetValue()); err != nil {
+	if _, err := tx.Write(val); err != nil {
 		return fmt.Errorf("failed to write value bytes: %w", err)
+	}
+
+	var checksumBytes [checksumSize]byte
+	byteOrder.PutUint32(checksumBytes[:], checksum)
+	if _, err := tx.Write(checksumBytes[:]); err != nil {
+		return fmt.Errorf("failed to write checksum: %w", err)
 	}
 
 	return nil

--- a/io_test.go
+++ b/io_test.go
@@ -131,4 +131,28 @@ func TestReadRecord_Errors(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to read value bytes")
 		assert.ErrorContains(t, err, "read value bytes failed")
 	})
+
+	t.Run("Error reading checksum", func(t *testing.T) {
+		var buf bytes.Buffer
+		ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, uint64(len(ikey)))
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5)
+		buf.Write(ikey)
+		buf.Write([]byte("value"))
+		_, err := ReadRecord(&buf)
+		assert.ErrorContains(t, err, "failed to read checksum")
+		assert.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("Checksum mismatch", func(t *testing.T) {
+		var buf bytes.Buffer
+		ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, uint64(len(ikey)))
+		WriteNumber(&Transaction{buffer: &buf, state: "active"}, 5)
+		buf.Write(ikey)
+		buf.Write([]byte("value"))
+		buf.Write([]byte{0, 0, 0, 0})
+		_, err := ReadRecord(&buf)
+		assert.ErrorIs(t, err, ErrChecksumMismatch)
+	})
 }

--- a/record.go
+++ b/record.go
@@ -21,7 +21,8 @@ func CalOnDiskSize(r Record) int {
 		mdByteSize /* value len size */ +
 		len(r.GetKey()) /* user key */ +
 		internalKeySuffixLen /* seq+type */ +
-		len(r.GetValue()))
+		len(r.GetValue()) /* value */ +
+		checksumSize /* checksum */)
 }
 
 var _ Record = RecordImpl{}

--- a/record_test.go
+++ b/record_test.go
@@ -18,12 +18,12 @@ func TestCalOnDiskSize(t *testing.T) {
 		{
 			name: "Key and value",
 			args: args{newRecord(Bytes("key"), Bytes("value"), 1)},
-			want: 33,
+			want: 37,
 		},
 		{
 			name: "Empty key and value",
 			args: args{newRecord(Bytes(nil), Bytes(nil), 18446744073709551615)},
-			want: 25,
+			want: 29,
 		},
 	}
 	for _, tt := range tests {

--- a/sstable.go
+++ b/sstable.go
@@ -113,6 +113,10 @@ func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes,
 				ERROR(ctx, "Unexpected EOF after reading at offset %d in %s", offset, s.Path())
 				return nil, fmt.Errorf("unexpected EOF after reading at offset %d: %w", offset, ErrMalFormedSSTable)
 			}
+			if errors.Is(err, ErrChecksumMismatch) {
+				ERROR(ctx, "Checksum mismatch at offset %d in %s", reader.Offset(), s.Path())
+				return nil, fmt.Errorf("checksum mismatch at offset %d: %w", reader.Offset(), err)
+			}
 			if errors.Is(err, ErrFileNotOpened) {
 				if err := s.Open(ctx); err != nil {
 					return nil, fmt.Errorf("failed to reopen sstable %s: %w", s.Path(), err)

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -344,9 +344,9 @@ func Test_genSparseIndex(t *testing.T) {
 	assert.Equal(t, Bytes("1"), index[0].key)
 	assert.Equal(t, int64(0), index[0].offset)
 	assert.Equal(t, Bytes("2"), index[1].key)
-	assert.Equal(t, int64(27), index[1].offset)
+	assert.Equal(t, int64(31), index[1].offset)
 	assert.Equal(t, Bytes("3"), index[2].key)
-	assert.Equal(t, int64(54), index[2].offset)
+	assert.Equal(t, int64(62), index[2].offset)
 }
 
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.
@@ -511,4 +511,25 @@ func TestBloomFilterSkipsReads(t *testing.T) {
 	posAfter, err := fs.CursorPos()
 	assert.NoError(t, err)
 	assert.Equal(t, posBefore, posAfter, "File cursor should remain unchanged due to Bloom filter")
+}
+
+// TestSStableChecksumMismatch verifies that corrupted checksums are reported.
+func TestSStableChecksumMismatch(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+	mem := InitMemtable(cfg)
+	rec := newRecord(Bytes("a"), Bytes("1"), 1)
+	mem.Put(rec)
+	sstable, err := flush(ctx, cfg, mem, fs)
+	assert.NoError(t, err)
+
+	offset := int64(CalOnDiskSize(rec)) - checksumSize
+	_, err = fs.file.WriteAt([]byte{0}, offset)
+	assert.NoError(t, err)
+
+	_, err = sstable.GetValue(ctx, Bytes("a"))
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
 }

--- a/wal.go
+++ b/wal.go
@@ -55,6 +55,9 @@ func (w *WAL) Load(ctx context.Context) (Memtable, error) {
 			if errors.Is(err, io.EOF) {
 				break // Normal end of file
 			}
+			if errors.Is(err, ErrChecksumMismatch) {
+				return Memtable{}, fmt.Errorf("checksum mismatch in WAL %s: %w", w.Path(), err)
+			}
 			return Memtable{}, fmt.Errorf("failed to read record from WAL %s: %w", w.Path(), err)
 		}
 
@@ -187,6 +190,11 @@ func (w *WAL) Clean(ctx context.Context, minSeq uint64) error {
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
+			}
+			if errors.Is(err, ErrChecksumMismatch) {
+				_ = tmpFS.Close()
+				_ = os.Remove(tmpPath)
+				return fmt.Errorf("checksum mismatch while reading WAL: %w", err)
 			}
 			_ = tmpFS.Close()
 			_ = os.Remove(tmpPath)

--- a/wal_test.go
+++ b/wal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"testing"
 
@@ -53,7 +54,7 @@ func validateWALFormat(t *testing.T, file io.ReadSeeker) {
 		// suffix for sequence number and type.
 		assert.Equal(t, int(keyLen), len(userKey)+internalKeySuffixLen)
 		// Ensure the record type is one of the valid constants.
-assert.Contains(t, []RecordType{TypeValue, TypeDeletion, TypeMerge}, typ)
+		assert.Contains(t, []RecordType{TypeValue, TypeDeletion, TypeMerge}, typ)
 		// Sequence number can be any uint64, but decoding should not
 		// return a negative value or overflow. Since seq is uint64, no
 		// additional check is needed beyond successful decoding.
@@ -63,6 +64,17 @@ assert.Contains(t, []RecordType{TypeValue, TypeDeletion, TypeMerge}, typ)
 		valueBytes := make([]byte, valueLen)
 		_, err = io.ReadFull(file, valueBytes)
 		assert.NoError(t, err)
+
+		// Read checksum and verify
+		checksumBytes := [checksumSize]byte{}
+		_, err = io.ReadFull(file, checksumBytes[:])
+		assert.NoError(t, err)
+		expected := byteOrder.Uint32(checksumBytes[:])
+		buf := make([]byte, len(keyBytes)+len(valueBytes))
+		copy(buf, keyBytes)
+		copy(buf[len(keyBytes):], valueBytes)
+		actual := crc32.ChecksumIEEE(buf)
+		assert.Equal(t, expected, actual)
 
 		_ = seq // silence unused warning if seq not used otherwise
 	}
@@ -222,4 +234,22 @@ func TestWALCrashRecovery_PartialWrite(t *testing.T) {
 	// Verify record 3 is NOT present
 	_, err = mem.Get(Bytes("key3"))
 	assert.Error(t, err) // Should return an error as key3 was not fully written
+}
+
+// TestWAL_LoadChecksumMismatch ensures checksum errors surface when loading WAL.
+func TestWAL_LoadChecksumMismatch(t *testing.T) {
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+	w := NewWAL(cfg, fs)
+	assert.NoError(t, w.Append(context.Background(), newRecord(Bytes("k"), Bytes("v"), 1)))
+
+	info, err := fs.file.Stat()
+	assert.NoError(t, err)
+	_, err = fs.file.WriteAt([]byte{0}, info.Size()-1)
+	assert.NoError(t, err)
+
+	_, err = w.Load(context.Background())
+	assert.ErrorIs(t, err, ErrChecksumMismatch)
 }


### PR DESCRIPTION
## Summary
- protect records with CRC32 checksums on read/write
- track checksum bytes in on-disk size calculations
- surface checksum mismatches via WAL and SSTable APIs

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b161cac8508325a3ae67a49934b453