### PR TITLE
docs: refine manifest refactor plans

### DIFF
--- a/docs/dev/53/compactor_plan.md
+++ b/docs/dev/53/compactor_plan.md
@@ -83,8 +83,8 @@ func (c *Compactor) commit(ctx context.Context, outs, dels []FileMeta) error {
 ```
 
 `removeFiles` deletes obsolete SSTable files from disk after the manifest edit is
-durably persisted. The helper already exists in `sstablemgmt.go` and is reused
-by the compactor.
+durably persisted. A new helper (see `overall_plan.md`) provides this function
+and is reused by the compactor.
 
 ## Internal Helpers
 ```go

--- a/docs/dev/53/overall_plan.md
+++ b/docs/dev/53/overall_plan.md
@@ -189,6 +189,9 @@ func (h *SSTableManager) LoadLevels(dir string) error {
 - Update `AddSSTable`, `Compact`, `compactLevel0`, `compactHigherLevel`,
   and `mergeSSTables` to emit `VersionEdit` records and apply them to `versionSet`.
 
+- Update unit tests to construct `VersionSet` fixtures instead of populating
+  `levels` lists.
+
 ### `rindb.go`
 - `InitRinDB` now bootstraps from the MANIFEST, which dictates both live SSTables and WAL identifiers.
 - Flow:
@@ -228,6 +231,8 @@ id := allocator.Next()
 walPath := path.Join(cfg.databaseDir, fmt.Sprintf("%06d.wal", id))
 ```
 
+- Update WAL tests to expect numbered log files seeded by the allocator.
+
 ### `sstablemgmt.go` `NewSSTableFS`
 - Replace ULID-based file names with allocator-issued numbers.
 ```go
@@ -240,8 +245,26 @@ id := allocator.Next()
 sstableFileName := fmt.Sprintf("%06d.sst", id)
 ```
 
+- Tests should seed the allocator to generate predictable file names.
+
 ### `config.go`
 - Extend `Config` with constructors for the manifest and file-number allocator (e.g., `newManifestFunc`, `newFileNumberAllocator`).
+
+### `sstable_builder.go`
+- Track `Smallest`, `Largest`, `SeqLo`, `SeqHi`, and total bytes during `Add`.
+- `Build` returns the `SSTable` and a `FileMeta` populated with the allocator-issued file number.
+- Callers assign the level and forward the metadata when constructing `VersionEdit`s.
+- Update `mergeSSTables` and existing tests to handle the new `FileMeta` result.
+
+### Memtable Flush Path
+- After flushing the memtable, create a `VersionEdit` containing the returned `FileMeta`.
+- Append through a `ManifestWriter`, `Sync`, apply it to the `VersionSet`, then clear the memtable and obsolete WAL.
+- Extend tests to verify the flush records the file in `VersionSet` and cleans up the WAL using that metadata.
+
+### `sstable_files.go`
+- Introduce `removeFiles(files []FileMeta)` to map file numbers to paths and delete them once the manifest edit is durable.
+- Replace ad-hoc file deletions in flush and compaction paths with this helper.
+- Cover deletion and error cases with unit tests.
 
 ## Next Steps
 - Implement manifest writer/reader packages.

--- a/docs/dev/53/sstable_builder_plan.md
+++ b/docs/dev/53/sstable_builder_plan.md
@@ -1,0 +1,39 @@
+# SSTableBuilder Metadata Plan
+
+Emit `FileMeta` during table construction so flush and compaction can write manifest edits.
+
+## Plan
+- Track smallest/largest keys, sequence bounds, and total bytes in `Add`.
+- `Build` takes a file number and returns an `SSTable` plus a populated `FileMeta`.
+- Callers assign the target level on the `FileMeta` before creating a `VersionEdit`.
+- Tests assert that key bounds, size, and sequence range are recorded.
+
+## Example
+```go
+// FileMeta records table statistics.
+type FileMeta struct {
+    FileNum        uint64
+    Level          int
+    Smallest, Largest InternalKey
+    SeqLo, SeqHi   uint64
+    Size           uint64
+}
+
+type SSTableBuilder struct {
+    w               io.Writer
+    smallest, largest InternalKey
+    seqLo, seqHi    uint64
+    written         uint64
+}
+
+func (b *SSTableBuilder) Add(ik InternalKey, val []byte) error {
+    // update bounds and sequence range
+}
+
+func (b *SSTableBuilder) Build(fileNum uint64) (*SSTable, FileMeta, error) {
+    meta := FileMeta{FileNum: fileNum, Smallest: b.smallest, Largest: b.largest,
+        SeqLo: b.seqLo, SeqHi: b.seqHi, Size: b.written}
+    return &SSTable{FileNum: fileNum}, meta, nil
+}
+```
+


### PR DESCRIPTION
## Summary
- expand manifest plan with builder metadata, flush edits, and file cleanup helper
- clarify compactor refactor to use new removeFiles helper
- add standalone plan for SSTableBuilder metadata
- balance SSTableBuilder plan with code-focused example (3:7 plan-to-code ratio)

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b315481dcc8325bb2e2454fc8282a8