### PR TITLE
refactor: simplify SSTable builder and consolidate tests

### DIFF
--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -86,7 +86,7 @@ func (b *SSTableBuilder) Add(rec Record) error {
 	return nil
 }
 
-func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
+func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, written int, err error) {
 	if len(b.index) == 0 {
 		return SStable{}, 0, fmt.Errorf("no records to build")
 	}
@@ -94,55 +94,52 @@ func (b *SSTableBuilder) Build(ctx context.Context) (SStable, int, error) {
 		return SStable{}, 0, ErrSSTableAlreadyBuilt
 	}
 
+	defer func() {
+		if err != nil {
+			if cleanErr := b.fs.Clean(); cleanErr != nil {
+				WARN(ctx, "failed to clean file system after error: %v", cleanErr)
+			}
+			sst = SStable{}
+			written = 0
+		}
+	}()
+
 	if b.bloom == nil {
 		n := len(b.index)
-		if n > 0 {
-			b.bloom = NewBloomFilter(
-				SetN(uint64(n)),
-				SetP(b.config.bloomFalsePositiveRate),
-				WithCalculatedM(),
-				WithCalculatedK(),
-			)
-			for _, ko := range b.index {
-				b.bloom.Insert(ko.key)
-			}
-		} else {
-			// n=0 would panic when calculating Bloom filter parameters.
-			// Use n=1 to create a valid but empty filter.
-			b.bloom = NewBloomFilter(
-				SetN(1),
-				SetP(b.config.bloomFalsePositiveRate),
-				WithCalculatedM(),
-				WithCalculatedK(),
-			)
+		b.bloom = NewBloomFilter(
+			SetN(uint64(n)),
+			SetP(b.config.bloomFalsePositiveRate),
+			WithCalculatedM(),
+			WithCalculatedK(),
+		)
+		for _, ko := range b.index {
+			b.bloom.Insert(ko.key)
 		}
 	}
 	sparseIndexOffset := int64(b.tx.buffer.Len())
 	for _, ko := range b.index {
-		if err := writeKeyOffset(b.tx, ko); err != nil {
-			return SStable{}, 0, err
+		if err = writeKeyOffset(b.tx, ko); err != nil {
+			return
 		}
 	}
-	if err := WriteNumber(b.tx, uint64(sparseIndexOffset)); err != nil {
-		return SStable{}, 0, fmt.Errorf("failed to write sparse index offset: %w", err)
+	if err = WriteNumber(b.tx, uint64(sparseIndexOffset)); err != nil {
+		err = fmt.Errorf("failed to write sparse index offset: %w", err)
+		return
 	}
-	written := b.tx.buffer.Len()
-	if err := b.tx.Commit(ctx, b.fs); err != nil {
-		if cleanErr := b.fs.Clean(); cleanErr != nil {
-			WARN(ctx, "failed to clean file system after commit error: %v", cleanErr)
-		}
-		return SStable{}, 0, fmt.Errorf("failed to commit transaction: %w", err)
+	written = b.tx.buffer.Len()
+	if err = b.tx.Commit(ctx, b.fs); err != nil {
+		err = fmt.Errorf("failed to commit transaction: %w", err)
+		return
 	}
 
-	if err := b.fs.Sync(); err != nil {
-		if cleanErr := b.fs.Clean(); cleanErr != nil {
-			WARN(ctx, "failed to clean file system after sync error: %v", cleanErr)
-		}
-		return SStable{}, 0, fmt.Errorf("failed to sync file system for %s: %w", b.fs.Path(), err)
+	if err = b.fs.Sync(); err != nil {
+		err = fmt.Errorf("failed to sync file system for %s: %w", b.fs.Path(), err)
+		return
 	}
 
 	b.built = true
-	return SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom}, written, nil
+	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom}
+	return
 }
 
 func (b *SSTableBuilder) Close(ctx context.Context) error {

--- a/sstable_builder_test.go
+++ b/sstable_builder_test.go
@@ -1,22 +1,152 @@
 package rindb
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSSTableBuilder_BuildWithoutAdd(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig()
-	fss, closer := initTempFileSystems(t, 1, nil)
-	defer closer()
-	fs := fss[0]
+func TestSSTableBuilder(t *testing.T) {
+	t.Run("BuildWithoutAdd", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := testConfig()
+		fss, closer := initTempFileSystems(t, 1, nil)
+		defer closer()
+		fs := fss[0]
 
-	builder, err := NewSSTableBuilder(ctx, cfg, fs, 0)
-	assert.NoError(t, err)
+		builder, err := NewSSTableBuilder(ctx, cfg, fs, 0)
+		assert.NoError(t, err)
 
-	_, _, err = builder.Build(ctx)
-	assert.EqualError(t, err, "no records to build")
+		_, _, err = builder.Build(ctx)
+		assert.EqualError(t, err, "no records to build")
+	})
+
+	t.Run("Build", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := testConfig()
+		fss, closer := initTempFileSystems(t, 1, nil)
+		defer closer()
+		fs := fss[0]
+
+		recs := []Record{
+			newRecord(Bytes("a"), Bytes("1"), 1),
+			newRecord(Bytes("b"), Bytes("2"), 2),
+			newRecord(Bytes("c"), Bytes("3"), 3),
+		}
+		builder, err := NewSSTableBuilder(ctx, cfg, fs, len(recs))
+		assert.NoError(t, err)
+		for _, r := range recs {
+			assert.NoError(t, builder.Add(r))
+		}
+
+		sst, _, err := builder.Build(ctx)
+		assert.NoError(t, err)
+
+		var offset int64
+		for i, r := range recs {
+			assert.Equal(t, r.GetKey(), sst.SparseIndex[i].key)
+			assert.Equal(t, offset, sst.SparseIndex[i].offset)
+			assert.True(t, sst.Bloom.Lookup(r.GetKey()))
+			offset += int64(CalOnDiskSize(r))
+		}
+		assert.False(t, sst.Bloom.Lookup(Bytes("z")))
+	})
+
+	t.Run("AddEnforcesOrder", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := testConfig()
+		fss, closer := initTempFileSystems(t, 1, nil)
+		defer closer()
+		fs := fss[0]
+
+		builder, err := NewSSTableBuilder(ctx, cfg, fs, 4)
+		assert.NoError(t, err)
+
+		assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 2)))
+		assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("0"), 1)))
+		assert.Error(t, builder.Add(newRecord(Bytes("a"), Bytes("2"), 1)))
+		assert.Error(t, builder.Add(newRecord(Bytes("0"), Bytes("3"), 3)))
+	})
+
+	t.Run("TruncatesExistingFile", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := testConfig()
+		initial := bytes.Repeat([]byte("x"), 256)
+		fss, closer := initTempFileSystems(t, 1, [][]byte{initial})
+		defer closer()
+		fs := fss[0]
+
+		builder, err := NewSSTableBuilder(ctx, cfg, fs, 1)
+		assert.NoError(t, err)
+		assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
+
+		_, written, err := builder.Build(ctx)
+		assert.NoError(t, err)
+
+		info, err := os.Stat(fs.Path())
+		assert.NoError(t, err)
+		assert.Equal(t, int64(written), info.Size())
+	})
+
+	t.Run("Errors", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := testConfig()
+		fss, closer := initTempFileSystems(t, 1, nil)
+		defer closer()
+		fs := fss[0]
+
+		builder, err := NewSSTableBuilder(ctx, cfg, fs, 2)
+		assert.NoError(t, err)
+
+		rec := newRecord(Bytes("a"), Bytes("1"), 1)
+		assert.NoError(t, builder.Add(rec))
+
+		_, _, err = builder.Build(ctx)
+		assert.NoError(t, err)
+
+		t.Run("AddAfterBuild", func(t *testing.T) {
+			err := builder.Add(newRecord(Bytes("b"), Bytes("2"), 2))
+			assert.ErrorIs(t, err, ErrSSTableAlreadyBuilt)
+		})
+
+		t.Run("BuildTwice", func(t *testing.T) {
+			_, _, err := builder.Build(ctx)
+			assert.ErrorIs(t, err, ErrSSTableAlreadyBuilt)
+		})
+	})
+
+	t.Run("CleansOnWriteError", func(t *testing.T) {
+		ctx := context.Background()
+		cfg := testConfig()
+
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "fail.sst")
+
+		fs := &FileSystem{filePath: path}
+
+		builder, err := NewSSTableBuilder(ctx, cfg, fs, 1)
+		require.NoError(t, err)
+
+		rw := fs.file
+		ro, err := os.Open(path)
+		require.NoError(t, err)
+		_ = rw.Close()
+		fs.file = ro
+
+		require.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
+
+		_, _, err = builder.Build(ctx)
+		require.Error(t, err)
+
+		info, statErr := os.Stat(path)
+		require.NoError(t, statErr)
+		require.Equal(t, int64(0), info.Size())
+
+		require.NoError(t, fs.Close())
+	})
 }

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -1,14 +1,10 @@
 package rindb
 
 import (
-	"bytes"
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestSStable tests the SStable functionality.
@@ -335,139 +331,6 @@ func TestSStable(t *testing.T) {
 			})
 		}
 	})
-}
-
-// TestSSTableBuilder verifies that the builder writes sparse index and Bloom filter entries correctly.
-func TestSSTableBuilder(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig()
-	fss, closer := initTempFileSystems(t, 1, nil)
-	defer closer()
-	fs := fss[0]
-
-	recs := []Record{
-		newRecord(Bytes("a"), Bytes("1"), 1),
-		newRecord(Bytes("b"), Bytes("2"), 2),
-		newRecord(Bytes("c"), Bytes("3"), 3),
-	}
-	builder, err := NewSSTableBuilder(ctx, cfg, fs, len(recs))
-	assert.NoError(t, err)
-	for _, r := range recs {
-		assert.NoError(t, builder.Add(r))
-	}
-
-	sst, _, err := builder.Build(ctx)
-	assert.NoError(t, err)
-
-	// Verify sparse index entries and offsets
-	var offset int64
-	for i, r := range recs {
-		assert.Equal(t, r.GetKey(), sst.SparseIndex[i].key)
-		assert.Equal(t, offset, sst.SparseIndex[i].offset)
-		assert.True(t, sst.Bloom.Lookup(r.GetKey()))
-		offset += int64(CalOnDiskSize(r))
-	}
-
-	// Bloom filter should reject an unknown key
-	assert.False(t, sst.Bloom.Lookup(Bytes("z")))
-}
-
-func TestSSTableBuilder_AddEnforcesOrder(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig()
-	fss, closer := initTempFileSystems(t, 1, nil)
-	defer closer()
-	fs := fss[0]
-
-	builder, err := NewSSTableBuilder(ctx, cfg, fs, 4)
-	assert.NoError(t, err)
-
-	// Increasing key order
-	assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 2)))
-	// Same key with lower sequence number is allowed
-	assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("0"), 1)))
-	// Non-decreasing sequence number for same key is rejected
-	assert.Error(t, builder.Add(newRecord(Bytes("a"), Bytes("2"), 1)))
-	// Keys must be non-decreasing
-	assert.Error(t, builder.Add(newRecord(Bytes("0"), Bytes("3"), 3)))
-}
-
-func TestSSTableBuilder_TruncatesExistingFile(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig()
-	initial := bytes.Repeat([]byte("x"), 256)
-	fss, closer := initTempFileSystems(t, 1, [][]byte{initial})
-	defer closer()
-	fs := fss[0]
-
-	builder, err := NewSSTableBuilder(ctx, cfg, fs, 1)
-	assert.NoError(t, err)
-	assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
-
-	_, written, err := builder.Build(ctx)
-	assert.NoError(t, err)
-
-	info, err := os.Stat(fs.Path())
-	assert.NoError(t, err)
-	assert.Equal(t, int64(written), info.Size())
-}
-
-// TestSSTableBuilder_Errors verifies that calling Add or Build after a successful build returns an error.
-func TestSSTableBuilder_Errors(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig()
-	fss, closer := initTempFileSystems(t, 1, nil)
-	defer closer()
-	fs := fss[0]
-
-	builder, err := NewSSTableBuilder(ctx, cfg, fs, 2)
-	assert.NoError(t, err)
-
-	rec := newRecord(Bytes("a"), Bytes("1"), 1)
-	assert.NoError(t, builder.Add(rec))
-
-	_, _, err = builder.Build(ctx)
-	assert.NoError(t, err)
-
-	t.Run("AddAfterBuild", func(t *testing.T) {
-		err := builder.Add(newRecord(Bytes("b"), Bytes("2"), 2))
-		assert.ErrorIs(t, err, ErrSSTableAlreadyBuilt)
-	})
-
-	t.Run("BuildTwice", func(t *testing.T) {
-		_, _, err := builder.Build(ctx)
-		assert.ErrorIs(t, err, ErrSSTableAlreadyBuilt)
-	})
-}
-
-// TestSSTableBuilder_CleansOnWriteError ensures that a write failure triggers filesystem cleanup.
-func TestSSTableBuilder_CleansOnWriteError(t *testing.T) {
-	ctx := context.Background()
-	cfg := testConfig()
-
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "fail.sst")
-
-	devFull, err := os.OpenFile("/dev/full", os.O_WRONLY, 0)
-	if err != nil {
-		t.Skip("/dev/full not available")
-	}
-
-	fs := &FileSystem{filePath: path, file: devFull}
-
-	builder, err := NewSSTableBuilder(ctx, cfg, fs, 1)
-	require.NoError(t, err)
-
-	require.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
-
-	_, _, err = builder.Build(ctx)
-	require.Error(t, err)
-
-	info, statErr := os.Stat(path)
-	require.NoError(t, statErr)
-	require.Equal(t, int64(0), info.Size())
-
-	require.NoError(t, fs.Close())
 }
 
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.


### PR DESCRIPTION
## Summary
- streamline `SSTableBuilder.Build` with deferred cleanup and simpler Bloom filter setup
- move and group SSTable builder unit tests into `sstable_builder_test.go`

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b29fc7cf888325b1f38dc8fc0f84e7