### PR TITLE
fix: sync filesystem after SSTable commit

### DIFF
--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -66,6 +66,10 @@ func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
 		return SStable{}, 0, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
+	if err := b.fs.Sync(); err != nil {
+		return SStable{}, 0, fmt.Errorf("failed to sync file system: %w", err)
+	}
+
 	return SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom}, written, nil
 }
 

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -67,7 +67,7 @@ func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
 	}
 
 	if err := b.fs.Sync(); err != nil {
-		return SStable{}, 0, fmt.Errorf("failed to sync file system: %w", err)
+		return SStable{}, 0, fmt.Errorf("failed to sync file system for %s: %w", b.fs.Path(), err)
 	}
 
 	return SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom}, written, nil


### PR DESCRIPTION
## Summary
- sync SSTable file system after committing the write
- surface any sync errors to callers

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b1912b12408325a05ab2ac79a28cd5