### PR TITLE
feat: allow configuring SSTable builder size

### DIFF
--- a/sstable.go
+++ b/sstable.go
@@ -279,7 +279,7 @@ func flush(ctx context.Context, config Config, mem Memtable, fs *FileSystem) (SS
 		log.Panic("empty memtable!")
 	}
 
-	builder, err := NewSSTableBuilder(ctx, config, fs)
+	builder, err := NewSSTableBuilder(ctx, config, fs, int(mem.data.Len()))
 	if err != nil {
 		return SStable{}, fmt.Errorf("failed to create sstable builder: %w", err)
 	}

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -14,9 +14,10 @@ type SSTableBuilder struct {
 	config  Config
 	lastKey Bytes
 	lastSeq uint64
+	expect  int
 }
 
-func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem) (*SSTableBuilder, error) {
+func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem, expected int) (*SSTableBuilder, error) {
 	if fs == nil {
 		return nil, fmt.Errorf("file system is nil")
 	}
@@ -27,19 +28,27 @@ func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem) (*SSTabl
 	}
 	tm := NewTransactionManager()
 	tx := tm.Begin()
-	bloom := NewBloomFilter(
-		SetN(uint64(cfg.maxMemtableSize)),
-		SetP(cfg.bloomFalsePositiveRate),
-		WithCalculatedM(),
-		WithCalculatedK(),
-	)
+	var bloom *BloomFilter
+	if expected > 0 {
+		bloom = NewBloomFilter(
+			SetN(uint64(expected)),
+			SetP(cfg.bloomFalsePositiveRate),
+			WithCalculatedM(),
+			WithCalculatedK(),
+		)
+	}
+	cap := expected
+	if cap <= 0 {
+		cap = int(cfg.maxMemtableSize)
+	}
 	return &SSTableBuilder{
 		tx:     tx,
-		index:  make([]KeyOffset, 0, int(cfg.maxMemtableSize)),
+		index:  make([]KeyOffset, 0, cap),
 		bloom:  bloom,
 		offset: 0,
 		fs:     fs,
 		config: cfg,
+		expect: expected,
 	}, nil
 }
 
@@ -59,7 +68,9 @@ func (b *SSTableBuilder) Add(rec Record) error {
 		return err
 	}
 	b.index = append(b.index, KeyOffset{key: key.Clone(), offset: b.offset})
-	b.bloom.Insert(key)
+	if b.bloom != nil {
+		b.bloom.Insert(key)
+	}
 	b.offset += int64(CalOnDiskSize(rec))
 	b.lastKey = key.Clone()
 	b.lastSeq = seq
@@ -67,6 +78,18 @@ func (b *SSTableBuilder) Add(rec Record) error {
 }
 
 func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
+	if b.bloom == nil {
+		n := len(b.index)
+		b.bloom = NewBloomFilter(
+			SetN(uint64(n)),
+			SetP(b.config.bloomFalsePositiveRate),
+			WithCalculatedM(),
+			WithCalculatedK(),
+		)
+		for _, ko := range b.index {
+			b.bloom.Insert(ko.key)
+		}
+	}
 	sparseIndexOffset := int64(b.tx.buffer.Len())
 	for _, ko := range b.index {
 		if err := writeKeyOffset(b.tx, ko); err != nil {

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -341,14 +341,13 @@ func TestSSTableBuilder(t *testing.T) {
 	defer closer()
 	fs := fss[0]
 
-	builder, err := NewSSTableBuilder(ctx, cfg, fs)
-	assert.NoError(t, err)
-
 	recs := []Record{
 		newRecord(Bytes("a"), Bytes("1"), 1),
 		newRecord(Bytes("b"), Bytes("2"), 2),
 		newRecord(Bytes("c"), Bytes("3"), 3),
 	}
+	builder, err := NewSSTableBuilder(ctx, cfg, fs, len(recs))
+	assert.NoError(t, err)
 	for _, r := range recs {
 		assert.NoError(t, builder.Add(r))
 	}
@@ -376,7 +375,7 @@ func TestSSTableBuilder_AddEnforcesOrder(t *testing.T) {
 	defer closer()
 	fs := fss[0]
 
-	builder, err := NewSSTableBuilder(ctx, cfg, fs)
+	builder, err := NewSSTableBuilder(ctx, cfg, fs, 4)
 	assert.NoError(t, err)
 
 	// Increasing key order

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -869,7 +869,12 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 		}
 	}()
 
-	builder, err := NewSSTableBuilder(ctx, config, target)
+	expected := 0
+	for _, sstable := range sources {
+		expected += len(sstable.SparseIndex)
+	}
+
+	builder, err := NewSSTableBuilder(ctx, config, target, expected)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- allow SSTable builder to accept an expected record count
- build Bloom filter from estimate or actual index size
- pass estimates from flush and compaction paths

## Testing
- `GOTOOLCHAIN=local make check` *(fails: internal error in staticcheck)*
- `GOTOOLCHAIN=local make test`
- `GOTOOLCHAIN=local make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b2613cf9cc8325a1629ad95e3d39ae