### PR TITLE
fix: return error when building empty SSTables

### DIFF
--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -67,6 +67,9 @@ func (b *SSTableBuilder) Add(rec Record) error {
 }
 
 func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
+	if len(b.index) == 0 {
+		return SStable{}, 0, fmt.Errorf("no records to build")
+	}
 	sparseIndexOffset := int64(b.tx.buffer.Len())
 	for _, ko := range b.index {
 		if err := writeKeyOffset(b.tx, ko); err != nil {

--- a/sstable_builder_test.go
+++ b/sstable_builder_test.go
@@ -1,0 +1,22 @@
+package rindb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSTableBuilder_BuildWithoutAdd(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	builder, err := NewSSTableBuilder(ctx, cfg, fs)
+	assert.NoError(t, err)
+
+	_, _, err = builder.Build(ctx)
+	assert.EqualError(t, err, "no records to build")
+}


### PR DESCRIPTION
## Summary
- ensure `SSTableBuilder.Build` returns error when no records were added
- add test that validates Build fails without prior Add

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b2611783e88325b1b3e6dd1cbcb332