### PR TITLE
feat: add manifest versioning foundation

### DIFF
--- a/docs/dev/53/compactor_plan.md
+++ b/docs/dev/53/compactor_plan.md
@@ -1,8 +1,9 @@
 # Compactor Refactor Plan
 
-The current `SSTableManager` embeds all compaction logic.  To align with the manifest
-work and enable the `commit` workflow described in `overall_plan.md`, compaction will
-be extracted into a dedicated `Compactor` type located in `compactor.go`.
+With manifest-based versioning in place, the current `SSTableManager` still embeds all
+compaction logic. To align with this new foundation and enable the `commit`
+workflow described in `overall_plan.md`, compaction will be extracted into a
+dedicated `Compactor` type located in `compactor.go`.
 
 ## Type & Constructor
 ```go

--- a/docs/dev/53/compactor_plan.md
+++ b/docs/dev/53/compactor_plan.md
@@ -72,7 +72,7 @@ threshold—so restarting the scan ensures each decision uses the latest state.
 // commit persists version edits and removes obsolete files.
 func (c *Compactor) commit(ctx context.Context, outs, dels []FileMeta) error {
     last := maxSeq(outs)
-    edit := VersionEdit{AddFiles: outs, LastSequence: &last}
+    edit := VersionEdit{AddFiles: outs, LastSequence: last}
     for _, f := range dels {
         edit.DeleteFiles = append(edit.DeleteFiles, DeletedFileMeta{Level: f.Level, Number: f.Number})
     }

--- a/docs/dev/53/overall_plan.md
+++ b/docs/dev/53/overall_plan.md
@@ -1,6 +1,6 @@
 # Manifest and Versioning Plan
 
-This document outlines how to integrate a MANIFEST-based versioning system into `rindb`.  The plan below balances prose and illustrative code snippets at roughly a 3:7 ratio.
+This document tracks ongoing work after landing a MANIFEST-based versioning system in `rindb`.  It balances prose and illustrative code snippets at roughly a 3:7 ratio.
 
 ## Data Structures
 - Introduce in-memory `VersionSet` as the authoritative mapping from levels to files.
@@ -66,9 +66,20 @@ func WriteCURRENT(ctx context.Context, dir, manifest string) error {
     tmp := filepath.Join(dir, "CURRENT.tmp")
     fs, err := OpenFS(ctx, tmp)
     if err != nil { return err }
-    if _, err := fs.Write([]byte(manifest+"\n")); err != nil { return err }
-    if err := fs.Sync(); err != nil { return err }
-    if err := fs.Rename(filepath.Join(dir, "CURRENT")); err != nil { return err }
+    if _, err := fs.Write([]byte(manifest+"\n")); err != nil {
+        _ = fs.Close()
+        _ = os.Remove(tmp)
+        return err
+    }
+    if err := fs.Sync(); err != nil {
+        _ = fs.Close()
+        _ = os.Remove(tmp)
+        return err
+    }
+    if err := fs.Rename(filepath.Join(dir, "CURRENT")); err != nil {
+        _ = os.Remove(tmp)
+        return err
+    }
     return syncDir(dir)
 }
 ```
@@ -300,6 +311,5 @@ vs.Apply(edit)
 - Cover deletion and error cases with unit tests.
 
 ## Next Steps
-- Implement manifest writer/reader packages.
 - Integrate allocator and version set into existing DB paths.
 - Add integration tests covering crash recovery and rotation.

--- a/docs/dev/53/overall_plan.md
+++ b/docs/dev/53/overall_plan.md
@@ -9,11 +9,11 @@ This document outlines how to integrate a MANIFEST-based versioning system into 
 ```go
 // Describes a new or updated state change.
 type VersionEdit struct {
-    ComparatorName *string
-    LastSequence   *uint64
-    NextFileNumber *uint64
-    LogNumber      *uint64
-    PrevLogNumber  *uint64
+    ComparatorName string
+    LastSequence   uint64
+    NextFileNumber uint64
+    LogNumber      uint64
+    PrevLogNumber  uint64
     AddFiles    []FileMeta
     DeleteFiles []DeletedFileMeta
 }
@@ -62,10 +62,13 @@ type ManifestReader interface {
     Close() error
 }
 
-func WriteCURRENT(dir, manifest string) error {
+func WriteCURRENT(ctx context.Context, dir, manifest string) error {
     tmp := filepath.Join(dir, "CURRENT.tmp")
-    if err := os.WriteFile(tmp, []byte(manifest+"\n"), 0o644); err != nil { return err }
-    if err := os.Rename(tmp, filepath.Join(dir, "CURRENT")); err != nil { return err }
+    fs, err := OpenFS(ctx, tmp)
+    if err != nil { return err }
+    if _, err := fs.Write([]byte(manifest+"\n")); err != nil { return err }
+    if err := fs.Sync(); err != nil { return err }
+    if err := fs.Rename(filepath.Join(dir, "CURRENT")); err != nil { return err }
     return syncDir(dir)
 }
 ```
@@ -132,7 +135,7 @@ func rotateManifest(dir string, vs *VersionSet) error {
         w.Close()
         return err
     }
-    if err := WriteCURRENT(dir, w.Path()); err != nil {
+    if err := WriteCURRENT(ctx, dir, w.Path()); err != nil {
         w.Close()
         return err
     }
@@ -161,7 +164,7 @@ func (a *FileNumberAllocator) Apply(edit VersionEdit) {
 ```go
 func InitSSTableManager(ctx context.Context, cfg Config) (*SSTableManager, error) {
     if cfg.repairMode { return loadByScan(ctx, cfg) }
-    vs, err := recoverVersionSet(cfg.databaseDir)
+    vs, err := recoverVersionSet(ctx, cfg.databaseDir)
     if err != nil { return nil, err }
     return &SSTableManager{versionSet: vs, config: cfg}, nil
 }
@@ -205,7 +208,7 @@ func (h *SSTableManager) LoadLevels(dir string) error {
 func InitRinDB(ctx context.Context, opts ...Option) (*Rindb, error) {
     cfg := NewConfig(opts...)
 
-    vs, err := recoverVersionSet(cfg.databaseDir)
+    vs, err := recoverVersionSet(ctx, cfg.databaseDir)
     if err != nil { return nil, err }
 
     allocator := cfg.newFileNumberAllocatorFunc(vs.NextFileNumber)
@@ -283,7 +286,7 @@ func WithRepairMode(v bool) Option {
 ```go
 meta := FileMeta{Number: id, Level: 0, Smallest: s, Largest: l, SeqLo: lo, SeqHi: hi}
 last := meta.SeqHi
-edit := VersionEdit{AddFiles: []FileMeta{meta}, LastSequence: &last}
+edit := VersionEdit{AddFiles: []FileMeta{meta}, LastSequence: last}
 if err := mw.Append(edit); err != nil { return err }
 if err := mw.Sync(); err != nil { return err }
 vs.Apply(edit)

--- a/docs/dev/53/read_path_plan.md
+++ b/docs/dev/53/read_path_plan.md
@@ -1,6 +1,6 @@
 # VersionSet Read Path Plan
 
-Migrate lookup helpers to operate on `VersionSet` metadata rather than legacy linked lists. The prose-to-code ratio is roughly 3:7.
+Now that `VersionSet` tracks SSTables, migrate lookup helpers to operate on its metadata rather than legacy linked lists. The prose-to-code ratio is roughly 3:7.
 
 ## Plan
 - Iterate `VersionSet.Levels` and return file numbers overlapping a key range.

--- a/docs/dev/53/sstable_builder_plan.md
+++ b/docs/dev/53/sstable_builder_plan.md
@@ -1,6 +1,6 @@
 # SSTableBuilder Metadata Plan
 
-Emit `FileMeta` during table construction so flush and compaction can write manifest edits.
+With `FileMeta` and manifest editing in place, emit `FileMeta` during table construction so flush and compaction can write manifest edits.
 
 ## Plan
 - Track smallest/largest keys, sequence bounds, and total bytes in `Add`.

--- a/filesystem.go
+++ b/filesystem.go
@@ -88,6 +88,25 @@ func (fs *FileSystem) Close() error {
 	return nil
 }
 
+// Rename moves the underlying file to newPath.
+// It closes the file if it's open and updates the internal path.
+func (fs *FileSystem) Rename(newPath string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file != nil {
+		if err := fs.file.Close(); err != nil {
+			return err
+		}
+		fs.file = nil
+	}
+	if err := os.Rename(fs.filePath, newPath); err != nil {
+		return err
+	}
+	fs.filePath = newPath
+	return nil
+}
+
 func (fs *FileSystem) Clean() error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -42,6 +42,17 @@ func TestFileSystem(t *testing.T) {
 		assert.NoError(t, fs.Close())
 		assert.NoError(t, emptyFs.Close())
 	})
+
+	t.Run("Rename file", func(t *testing.T) {
+		fss, closer := initTempFileSystems(t, 1, nil)
+		defer closer()
+
+		fs := fss[0]
+		newPath := fs.Path() + "-renamed"
+
+		assert.NoError(t, fs.Rename(newPath))
+		assert.Equal(t, newPath, fs.Path())
+	})
 }
 
 func TestFileSystem_Errors(t *testing.T) {

--- a/manifest.go
+++ b/manifest.go
@@ -110,10 +110,12 @@ func WriteCURRENT(ctx context.Context, dir, manifest string) error {
 	}
 	if _, err := fs.Write([]byte(manifest + "\n")); err != nil {
 		_ = fs.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := fs.Sync(); err != nil {
 		_ = fs.Close()
+		_ = os.Remove(tmp)
 		return err
 	}
 	if err := fs.Rename(filepath.Join(dir, "CURRENT")); err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -1,0 +1,165 @@
+package rindb
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// crcTable holds the Castagnoli table used for CRC32C checksums.
+var crcTable = crc32.MakeTable(crc32.Castagnoli)
+
+// ManifestWriter appends edits to a MANIFEST file.
+type ManifestWriter interface {
+	Append(VersionEdit) error
+	Sync() error
+	Close() error
+}
+
+// ManifestReader iterates over manifest records.
+type ManifestReader interface {
+	Next() (VersionEdit, error)
+	Close() error
+}
+
+type fileManifestWriter struct {
+	fs *FileSystem
+}
+
+type fileManifestReader struct {
+	fs *FileSystem
+}
+
+// NewManifestWriter creates a writer for the given path.
+func NewManifestWriter(ctx context.Context, path string) (ManifestWriter, error) {
+	fs, err := OpenFS(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := fs.Seek(0, io.SeekEnd); err != nil {
+		_ = fs.Close()
+		return nil, err
+	}
+	return &fileManifestWriter{fs: fs}, nil
+}
+
+func (w *fileManifestWriter) Append(edit VersionEdit) error {
+	data, err := json.Marshal(edit)
+	if err != nil {
+		return err
+	}
+	var header [8]byte
+	byteOrder.PutUint32(header[0:4], uint32(len(data)))
+	crc := crc32.Checksum(data, crcTable)
+	byteOrder.PutUint32(header[4:8], crc)
+	if _, err := w.fs.Write(header[:]); err != nil {
+		return err
+	}
+	if _, err := w.fs.Write(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *fileManifestWriter) Sync() error  { return w.fs.Sync() }
+func (w *fileManifestWriter) Close() error { return w.fs.Close() }
+
+// NewManifestReader opens a reader for the manifest at path.
+func NewManifestReader(ctx context.Context, path string) (ManifestReader, error) {
+	fs, err := OpenFS(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	return &fileManifestReader{fs: fs}, nil
+}
+
+func (r *fileManifestReader) Next() (VersionEdit, error) {
+	var header [8]byte
+	if _, err := io.ReadFull(r.fs, header[:]); err != nil {
+		return VersionEdit{}, err
+	}
+	n := byteOrder.Uint32(header[0:4])
+	crc := byteOrder.Uint32(header[4:8])
+	data := make([]byte, n)
+	if _, err := io.ReadFull(r.fs, data); err != nil {
+		return VersionEdit{}, err
+	}
+	if crc32.Checksum(data, crcTable) != crc {
+		return VersionEdit{}, ErrChecksumMismatch
+	}
+	var edit VersionEdit
+	if err := json.Unmarshal(data, &edit); err != nil {
+		return VersionEdit{}, err
+	}
+	return edit, nil
+}
+
+func (r *fileManifestReader) Close() error { return r.fs.Close() }
+
+// WriteCURRENT atomically updates the CURRENT file to point to manifest.
+func WriteCURRENT(ctx context.Context, dir, manifest string) error {
+	tmp := filepath.Join(dir, "CURRENT.tmp")
+	fs, err := OpenFS(ctx, tmp)
+	if err != nil {
+		return err
+	}
+	if _, err := fs.Write([]byte(manifest + "\n")); err != nil {
+		_ = fs.Close()
+		return err
+	}
+	if err := fs.Sync(); err != nil {
+		_ = fs.Close()
+		return err
+	}
+	if err := fs.Rename(filepath.Join(dir, "CURRENT")); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return syncDir(dir)
+}
+
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+
+// recoverVersionSet rebuilds the VersionSet by replaying the MANIFEST.
+func recoverVersionSet(ctx context.Context, dir string) (*VersionSet, error) {
+	vs := &VersionSet{}
+	curr := filepath.Join(dir, "CURRENT")
+	data, err := os.ReadFile(curr)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return vs, nil
+		}
+		return nil, err
+	}
+	manifest := strings.TrimSpace(string(data))
+	r, err := NewManifestReader(ctx, filepath.Join(dir, manifest))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	for {
+		edit, err := r.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		if err := edit.Apply(vs); err != nil {
+			return nil, err
+		}
+	}
+	return vs, nil
+}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1,0 +1,112 @@
+package rindb
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestManifest(t *testing.T) {
+	t.Run("WriteRead", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		mf := filepath.Join(dir, "MANIFEST-000001")
+		w, err := NewManifestWriter(ctx, mf)
+		require.NoError(t, err)
+		edit := VersionEdit{ComparatorName: "bytes", LastSequence: 7}
+		require.NoError(t, w.Append(edit))
+		require.NoError(t, w.Sync())
+		require.NoError(t, w.Close())
+
+		r, err := NewManifestReader(ctx, mf)
+		require.NoError(t, err)
+		got, err := r.Next()
+		require.NoError(t, err)
+		require.Equal(t, edit, got)
+		_, err = r.Next()
+		require.ErrorIs(t, err, io.EOF)
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("ReaderBadCRC", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		mf := filepath.Join(dir, "MANIFEST-000001")
+		w, err := NewManifestWriter(ctx, mf)
+		require.NoError(t, err)
+		edit := VersionEdit{LastSequence: 1}
+		require.NoError(t, w.Append(edit))
+		require.NoError(t, w.Close())
+
+		f, err := os.OpenFile(mf, os.O_RDWR, 0)
+		require.NoError(t, err)
+		_, err = f.Seek(8, io.SeekStart)
+		require.NoError(t, err)
+		b := []byte{0}
+		_, err = f.Read(b)
+		require.NoError(t, err)
+		b[0] ^= 0xff
+		_, err = f.Seek(8, io.SeekStart)
+		require.NoError(t, err)
+		_, err = f.Write(b)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		r, err := NewManifestReader(ctx, mf)
+		require.NoError(t, err)
+		_, err = r.Next()
+		require.ErrorIs(t, err, ErrChecksumMismatch)
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("ReaderTruncated", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		mf := filepath.Join(dir, "MANIFEST-000001")
+		w, err := NewManifestWriter(ctx, mf)
+		require.NoError(t, err)
+		edit := VersionEdit{LastSequence: 1}
+		require.NoError(t, w.Append(edit))
+		require.NoError(t, w.Close())
+
+		fi, err := os.Stat(mf)
+		require.NoError(t, err)
+		require.NoError(t, os.Truncate(mf, fi.Size()-1))
+
+		r, err := NewManifestReader(ctx, mf)
+		require.NoError(t, err)
+		_, err = r.Next()
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("RecoverVersionSet", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		mf := "MANIFEST-000001"
+		path := filepath.Join(dir, mf)
+		w, err := NewManifestWriter(ctx, path)
+		require.NoError(t, err)
+		seq := uint64(123)
+		require.NoError(t, w.Append(VersionEdit{LastSequence: seq}))
+		require.NoError(t, w.Sync())
+		require.NoError(t, w.Close())
+		require.NoError(t, WriteCURRENT(ctx, dir, mf))
+
+		vs, err := recoverVersionSet(ctx, dir)
+		require.NoError(t, err)
+		require.Equal(t, seq, vs.LastSequence)
+	})
+
+	t.Run("RecoverVersionSetNoManifest", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		vs, err := recoverVersionSet(ctx, dir)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), vs.LastSequence)
+	})
+}

--- a/rindb.go
+++ b/rindb.go
@@ -22,6 +22,7 @@ type Rindb struct {
 	wal               *WAL
 	memtable          Memtable
 	ssTableManager    *SSTableManager
+	versionSet        *VersionSet
 	config            Config
 	shutdownTelemetry func(context.Context) error
 	mu                sync.RWMutex   // Mutex for thread-safe access
@@ -88,6 +89,11 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 		return nil, fmt.Errorf("failed to create database directory %s: %w", cfg.databaseDir, err)
 	}
 
+	vs, err := recoverVersionSet(ctx, cfg.databaseDir)
+	if err != nil {
+		return nil, err
+	}
+
 	wal, err := cfg.newWALFunc(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -106,7 +112,7 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 
 	// Set default is 0, while inserting new record, it will automatically increase
 	// So first record's sequence number is always 1 if database is empty
-	var maxSeqNum uint64 = 0
+	var maxSeqNum uint64 = vs.LastSequence
 
 	memMaxSeqNum, err := getMaxSequenceNumberFromMemtable(memtable)
 	if err != nil {
@@ -132,6 +138,7 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 		wal:               wal,
 		memtable:          memtable,
 		ssTableManager:    ssTableManager,
+		versionSet:        vs,
 		config:            cfg,
 		shutdownTelemetry: shutdownTelemetry,
 		sequenceNumber:    maxSeqNum,

--- a/version.go
+++ b/version.go
@@ -73,15 +73,27 @@ func (e VersionEdit) Apply(vs *VersionSet) error {
 		vs.ensureLevel(f.Level)
 		vs.Levels[f.Level] = append(vs.Levels[f.Level], f)
 	}
-	for _, d := range e.DeleteFiles {
-		if d.Level < len(vs.Levels) {
-			files := vs.Levels[d.Level]
-			for i, f := range files {
-				if f.Number == d.Number {
-					vs.Levels[d.Level] = append(files[:i], files[i+1:]...)
-					break
+	if len(e.DeleteFiles) > 0 {
+		deletionsByLevel := make(map[int]map[uint64]struct{})
+		for _, d := range e.DeleteFiles {
+			if _, ok := deletionsByLevel[d.Level]; !ok {
+				deletionsByLevel[d.Level] = make(map[uint64]struct{})
+			}
+			deletionsByLevel[d.Level][d.Number] = struct{}{}
+		}
+
+		for level, toDelete := range deletionsByLevel {
+			if level >= len(vs.Levels) {
+				continue
+			}
+			files := vs.Levels[level]
+			filtered := files[:0]
+			for _, f := range files {
+				if _, ok := toDelete[f.Number]; !ok {
+					filtered = append(filtered, f)
 				}
 			}
+			vs.Levels[level] = filtered
 		}
 	}
 	return nil

--- a/version.go
+++ b/version.go
@@ -1,0 +1,88 @@
+package rindb
+
+import "fmt"
+
+// FileMeta holds metadata about an SSTable file.
+type FileMeta struct {
+	Number   uint64
+	Level    int
+	Smallest InternalKey
+	Largest  InternalKey
+	Size     uint64
+	SeqLo    uint64
+	SeqHi    uint64
+}
+
+// DeletedFileMeta references a file to remove.
+type DeletedFileMeta struct {
+	Level  int
+	Number uint64
+}
+
+// VersionEdit describes a change to the VersionSet.
+type VersionEdit struct {
+	ComparatorName string `json:",omitempty"`
+	LastSequence   uint64 `json:",omitempty"`
+	NextFileNumber uint64 `json:",omitempty"`
+	LogNumber      uint64 `json:",omitempty"`
+	PrevLogNumber  uint64 `json:",omitempty"`
+
+	AddFiles    []FileMeta        `json:",omitempty"`
+	DeleteFiles []DeletedFileMeta `json:",omitempty"`
+}
+
+// VersionSet represents the in-memory state of levels and file numbering.
+type VersionSet struct {
+	Levels         [][]FileMeta
+	Comparator     string
+	NextFileNumber uint64
+	LogNumber      uint64
+	PrevLogNumber  uint64
+	LastSequence   uint64
+}
+
+func (vs *VersionSet) ensureLevel(level int) {
+	for len(vs.Levels) <= level {
+		vs.Levels = append(vs.Levels, nil)
+	}
+}
+
+// coalesceNonZero returns newVal if it's not the zero value for its type,
+// otherwise returns existing.
+func coalesceNonZero[T uint | uint64 | int | int32 | int64 | float32 | float64 | string](existing, newVal T) T {
+	var zero T
+	if newVal != zero {
+		return newVal
+	}
+	return existing
+}
+
+// Apply applies the VersionEdit to the VersionSet.
+func (e VersionEdit) Apply(vs *VersionSet) error {
+	if e.ComparatorName != "" {
+		if vs.Comparator != "" && vs.Comparator != e.ComparatorName {
+			return fmt.Errorf("comparator mismatch: have %s want %s", vs.Comparator, e.ComparatorName)
+		}
+		vs.Comparator = e.ComparatorName
+	}
+	vs.LastSequence = coalesceNonZero(vs.LastSequence, e.LastSequence)
+	vs.NextFileNumber = coalesceNonZero(vs.NextFileNumber, e.NextFileNumber)
+	vs.LogNumber = coalesceNonZero(vs.LogNumber, e.LogNumber)
+	vs.PrevLogNumber = coalesceNonZero(vs.PrevLogNumber, e.PrevLogNumber)
+	for _, f := range e.AddFiles {
+		vs.ensureLevel(f.Level)
+		vs.Levels[f.Level] = append(vs.Levels[f.Level], f)
+	}
+	for _, d := range e.DeleteFiles {
+		if d.Level < len(vs.Levels) {
+			files := vs.Levels[d.Level]
+			for i, f := range files {
+				if f.Number == d.Number {
+					vs.Levels[d.Level] = append(files[:i], files[i+1:]...)
+					break
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,53 @@
+package rindb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionEdit(t *testing.T) {
+	t.Run("ComparatorMismatch", func(t *testing.T) {
+		vs := &VersionSet{Comparator: "bytes"}
+		edit := VersionEdit{ComparatorName: "rev"}
+		err := edit.Apply(vs)
+		require.Error(t, err)
+	})
+
+	t.Run("AddAndDeleteFiles", func(t *testing.T) {
+		vs := &VersionSet{}
+		fm := FileMeta{Number: 1, Level: 1}
+		edit := VersionEdit{AddFiles: []FileMeta{fm}}
+		require.NoError(t, edit.Apply(vs))
+		require.Len(t, vs.Levels, 2)
+		require.Equal(t, fm, vs.Levels[1][0])
+
+		del := VersionEdit{DeleteFiles: []DeletedFileMeta{{Level: 1, Number: 1}}}
+		require.NoError(t, del.Apply(vs))
+		require.Empty(t, vs.Levels[1])
+	})
+
+	t.Run("DeleteNonExistent", func(t *testing.T) {
+		vs := &VersionSet{}
+		edit := VersionEdit{DeleteFiles: []DeletedFileMeta{{Level: 2, Number: 5}}}
+		require.NoError(t, edit.Apply(vs))
+		require.Len(t, vs.Levels, 0)
+	})
+
+	t.Run("Metadata", func(t *testing.T) {
+		vs := &VersionSet{}
+		edit := VersionEdit{
+			ComparatorName: "bytes",
+			LastSequence:   1,
+			NextFileNumber: 2,
+			LogNumber:      3,
+			PrevLogNumber:  4,
+		}
+		require.NoError(t, edit.Apply(vs))
+		require.Equal(t, "bytes", vs.Comparator)
+		require.Equal(t, uint64(1), vs.LastSequence)
+		require.Equal(t, uint64(2), vs.NextFileNumber)
+		require.Equal(t, uint64(3), vs.LogNumber)
+		require.Equal(t, uint64(4), vs.PrevLogNumber)
+	})
+}

--- a/wal.go
+++ b/wal.go
@@ -221,16 +221,13 @@ func (w *WAL) Clean(ctx context.Context, minSeq uint64) error {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to sync WAL: %w", err)
 	}
-	if err := tmpFS.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return fmt.Errorf("failed to close temp WAL: %w", err)
-	}
 
 	if err := w.Close(); err != nil {
+		_ = tmpFS.Close()
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to close WAL: %w", err)
 	}
-	if err := os.Rename(tmpPath, w.Path()); err != nil {
+	if err := tmpFS.Rename(w.Path()); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to replace WAL: %w", err)
 	}


### PR DESCRIPTION
## Summary
- rely on FileSystem for manifest I/O and atomic CURRENT swaps
- drop pointer fields in VersionEdit and coalesce zero values
- restructure manifest and version tests into subtests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b39ad0f1d483258bb35af0f0ddd4bb