### PR TITLE
fix: prevent SSTableBuilder reuse after build

### DIFF
--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -2,8 +2,11 @@ package rindb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
+
+var ErrSSTableAlreadyBuilt = errors.New("SSTable already built")
 
 type SSTableBuilder struct {
 	tx     *Transaction
@@ -44,7 +47,7 @@ func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem) (*SSTabl
 
 func (b *SSTableBuilder) Add(rec Record) error {
 	if b.built {
-		return fmt.Errorf("SSTable already built")
+		return ErrSSTableAlreadyBuilt
 	}
 	if err := WriteRecord(b.tx, rec); err != nil {
 		return err
@@ -57,7 +60,7 @@ func (b *SSTableBuilder) Add(rec Record) error {
 
 func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
 	if b.built {
-		return SStable{}, 0, fmt.Errorf("SSTable already built")
+		return SStable{}, 0, ErrSSTableAlreadyBuilt
 	}
 	sparseIndexOffset := int64(b.tx.buffer.Len())
 	for _, ko := range b.index {

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -12,6 +12,7 @@ type SSTableBuilder struct {
 	offset int64
 	fs     *FileSystem
 	config Config
+	built  bool
 }
 
 func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem) (*SSTableBuilder, error) {
@@ -42,6 +43,9 @@ func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem) (*SSTabl
 }
 
 func (b *SSTableBuilder) Add(rec Record) error {
+	if b.built {
+		return fmt.Errorf("SSTable already built")
+	}
 	if err := WriteRecord(b.tx, rec); err != nil {
 		return err
 	}
@@ -52,6 +56,9 @@ func (b *SSTableBuilder) Add(rec Record) error {
 }
 
 func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
+	if b.built {
+		return SStable{}, 0, fmt.Errorf("SSTable already built")
+	}
 	sparseIndexOffset := int64(b.tx.buffer.Len())
 	for _, ko := range b.index {
 		if err := writeKeyOffset(b.tx, ko); err != nil {
@@ -70,6 +77,7 @@ func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
 		return SStable{}, 0, fmt.Errorf("failed to sync file system for %s: %w", b.fs.Path(), err)
 	}
 
+	b.built = true
 	return SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom}, written, nil
 }
 

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -369,6 +369,36 @@ func TestSSTableBuilder(t *testing.T) {
 	assert.False(t, sst.Bloom.Lookup(Bytes("z")))
 }
 
+// TestSSTableBuilder_Errors verifies that calling Add or Build after a successful build returns an error.
+func TestSSTableBuilder_Errors(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	builder, err := NewSSTableBuilder(ctx, cfg, fs)
+	assert.NoError(t, err)
+
+	rec := newRecord(Bytes("a"), Bytes("1"), 1)
+	assert.NoError(t, builder.Add(rec))
+
+	_, _, err = builder.Build(ctx)
+	assert.NoError(t, err)
+
+	t.Run("AddAfterBuild", func(t *testing.T) {
+		err := builder.Add(newRecord(Bytes("b"), Bytes("2"), 2))
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "SSTable already built")
+	})
+
+	t.Run("BuildTwice", func(t *testing.T) {
+		_, _, err := builder.Build(ctx)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "SSTable already built")
+	})
+}
+
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.
 func TestSparseIndex_GetOffset(t *testing.T) {
 	type args struct {

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -388,14 +388,12 @@ func TestSSTableBuilder_Errors(t *testing.T) {
 
 	t.Run("AddAfterBuild", func(t *testing.T) {
 		err := builder.Add(newRecord(Bytes("b"), Bytes("2"), 2))
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "SSTable already built")
+		assert.ErrorIs(t, err, ErrSSTableAlreadyBuilt)
 	})
 
 	t.Run("BuildTwice", func(t *testing.T) {
 		_, _, err := builder.Build(ctx)
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "SSTable already built")
+		assert.ErrorIs(t, err, ErrSSTableAlreadyBuilt)
 	})
 }
 


### PR DESCRIPTION
## Summary
- add `built` flag to `SSTableBuilder`
- error on `Add`/`Build` after table is already built
- test that repeated `Add` or `Build` calls fail

## Testing
- `make check` *(fails: terminated while building toolchain)*
- `make test` *(fails: terminated while running go test)*
- `GOTOOLCHAIN=local go test -run TestSSTableBuilder_Errors -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68b1bb6fc56c83258aea976d2eb49e91