### PR TITLE
refactor: switch to CRC-32C checksum

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,13 @@
+package rindb
+
+import "hash/crc32"
+
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+func checksum(parts ...[]byte) uint32 {
+	var sum uint32
+	for _, p := range parts {
+		sum = crc32.Update(sum, crc32cTable, p)
+	}
+	return sum
+}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,14 @@
+package rindb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChecksumCRC32C(t *testing.T) {
+	data := []byte("hello world")
+	expected := uint32(0xc99465aa)
+	actual := checksum(data)
+	assert.Equal(t, expected, actual)
+}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -7,8 +7,24 @@ import (
 )
 
 func TestChecksumCRC32C(t *testing.T) {
-	data := []byte("hello world")
+	cases := []struct {
+		name  string
+		parts [][]byte
+	}{
+		{
+			name:  "single slice",
+			parts: [][]byte{[]byte("hello world")},
+		},
+		{
+			name:  "multiple slices",
+			parts: [][]byte{[]byte("hello"), []byte(" world")},
+		},
+	}
 	expected := uint32(0xc99465aa)
-	actual := checksum(data)
-	assert.Equal(t, expected, actual)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := checksum(tc.parts...)
+			assert.Equal(t, expected, actual)
+		})
+	}
 }

--- a/docs/dev/53/checksum_crc32c_plan.md
+++ b/docs/dev/53/checksum_crc32c_plan.md
@@ -1,0 +1,43 @@
+# CRC-32C Migration Plan
+
+## Objective
+Switch checksum calculations from streaming CRC-32 IEEE (`crc32.NewIEEE()`) to one-shot CRC-32C Castagnoli.
+
+## Plan
+1. **Introduce CRC-32C Table**
+   - Create a package-level lookup table so every checksum call can reuse it.
+   ```go
+   var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+   ```
+
+2. **Replace Streaming Hashers**
+   - Convert existing code that constructs a `crc32.NewIEEE()` hasher and writes to it in chunks.
+   - Instead, compute the checksum in one call using the table.
+   ```go
+   checksum := crc32.Checksum(buf, crc32cTable)
+   ```
+
+3. **Update Write Path**
+   - In modules like `io.go`, remove incremental writes and pass the full byte slice to `crc32.Checksum`.
+   - Return the resulting checksum as `uint32` without keeping a hasher state.
+   ```go
+   func checksum(b []byte) uint32 {
+       return crc32.Checksum(b, crc32cTable)
+   }
+   ```
+
+4. **Adjust Tests**
+   - Rewrite tests that previously fed data to the streaming hasher.
+   - Use one-shot calls and assert against precomputed CRC-32C values.
+   ```go
+   expected := uint32(0x8a9136aa)
+   actual := crc32.Checksum(data, crc32cTable)
+   require.Equal(t, expected, actual)
+   ```
+
+5. **Verify Build & Tests**
+   - Run `make check`, `make test`, and `make test-integration-smoke` to ensure the code compiles and behaves correctly.
+
+## Rollout Considerations
+- Review any interoperability requirements; CRC-32C differs from IEEE, so persisted data may need versioning.
+- Document the change so users know new checksums are CRC-32C.

--- a/docs/dev/53/checksum_crc32c_plan.md
+++ b/docs/dev/53/checksum_crc32c_plan.md
@@ -12,26 +12,30 @@ Switch checksum calculations from streaming CRC-32 IEEE (`crc32.NewIEEE()`) to o
 
 2. **Replace Streaming Hashers**
    - Convert existing code that constructs a `crc32.NewIEEE()` hasher and writes to it in chunks.
-   - Instead, compute the checksum in one call using the table.
+   - Instead, compute the checksum directly using `crc32.Update` with the CRC-32C table.
    ```go
-   checksum := crc32.Checksum(buf, crc32cTable)
+   sum := crc32.Update(0, crc32cTable, buf)
    ```
 
 3. **Update Write Path**
-   - In modules like `io.go`, remove incremental writes and pass the full byte slice to `crc32.Checksum`.
+   - In modules like `io.go`, remove incremental writes and pass slices to a helper that folds them with `crc32.Update`.
    - Return the resulting checksum as `uint32` without keeping a hasher state.
    ```go
-   func checksum(b []byte) uint32 {
-       return crc32.Checksum(b, crc32cTable)
+   func checksum(parts ...[]byte) uint32 {
+       var sum uint32
+       for _, p := range parts {
+           sum = crc32.Update(sum, crc32cTable, p)
+       }
+       return sum
    }
    ```
 
 4. **Adjust Tests**
    - Rewrite tests that previously fed data to the streaming hasher.
-   - Use one-shot calls and assert against precomputed CRC-32C values.
+   - Call the new helper with one or multiple slices and assert against precomputed CRC-32C values.
    ```go
    expected := uint32(0x8a9136aa)
-   actual := crc32.Checksum(data, crc32cTable)
+   actual := checksum([]byte("foo"), []byte("bar"))
    require.Equal(t, expected, actual)
    ```
 

--- a/io.go
+++ b/io.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"io"
 )
 
@@ -63,10 +62,7 @@ func ReadRecord(storage io.Reader) (Record, error) {
 		return nil, fmt.Errorf("failed to read checksum: %w", err)
 	}
 	expected := byteOrder.Uint32(checksumBytes[:])
-	hasher := crc32.NewIEEE()
-	_, _ = hasher.Write(internalKeyBytes)
-	_, _ = hasher.Write(valueBytes)
-	if actual := hasher.Sum32(); actual != expected {
+	if actual := checksum(internalKeyBytes, valueBytes); actual != expected {
 		return nil, ErrChecksumMismatch
 	}
 
@@ -91,10 +87,7 @@ func WriteRecord(tx *Transaction, record Record) error {
 	ikey := EncodeInternalKey(record.GetKey(), record.GetSequenceNumber(), record.GetType())
 	val := record.GetValue()
 
-	hasher := crc32.NewIEEE()
-	_, _ = hasher.Write(ikey)
-	_, _ = hasher.Write(val)
-	checksum := hasher.Sum32()
+	checksum := checksum(ikey, val)
 
 	if err := WriteNumber(tx, uint64(len(ikey))); err != nil {
 		return fmt.Errorf("failed to write internal key length: %w", err)

--- a/wal_test.go
+++ b/wal_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"testing"
 
@@ -70,10 +69,7 @@ func validateWALFormat(t *testing.T, file io.ReadSeeker) {
 		_, err = io.ReadFull(file, checksumBytes[:])
 		assert.NoError(t, err)
 		expected := byteOrder.Uint32(checksumBytes[:])
-		hasher := crc32.NewIEEE()
-		_, _ = hasher.Write(keyBytes)
-		_, _ = hasher.Write(valueBytes)
-		actual := hasher.Sum32()
+		actual := checksum(keyBytes, valueBytes)
 		assert.Equal(t, expected, actual)
 
 		_ = seq // silence unused warning if seq not used otherwise


### PR DESCRIPTION
## Summary
- add CRC-32C table and helper for one-shot checksums
- replace streaming CRC-32 with CRC-32C in record I/O and WAL tests
- verify CRC-32C output with a deterministic unit test

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b3b3e00f3c8325970a2be66476240f