### PR TITLE
fix: clean file on SSTable build errors

### DIFF
--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -78,12 +78,16 @@ func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
 	}
 	written := b.tx.buffer.Len()
 	if err := b.tx.Commit(ctx, b.fs); err != nil {
-		_ = b.fs.Clean()
+		if cleanErr := b.fs.Clean(); cleanErr != nil {
+			WARN(ctx, "failed to clean file system after commit error: %v", cleanErr)
+		}
 		return SStable{}, 0, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	if err := b.fs.Sync(); err != nil {
-		_ = b.fs.Clean()
+		if cleanErr := b.fs.Clean(); cleanErr != nil {
+			WARN(ctx, "failed to clean file system after sync error: %v", cleanErr)
+		}
 		return SStable{}, 0, fmt.Errorf("failed to sync file system for %s: %w", b.fs.Path(), err)
 	}
 

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -78,10 +78,12 @@ func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
 	}
 	written := b.tx.buffer.Len()
 	if err := b.tx.Commit(ctx, b.fs); err != nil {
+		_ = b.fs.Clean()
 		return SStable{}, 0, fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	if err := b.fs.Sync(); err != nil {
+		_ = b.fs.Clean()
 		return SStable{}, 0, fmt.Errorf("failed to sync file system for %s: %w", b.fs.Path(), err)
 	}
 

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -2,9 +2,12 @@ package rindb
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSStable tests the SStable functionality.
@@ -387,6 +390,37 @@ func TestSSTableBuilder_AddEnforcesOrder(t *testing.T) {
 	assert.Error(t, builder.Add(newRecord(Bytes("a"), Bytes("2"), 1)))
 	// Keys must be non-decreasing
 	assert.Error(t, builder.Add(newRecord(Bytes("0"), Bytes("3"), 3)))
+}
+
+// TestSSTableBuilder_CleansOnWriteError ensures that a write failure triggers filesystem cleanup.
+func TestSSTableBuilder_CleansOnWriteError(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "fail.sst")
+
+	devFull, err := os.OpenFile("/dev/full", os.O_WRONLY, 0)
+	if err != nil {
+		t.Skip("/dev/full not available")
+	}
+	defer devFull.Close()
+
+	fs := &FileSystem{filePath: path, file: devFull}
+
+	builder, err := NewSSTableBuilder(ctx, cfg, fs)
+	require.NoError(t, err)
+
+	require.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
+
+	_, _, err = builder.Build(ctx)
+	require.Error(t, err)
+
+	info, statErr := os.Stat(path)
+	require.NoError(t, statErr)
+	require.Equal(t, int64(0), info.Size())
+
+	_ = fs.Close()
 }
 
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -404,7 +404,6 @@ func TestSSTableBuilder_CleansOnWriteError(t *testing.T) {
 	if err != nil {
 		t.Skip("/dev/full not available")
 	}
-	defer devFull.Close()
 
 	fs := &FileSystem{filePath: path, file: devFull}
 
@@ -420,7 +419,7 @@ func TestSSTableBuilder_CleansOnWriteError(t *testing.T) {
 	require.NoError(t, statErr)
 	require.Equal(t, int64(0), info.Size())
 
-	_ = fs.Close()
+	require.NoError(t, fs.Close())
 }
 
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.


### PR DESCRIPTION
## Summary
- clean partial SSTable files when build commit or sync fails
- add test simulating write failure to ensure file cleanup

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b2611d012083259aa5562063ef2ee8