### PR TITLE
fix: clean SSTable file before building

### DIFF
--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -25,6 +25,9 @@ func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem) (*SSTabl
 			return nil, fmt.Errorf("failed to open file system: %w", err)
 		}
 	}
+	if err := fs.Clean(); err != nil {
+		return nil, fmt.Errorf("failed to clean file system: %w", err)
+	}
 	tm := NewTransactionManager()
 	tx := tm.Begin()
 	bloom := NewBloomFilter(

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -1,7 +1,9 @@
 package rindb
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -387,6 +389,26 @@ func TestSSTableBuilder_AddEnforcesOrder(t *testing.T) {
 	assert.Error(t, builder.Add(newRecord(Bytes("a"), Bytes("2"), 1)))
 	// Keys must be non-decreasing
 	assert.Error(t, builder.Add(newRecord(Bytes("0"), Bytes("3"), 3)))
+}
+
+func TestSSTableBuilder_TruncatesExistingFile(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	initial := bytes.Repeat([]byte("x"), 256)
+	fss, closer := initTempFileSystems(t, 1, [][]byte{initial})
+	defer closer()
+	fs := fss[0]
+
+	builder, err := NewSSTableBuilder(ctx, cfg, fs)
+	assert.NoError(t, err)
+	assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
+
+	_, written, err := builder.Build(ctx)
+	assert.NoError(t, err)
+
+	info, err := os.Stat(fs.Path())
+	assert.NoError(t, err)
+	assert.Equal(t, int64(written), info.Size())
 }
 
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.


### PR DESCRIPTION
## Summary
- truncate SSTable file before writing in `NewSSTableBuilder`
- add regression test ensuring no residual bytes remain

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b26103bc4c8325b457886bf6dbb09f