### PR TITLE
docs: refine compactor and manifest plans

### DIFF
--- a/docs/dev/53/compactor_plan.md
+++ b/docs/dev/53/compactor_plan.md
@@ -40,6 +40,8 @@ func NewCompactor(ops CompactionOps, mw ManifestWriter, vs *VersionSet) *Compact
 ## Public Entry
 ```go
 // Compact scans levels and continues dispatching work until no level qualifies.
+// After each compaction the scan restarts from level 0 because compaction can
+// alter which levels require work.
 func (c *Compactor) Compact(ctx context.Context) error {
     for {
         progressed := false
@@ -51,6 +53,7 @@ func (c *Compactor) Compact(ctx context.Context) error {
                 return err
             }
             progressed = true
+            break // restart scan with refreshed view of c.version.Levels
         }
         if !progressed {
             return nil
@@ -58,6 +61,11 @@ func (c *Compactor) Compact(ctx context.Context) error {
     }
 }
 ```
+
+Breaking out of the inner loop avoids iterating over a stale snapshot of
+`c.version.Levels`. Compaction at one level can change the size of adjacent
+levels—for example, compacting level 0 into level 1 may push level 1 over its
+threshold—so restarting the scan ensures each decision uses the latest state.
 
 ## Commit Hook
 ```go

--- a/docs/dev/53/compactor_plan.md
+++ b/docs/dev/53/compactor_plan.md
@@ -11,10 +11,15 @@ type CompactionOps interface {
     ShouldCompact(ctx context.Context, level int, files []FileMeta) bool
     PickFiles(ctx context.Context, level int, files []FileMeta) []FileMeta
     FindOverlaps(ctx context.Context, level int, inputs []FileMeta) ([]FileMeta, error)
+    // Merge writes a new set of SSTables for the destination level and returns
+    // FileMeta populated with that level and allocator-assigned file numbers
+    // (see allocator notes in overall_plan.md).
     Merge(ctx context.Context, level int, inputs []FileMeta) ([]FileMeta, error)
 }
 
-// Compactor orchestrates SSTable merges and manifest updates.
+// Compactor orchestrates SSTable merges and manifest updates. It is not
+// concurrency-safe; callers (e.g., SSTableManager) must hold their own locks
+// around Compact to serialize access to VersionSet and filesystem state.
 type Compactor struct {
     ops      CompactionOps
     manifest ManifestWriter
@@ -26,15 +31,31 @@ func NewCompactor(ops CompactionOps, mw ManifestWriter, vs *VersionSet) *Compact
 }
 ```
 
+## Concurrency
+
+`Compactor` relies on its caller for synchronization. `SSTableManager` holds its
+`mu` while invoking `Compact` and throughout `commit`, serializing updates to the
+`VersionSet` and physical file removals.
+
 ## Public Entry
 ```go
-// Compact scans levels from the VersionSet and dispatches work.
+// Compact scans levels and continues dispatching work until no level qualifies.
 func (c *Compactor) Compact(ctx context.Context) error {
-    for lvl, files := range c.version.Levels {
-        if !c.ops.ShouldCompact(ctx, lvl, files) { continue }
-        if err := c.compactLevel(ctx, lvl, files); err != nil { return err }
+    for {
+        progressed := false
+        for lvl, files := range c.version.Levels {
+            if !c.ops.ShouldCompact(ctx, lvl, files) {
+                continue
+            }
+            if err := c.compactLevel(ctx, lvl, files); err != nil {
+                return err
+            }
+            progressed = true
+        }
+        if !progressed {
+            return nil
+        }
     }
-    return nil
 }
 ```
 
@@ -44,7 +65,7 @@ func (c *Compactor) Compact(ctx context.Context) error {
 func (c *Compactor) commit(ctx context.Context, outs, dels []FileMeta) error {
     edit := VersionEdit{AddFiles: outs}
     for _, f := range dels {
-        edit.DeleteFiles = append(edit.DeleteFiles, struct{Level int; Number uint64}{f.Level, f.Number})
+        edit.DeleteFiles = append(edit.DeleteFiles, DeletedFileMeta{Level: f.Level, Number: f.Number})
     }
     if err := c.manifest.Append(edit); err != nil { return err }
     if err := c.manifest.Sync(); err != nil { return err }
@@ -52,6 +73,10 @@ func (c *Compactor) commit(ctx context.Context, outs, dels []FileMeta) error {
     return removeFiles(dels)
 }
 ```
+
+`removeFiles` deletes obsolete SSTable files from disk after the manifest edit is
+durably persisted. The helper already exists in `sstablemgmt.go` and is reused
+by the compactor.
 
 ## Internal Helpers
 ```go

--- a/docs/dev/53/overall_plan.md
+++ b/docs/dev/53/overall_plan.md
@@ -108,6 +108,10 @@ func (c *Compactor) commit(ctx context.Context, outs []FileMeta, dels []FileMeta
 }
 ```
 
+`removeFiles` deletes the physical SSTable files referenced by `dels` after the
+manifest edit has been synced, ensuring obsolete files are reclaimed only after
+the new state is durable.
+
 ## Rotation and Checkpointing
 - When the MANIFEST grows beyond a threshold, write a new snapshot manifest and swap `CURRENT`.
 ```go


### PR DESCRIPTION
## Summary
- clarify CompactionOps.Merge responsibilities and locking strategy in compactor plan
- iterate compactions until work is exhausted and document file deletion helper
- note file removal timing in overall manifest plan

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b3031d374c83258281429e768a345c