### PR TITLE
Refactor persistence paths and manifest integration

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,6 +70,9 @@ type Config struct {
 
 	// newFileNumberAllocatorFunc constructs a FileNumberAllocator seeded with the given start.
 	newFileNumberAllocatorFunc func(start uint64) *FileNumberAllocator
+
+	// newManifestWriterFunc allows custom ManifestWriter initialization.
+	newManifestWriterFunc func(ctx context.Context, path string) (ManifestWriter, error)
 }
 
 // Option defines a functional option type for Config.
@@ -107,6 +110,7 @@ func DefaultConfig() Config {
 		newSSTableManagerFunc:      InitSSTableManager,
 		fileNumberAllocator:        NewFileNumberAllocator(1),
 		newFileNumberAllocatorFunc: NewFileNumberAllocator,
+		newManifestWriterFunc:      NewManifestWriter,
 	}
 }
 
@@ -165,6 +169,9 @@ func (c Config) Validate() {
 	}
 	if c.newFileNumberAllocatorFunc == nil {
 		panic("newFileNumberAllocatorFunc cannot be nil")
+	}
+	if c.newManifestWriterFunc == nil {
+		panic("newManifestWriterFunc cannot be nil")
 	}
 }
 
@@ -249,4 +256,9 @@ func WithFileNumberAllocator(a *FileNumberAllocator) Option {
 // WithNewFileNumberAllocatorFunc sets the constructor for FileNumberAllocator.
 func WithNewFileNumberAllocatorFunc(f func(start uint64) *FileNumberAllocator) Option {
 	return func(c *Config) { c.newFileNumberAllocatorFunc = f }
+}
+
+// WithNewManifestWriterFunc sets the constructor for ManifestWriter.
+func WithNewManifestWriterFunc(f func(ctx context.Context, path string) (ManifestWriter, error)) Option {
+	return func(c *Config) { c.newManifestWriterFunc = f }
 }

--- a/filepaths.go
+++ b/filepaths.go
@@ -1,6 +1,19 @@
 package rindb
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
 
 func walPath(num uint64) string { return fmt.Sprintf("%06d.wal", num) }
 func sstPath(num uint64) string { return fmt.Sprintf("%06d.sst", num) }
+
+// fileNum extracts the numeric identifier from a WAL or SSTable path.
+func fileNum(p string) (uint64, error) {
+	base := filepath.Base(p)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	return strconv.ParseUint(name, 10, 64)
+}

--- a/manifest.go
+++ b/manifest.go
@@ -131,20 +131,21 @@ func syncDir(dir string) error {
 }
 
 // recoverVersionSet rebuilds the VersionSet by replaying the MANIFEST.
-func recoverVersionSet(ctx context.Context, dir string) (*VersionSet, error) {
+func recoverVersionSet(ctx context.Context, dir string) (*VersionSet, string, error) {
 	vs := &VersionSet{}
 	curr := filepath.Join(dir, "CURRENT")
 	data, err := os.ReadFile(curr)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return vs, nil
+			return vs, "", nil
 		}
-		return nil, err
+		return nil, "", err
 	}
 	manifest := strings.TrimSpace(string(data))
-	r, err := NewManifestReader(ctx, filepath.Join(dir, manifest))
+	manifestPath := filepath.Join(dir, manifest)
+	r, err := NewManifestReader(ctx, manifestPath)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer r.Close()
 	for {
@@ -153,11 +154,11 @@ func recoverVersionSet(ctx context.Context, dir string) (*VersionSet, error) {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return nil, err
+			return nil, "", err
 		}
 		if err := edit.Apply(vs); err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	}
-	return vs, nil
+	return vs, manifestPath, nil
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -97,7 +97,7 @@ func TestManifest(t *testing.T) {
 		require.NoError(t, w.Close())
 		require.NoError(t, WriteCURRENT(ctx, dir, mf))
 
-		vs, err := recoverVersionSet(ctx, dir)
+		vs, _, err := recoverVersionSet(ctx, dir)
 		require.NoError(t, err)
 		require.Equal(t, seq, vs.LastSequence)
 	})
@@ -105,7 +105,7 @@ func TestManifest(t *testing.T) {
 	t.Run("RecoverVersionSetNoManifest", func(t *testing.T) {
 		ctx := context.Background()
 		dir := t.TempDir()
-		vs, err := recoverVersionSet(ctx, dir)
+		vs, _, err := recoverVersionSet(ctx, dir)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), vs.LastSequence)
 	})

--- a/range_test.go
+++ b/range_test.go
@@ -86,7 +86,7 @@ func TestIRangeCloseReleasesSSTables(t *testing.T) {
 
 	mem1 := InitMemtable(cfg)
 	mem1.Put(newRecord(Bytes("a"), Bytes("sstA"), 1))
-	sst1, err := flush(ctx, cfg, mem1, ts.newSSTableFS(0))
+	sst1, _, err := flush(ctx, cfg, mem1, ts.newSSTableFS(0))
 	assert.NoError(t, err)
 	ts.AddSSTableToLevel(0, &sst1)
 

--- a/rindb.go
+++ b/rindb.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,6 +24,7 @@ type Rindb struct {
 	memtable          Memtable
 	ssTableManager    *SSTableManager
 	versionSet        *VersionSet
+	manifest          ManifestWriter
 	config            Config
 	shutdownTelemetry func(context.Context) error
 	mu                sync.RWMutex   // Mutex for thread-safe access
@@ -89,10 +91,26 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 		return nil, fmt.Errorf("failed to create database directory %s: %w", cfg.databaseDir, err)
 	}
 
-	vs, err := recoverVersionSet(ctx, cfg.databaseDir)
+	vs, manifestPath, err := recoverVersionSet(ctx, cfg.databaseDir)
 	if err != nil {
 		return nil, err
 	}
+	if manifestPath == "" {
+		manifestFile := "MANIFEST-000001"
+		manifestPath = path.Join(cfg.databaseDir, manifestFile)
+		if err := WriteCURRENT(ctx, cfg.databaseDir, manifestFile); err != nil {
+			return nil, err
+		}
+	}
+	mw, err := cfg.newManifestWriterFunc(ctx, manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			_ = mw.Close()
+		}
+	}()
 	if vs.NextFileNumber == 0 {
 		vs.NextFileNumber = 1
 	}
@@ -143,6 +161,7 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 		memtable:          memtable,
 		ssTableManager:    ssTableManager,
 		versionSet:        vs,
+		manifest:          mw,
 		config:            cfg,
 		shutdownTelemetry: shutdownTelemetry,
 		sequenceNumber:    maxSeqNum,
@@ -338,7 +357,7 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			return fmt.Errorf("failed to create new SSTable file system: %w", err)
 		}
 
-		_, err = flush(ctx, r.config, r.memtable, fs)
+		_, meta, err := flush(ctx, r.config, r.memtable, fs)
 		if err != nil {
 			_ = fs.Close() // Attempt to close FS on flush error
 			ERROR(ctx, "Failed to flush memtable: %v", err)
@@ -349,6 +368,23 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 		if err := r.ssTableManager.AddSSTable(ctx, 0, fs); err != nil {
 			ERROR(ctx, "Failed to register new SSTable %s: %v", fs.Path(), err)
 			return fmt.Errorf("failed to register new SSTable %s: %w", fs.Path(), err)
+		}
+
+		edit := VersionEdit{
+			AddFiles:       []FileMeta{meta},
+			LastSequence:   r.sequenceNumber,
+			NextFileNumber: r.config.fileNumberAllocator.Peek(),
+		}
+		if err := r.manifest.Append(edit); err != nil {
+			ERROR(ctx, "Failed to append manifest edit: %v", err)
+			return err
+		}
+		if err := r.manifest.Sync(); err != nil {
+			ERROR(ctx, "Failed to sync manifest: %v", err)
+			return err
+		}
+		if err := edit.Apply(r.versionSet); err != nil {
+			return err
 		}
 
 		// Clear the memtable and clean the WAL *after* successful flush and registration
@@ -473,6 +509,12 @@ func (r *Rindb) Close() error {
 	// Assuming SSTableManager.Close() handles potential errors internally or returns them
 	r.ssTableManager.Close(ctx) // SSTableManager.Close currently doesn't return an error
 	INFO(ctx, "SSTableManager closed.")
+
+	if r.manifest != nil {
+		if err := r.manifest.Close(); err != nil {
+			ERROR(ctx, "Error closing manifest: %v", err)
+		}
+	}
 
 	if err := r.shutdownTelemetry(ctx); err != nil {
 		ERROR(ctx, "Error shutting down telemetry: %v", err)

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -75,7 +75,7 @@ func TestRindb_IRange(t *testing.T) {
 	mem1 := InitMemtable(cfg)
 	mem1.Put(newRecord(Bytes("a"), Bytes("sstA"), 1))
 	mem1.Put(newRecord(Bytes("b"), Bytes("sstB"), 2))
-	sst1, err := flush(ctx, cfg, mem1, ts.newSSTableFS(0))
+	sst1, _, err := flush(ctx, cfg, mem1, ts.newSSTableFS(0))
 	assert.NoError(t, err)
 	ts.AddSSTableToLevel(0, &sst1)
 
@@ -83,7 +83,7 @@ func TestRindb_IRange(t *testing.T) {
 	mem2 := InitMemtable(cfg)
 	mem2.Put(newRecord(Bytes("k"), nil, 3)) // tombstone
 	mem2.Put(newRecord(Bytes("z"), Bytes("sstZ"), 4))
-	sst2, err := flush(ctx, cfg, mem2, ts.newSSTableFS(0))
+	sst2, _, err := flush(ctx, cfg, mem2, ts.newSSTableFS(0))
 	assert.NoError(t, err)
 	ts.AddSSTableToLevel(0, &sst2)
 
@@ -226,7 +226,7 @@ func TestRindb_FlushMemtable(t *testing.T) {
 	newSSTableFS, err := rin.ssTableManager.NewSSTableFS(ctx, 0)
 	assert.NoError(t, err)
 	defer func() { _ = newSSTableFS.Close() }() // Ensure the FS used for flushing is closed
-	newSStable, err := flush(ctx, rin.config, rin.memtable, newSSTableFS)
+	newSStable, _, err := flush(ctx, rin.config, rin.memtable, newSSTableFS)
 	assert.NoError(t, err)
 	err = rin.wal.Clean(ctx, math.MaxUint64)
 	assert.NoError(t, err)
@@ -476,7 +476,7 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 		mem := InitMemtable(rin.config)
 		mem.Put(newRecord(Bytes("sk1"), Bytes("sv1"), 50))
 		mem.Put(newRecord(Bytes("sk2"), Bytes("sv2"), 60))
-		_, err = flush(ctx, rin.config, mem, fs)
+		_, _, err = flush(ctx, rin.config, mem, fs)
 		assert.NoError(t, err)
 		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, 0, fs))
 
@@ -514,7 +514,7 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 
 		mem := InitMemtable(rin.config)
 		mem.Put(newRecord(Bytes("sk1"), Bytes("sv1"), 70))
-		_, err = flush(ctx, rin.config, mem, fs)
+		_, _, err = flush(ctx, rin.config, mem, fs)
 		assert.NoError(t, err)
 		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, 0, fs))
 

--- a/sstable.go
+++ b/sstable.go
@@ -266,10 +266,11 @@ func (s SStable) MaxSequenceNumber() (uint64, error) {
 	return maxSeqNum, nil
 }
 
-func flush(ctx context.Context, config Config, mem Memtable, fs *FileSystem) (SStable, error) {
+func flush(ctx context.Context, config Config, mem Memtable, fs *FileSystem) (SStable, FileMeta, error) {
 	ctx, span := sstableTracer.Start(ctx, "flush")
 	start := time.Now()
 	var written int
+	var meta FileMeta
 	defer func() {
 		span.End()
 		flushLatency.Record(ctx, float64(time.Since(start).Milliseconds()))
@@ -285,29 +286,30 @@ func flush(ctx context.Context, config Config, mem Memtable, fs *FileSystem) (SS
 
 	builder, err := NewSSTableBuilder(ctx, config, fs, int(mem.data.Len()))
 	if err != nil {
-		return SStable{}, fmt.Errorf("failed to create sstable builder: %w", err)
+		return SStable{}, FileMeta{}, fmt.Errorf("failed to create sstable builder: %w", err)
 	}
 	defer builder.Close(ctx)
 
 	for r := mem.data.Head().Next(); r != nil; r = r.Next() {
 		if err := builder.Add(r.Value); err != nil {
-			return SStable{}, fmt.Errorf("failed to add record to builder: %w", err)
+			return SStable{}, FileMeta{}, fmt.Errorf("failed to add record to builder: %w", err)
 		}
 	}
 
 	var sst SStable
-	sst, written, err = builder.Build(ctx)
+	sst, meta, written, err = builder.Build(ctx)
 	if err != nil {
 		written = 0
-		return SStable{}, err
+		return SStable{}, FileMeta{}, err
 	}
+	meta.Level = 0
 	INFO(ctx, "Flushed memtable to SSTable at %s with %d entries", fs.Path(), mem.data.Len())
 
 	// after flushing memtable to file system successfully.
 	// memtable is supposed to be purged
 	mem.Clear()
 
-	return sst, nil
+	return sst, meta, nil
 }
 
 var _ Iterator[Record] = (*sstableIterator)(nil)

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -4,20 +4,25 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 )
 
 var ErrSSTableAlreadyBuilt = errors.New("SSTable already built")
 
 type SSTableBuilder struct {
-	tx      *Transaction
-	index   []KeyOffset
-	bloom   *BloomFilter
-	offset  int64
-	fs      *FileSystem
-	config  Config
-	built   bool
-	lastKey Bytes
-	lastSeq uint64
+	tx       *Transaction
+	index    []KeyOffset
+	bloom    *BloomFilter
+	offset   int64
+	fs       *FileSystem
+	config   Config
+	built    bool
+	lastKey  Bytes
+	lastSeq  uint64
+	smallest InternalKey
+	largest  InternalKey
+	seqLo    uint64
+	seqHi    uint64
 }
 
 func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem, expected int) (*SSTableBuilder, error) {
@@ -54,6 +59,7 @@ func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem, expected
 		offset: 0,
 		fs:     fs,
 		config: cfg,
+		seqLo:  math.MaxUint64,
 	}, nil
 }
 
@@ -76,6 +82,7 @@ func (b *SSTableBuilder) Add(rec Record) error {
 	if err := WriteRecord(b.tx, rec); err != nil {
 		return err
 	}
+	ik := InternalKey{UserKey: key.Clone(), Seq: seq, Type: rec.GetType()}
 	b.index = append(b.index, KeyOffset{key: key.Clone(), offset: b.offset})
 	if b.bloom != nil {
 		b.bloom.Insert(key)
@@ -83,15 +90,25 @@ func (b *SSTableBuilder) Add(rec Record) error {
 	b.offset += int64(CalOnDiskSize(rec))
 	b.lastKey = key.Clone()
 	b.lastSeq = seq
+	if len(b.index) == 1 {
+		b.smallest = ik
+	}
+	b.largest = ik
+	if seq < b.seqLo {
+		b.seqLo = seq
+	}
+	if seq > b.seqHi {
+		b.seqHi = seq
+	}
 	return nil
 }
 
-func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, written int, err error) {
+func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, meta FileMeta, written int, err error) {
 	if len(b.index) == 0 {
-		return SStable{}, 0, fmt.Errorf("no records to build")
+		return SStable{}, FileMeta{}, 0, fmt.Errorf("no records to build")
 	}
 	if b.built {
-		return SStable{}, 0, ErrSSTableAlreadyBuilt
+		return SStable{}, FileMeta{}, 0, ErrSSTableAlreadyBuilt
 	}
 
 	defer func() {
@@ -100,6 +117,7 @@ func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, written int, e
 				WARN(ctx, "failed to clean file system after error: %v", cleanErr)
 			}
 			sst = SStable{}
+			meta = FileMeta{}
 			written = 0
 		}
 	}()
@@ -139,6 +157,19 @@ func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, written int, e
 
 	b.built = true
 	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom}
+	num, nerr := fileNum(b.fs.Path())
+	if nerr != nil {
+		err = fmt.Errorf("invalid sstable path %s: %w", b.fs.Path(), nerr)
+		return
+	}
+	meta = FileMeta{
+		Number:   num,
+		Smallest: b.smallest,
+		Largest:  b.largest,
+		Size:     uint64(written),
+		SeqLo:    b.seqLo,
+		SeqHi:    b.seqHi,
+	}
 	return
 }
 

--- a/sstable_builder_test.go
+++ b/sstable_builder_test.go
@@ -22,7 +22,7 @@ func TestSSTableBuilder(t *testing.T) {
 		builder, err := NewSSTableBuilder(ctx, cfg, fs, 0)
 		assert.NoError(t, err)
 
-		_, _, err = builder.Build(ctx)
+		_, _, _, err = builder.Build(ctx)
 		assert.EqualError(t, err, "no records to build")
 	})
 
@@ -44,7 +44,7 @@ func TestSSTableBuilder(t *testing.T) {
 			assert.NoError(t, builder.Add(r))
 		}
 
-		sst, _, err := builder.Build(ctx)
+		sst, _, _, err := builder.Build(ctx)
 		assert.NoError(t, err)
 
 		var offset int64
@@ -85,7 +85,7 @@ func TestSSTableBuilder(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
 
-		_, written, err := builder.Build(ctx)
+		_, _, written, err := builder.Build(ctx)
 		assert.NoError(t, err)
 
 		info, err := os.Stat(fs.Path())
@@ -106,7 +106,7 @@ func TestSSTableBuilder(t *testing.T) {
 		rec := newRecord(Bytes("a"), Bytes("1"), 1)
 		assert.NoError(t, builder.Add(rec))
 
-		_, _, err = builder.Build(ctx)
+		_, _, _, err = builder.Build(ctx)
 		assert.NoError(t, err)
 
 		t.Run("AddAfterBuild", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestSSTableBuilder(t *testing.T) {
 		})
 
 		t.Run("BuildTwice", func(t *testing.T) {
-			_, _, err := builder.Build(ctx)
+			_, _, _, err := builder.Build(ctx)
 			assert.ErrorIs(t, err, ErrSSTableAlreadyBuilt)
 		})
 	})
@@ -140,7 +140,7 @@ func TestSSTableBuilder(t *testing.T) {
 
 		require.NoError(t, builder.Add(newRecord(Bytes("a"), Bytes("1"), 1)))
 
-		_, _, err = builder.Build(ctx)
+		_, _, _, err = builder.Build(ctx)
 		require.Error(t, err)
 
 		info, statErr := os.Stat(path)

--- a/sstable_files.go
+++ b/sstable_files.go
@@ -1,0 +1,25 @@
+package rindb
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// removeFiles deletes SSTable files corresponding to the given metadata.
+// It ignores missing files and returns the first encountered error.
+func removeFiles(dir string, files []FileMeta) error {
+	var first error
+	for _, f := range files {
+		p := filepath.Join(dir, sstPath(f.Number))
+		if err := os.Remove(p); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			if first == nil {
+				first = err
+			}
+		}
+	}
+	return first
+}

--- a/sstable_files_test.go
+++ b/sstable_files_test.go
@@ -1,0 +1,28 @@
+package rindb
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveFiles(t *testing.T) {
+	dir := t.TempDir()
+	paths := []string{
+		filepath.Join(dir, sstPath(1)),
+		filepath.Join(dir, sstPath(2)),
+	}
+	for _, p := range paths {
+		f, err := os.Create(p)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+	}
+	files := []FileMeta{{Number: 1}, {Number: 2}, {Number: 3}}
+	require.NoError(t, removeFiles(dir, files))
+	for _, p := range paths {
+		_, err := os.Stat(p)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	}
+}

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -22,7 +22,7 @@ func TestSStable(t *testing.T) {
 		defer closer()
 		fs := fss[0]
 		mem := InitMemtable(cfg)
-		_, err := flush(context.Background(), cfg, mem, fs)
+		_, _, err := flush(context.Background(), cfg, mem, fs)
 		assert.NoError(t, err)
 	})
 	t.Run("FlushWithElements", func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestSStable(t *testing.T) {
 		for i, v := range data {
 			mem.Put(newRecord(v.key, v.value, uint64(i)))
 		}
-		sstable, err := flush(ctx, cfg, mem, fs)
+		sstable, _, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
 		tailSSTableOffset, err := readTailSSTable(sstable.FileSystem)
 		assert.NoError(t, err)
@@ -84,7 +84,7 @@ func TestSStable(t *testing.T) {
 		mem.Put(newRecord(Bytes("2"), Bytes("3"), 1))
 		mem.Put(newRecord(Bytes("1"), Bytes("2"), 2))
 		mem.Put(newRecord(Bytes("3"), Bytes("4"), 3))
-		sstable1, err := flush(ctx, cfg, mem, fs)
+		sstable1, _, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
 		sstable2, err := NewSSTable(ctx, cfg, fs)
 		assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestSStable(t *testing.T) {
 		mem.Put(newRecord(Bytes("2"), Bytes("3"), 1))
 		mem.Put(newRecord(Bytes("1"), Bytes("2"), 2))
 		mem.Put(newRecord(Bytes("3"), Bytes("4"), 3))
-		_, err := flush(ctx, cfg, mem, fs)
+		_, _, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
 		sstable, err := NewSSTable(ctx, cfg, fs)
 		assert.NoError(t, err)
@@ -122,7 +122,7 @@ func TestSStable(t *testing.T) {
 		mem.Put(newRecord(Bytes("1"), Bytes("2"), 2))
 		mem.Put(newRecord(Bytes("3"), Bytes("4"), 3))
 		assert.Equal(t, uint(3), mem.data.Len())
-		sstable, err := flush(ctx, cfg, mem, fs)
+		sstable, _, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
 		assert.Equal(t, uint(0), mem.data.Len())
 		value, err := sstable.GetValue(ctx, Bytes("2"))
@@ -146,7 +146,7 @@ func TestSStable(t *testing.T) {
 		mem := InitMemtable(cfg)
 		mem.Put(newRecord(Bytes("a"), Bytes("old"), 1))
 		mem.Put(newRecord(Bytes("a"), Bytes("new"), 2))
-		sstable, err := flush(ctx, cfg, mem, fs)
+		sstable, _, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
 		value, err := sstable.GetValue(ctx, Bytes("a"), 1)
 		assert.NoError(t, err)
@@ -163,7 +163,7 @@ func TestSStable(t *testing.T) {
 		mem.Put(newRecord(Bytes("2"), Bytes("3"), 1))
 		mem.Put(newRecord(Bytes("1"), Bytes("2"), 2))
 		mem.Put(newRecord(Bytes("3"), Bytes("4"), 3))
-		sstable, err := flush(context.Background(), cfg, mem, fs)
+		sstable, _, err := flush(context.Background(), cfg, mem, fs)
 		assert.NoError(t, err)
 		iterator, err := sstable.Iterator()
 		assert.NoError(t, err)
@@ -209,7 +209,7 @@ func TestSStable(t *testing.T) {
 		for i, v := range data {
 			mem.Put(newRecord(v.key, v.value, uint64(i)))
 		}
-		sstable, err := flush(context.Background(), cfg, mem, fs)
+		sstable, _, err := flush(context.Background(), cfg, mem, fs)
 		assert.NoError(t, err)
 
 		tests := []struct {
@@ -467,7 +467,7 @@ func TestFlushWithTombstones(t *testing.T) {
 	mem := InitMemtable(cfg)
 	mem.Put(newRecord(k1, Bytes("v1"), 1))
 	mem.Put(newRecord(k2, nil, 2))
-	sstable, err := flush(ctx, cfg, mem, fs)
+	sstable, _, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
 	v1, err := sstable.GetValue(ctx, k1)
 	assert.NoError(t, err)
@@ -486,7 +486,7 @@ func TestBloomFilterSkipsReads(t *testing.T) {
 	fs := fss[0]
 	mem := InitMemtable(cfg)
 	mem.Put(newRecord(Bytes("k1"), Bytes("v1"), 2))
-	sstable, err := flush(ctx, cfg, mem, fs)
+	sstable, _, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
 	posBefore, err := fs.CursorPos()
 	assert.NoError(t, err)
@@ -507,7 +507,7 @@ func TestSStableChecksumMismatch(t *testing.T) {
 	mem := InitMemtable(cfg)
 	rec := newRecord(Bytes("a"), Bytes("1"), 1)
 	mem.Put(rec)
-	sstable, err := flush(ctx, cfg, mem, fs)
+	sstable, _, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
 
 	offset := int64(CalOnDiskSize(rec)) - checksumSize

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -596,10 +596,17 @@ func (h *SSTableManager) mergeSSTables(ctx context.Context, newLevelNumb int, pi
 	}
 	h.levels[newLevelNumb].PushBack(newLevelSSTable)
 
+	var dels []FileMeta
 	for _, sstable := range pickedUpSSTable {
-		if err := os.Remove(sstable.Path()); err != nil {
-			ERROR(ctx, "Error removing file %s: %v", sstable.Path(), err)
+		num, nerr := fileNum(sstable.Path())
+		if nerr != nil {
+			ERROR(ctx, "Error parsing file number for %s: %v", sstable.Path(), nerr)
+			continue
 		}
+		dels = append(dels, FileMeta{Number: num})
+	}
+	if err := removeFiles(h.config.databaseDir, dels); err != nil {
+		ERROR(ctx, "Error removing files: %v", err)
 	}
 	return nil
 }
@@ -904,7 +911,7 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 		return nil, nil
 	}
 
-	sst, _, err := builder.Build(ctx)
+	sst, _, _, err := builder.Build(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1498,13 +1498,13 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		mem1 := InitMemtable(*ts.Config)
 		mem1.Put(newRecord(Bytes("a"), Bytes("1"), 1))
 		mem1.Put(newRecord(Bytes("b"), Bytes("2"), 2))
-		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		sst1, _, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem2 := InitMemtable(*ts.Config)
 		mem2.Put(newRecord(Bytes("b"), nil, 3))
 		mem2.Put(newRecord(Bytes("c"), Bytes("3"), 4))
-		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
@@ -1537,13 +1537,13 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		mem1 := InitMemtable(*ts.Config)
 		mem1.Put(newRecord(Bytes("a"), Bytes("1"), 1))
 		mem1.Put(newRecord(Bytes("b"), Bytes("2"), 2))
-		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		sst1, _, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem2 := InitMemtable(*ts.Config)
 		mem2.Put(newRecord(Bytes("b"), nil, 3))
 		mem2.Put(newRecord(Bytes("c"), Bytes("3"), 4))
-		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
@@ -1575,17 +1575,17 @@ func Test_mergeSSTablesV2(t *testing.T) {
 
 		mem1 := InitMemtable(*ts.Config)
 		mem1.Put(newRecord(Bytes("b"), Bytes("v1"), 1))
-		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		sst1, _, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem2 := InitMemtable(*ts.Config)
 		mem2.Put(newRecord(Bytes("b"), Bytes("v2"), 2))
-		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem3 := InitMemtable(*ts.Config)
 		mem3.Put(newRecord(Bytes("b"), nil, 3))
-		sst3, err := flush(ctx, *ts.Config, mem3, ts.newSSTableFS(0))
+		sst3, _, err := flush(ctx, *ts.Config, mem3, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
@@ -1619,17 +1619,17 @@ func Test_mergeSSTablesV2(t *testing.T) {
 
 		mem1 := InitMemtable(*ts.Config)
 		mem1.Put(newRecord(Bytes("b"), Bytes("v1"), 1))
-		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		sst1, _, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem2 := InitMemtable(*ts.Config)
 		mem2.Put(newRecord(Bytes("b"), Bytes("v2"), 2))
-		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem3 := InitMemtable(*ts.Config)
 		mem3.Put(newRecord(Bytes("b"), nil, 3))
-		sst3, err := flush(ctx, *ts.Config, mem3, ts.newSSTableFS(0))
+		sst3, _, err := flush(ctx, *ts.Config, mem3, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
@@ -1665,7 +1665,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 
 		mem := InitMemtable(*ts.Config)
 		mem.Put(newRecord(Bytes("a"), nil, 1))
-		sst, err := flush(ctx, *ts.Config, mem, ts.newSSTableFS(0))
+		sst, _, err := flush(ctx, *ts.Config, mem, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
@@ -1681,7 +1681,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 
 		mem := InitMemtable(*ts.Config)
 		mem.Put(newRecord(Bytes("a"), Bytes("1"), 1))
-		sst, err := flush(ctx, *ts.Config, mem, ts.newSSTableFS(0))
+		sst, _, err := flush(ctx, *ts.Config, mem, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS(1)
@@ -1706,13 +1706,13 @@ func TestSSTableManager_mergeSSTables(t *testing.T) {
 		mem1 := InitMemtable(*ts.Config)
 		mem1.Put(newRecord(Bytes("a"), Bytes("1"), 1))
 		mem1.Put(newRecord(Bytes("b"), Bytes("2"), 2))
-		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		sst1, _, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem2 := InitMemtable(*ts.Config)
 		mem2.Put(newRecord(Bytes("b"), nil, 3))
 		mem2.Put(newRecord(Bytes("c"), Bytes("3"), 4))
-		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		_, err = os.Stat(sst1.Path())
@@ -1760,12 +1760,12 @@ func TestSSTableManager_mergeSSTables(t *testing.T) {
 
 		mem1 := InitMemtable(*ts.Config)
 		mem1.Put(newRecord(Bytes("b"), Bytes("1"), 1))
-		sst1, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		sst1, _, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		mem2 := InitMemtable(*ts.Config)
 		mem2.Put(newRecord(Bytes("b"), nil, 3))
-		sst2, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
 		ts.Manager.mu.Lock()

--- a/utils_test.go
+++ b/utils_test.go
@@ -174,7 +174,7 @@ func (ts *testRindbSetup) createSSTable(level int, kvs map[string]string) *SStab
 		seqNum++
 		mem.Put(newRecord(Bytes(k), Bytes(v), seqNum))
 	}
-	sstable, err := flush(context.Background(), *ts.Config, mem, fs)
+	sstable, _, err := flush(context.Background(), *ts.Config, mem, fs)
 	assert.NoError(ts.T, err)
 	return &sstable
 }
@@ -188,7 +188,7 @@ func (ts *testRindbSetup) createSSTableWithSequence(level int, kvs map[string]st
 		mem.Put(newRecord(Bytes(k), Bytes(v), seqNum))
 		seqNum++
 	}
-	sstable, err := flush(context.Background(), *ts.Config, mem, fs)
+	sstable, _, err := flush(context.Background(), *ts.Config, mem, fs)
 	assert.NoError(ts.T, err)
 	return &sstable
 }
@@ -222,7 +222,8 @@ func initTempFileSystems(t *testing.T, n int, initialContents [][]byte) ([]*File
 	fss := make([]*FileSystem, 0, n)
 	tempDir := t.TempDir()
 	for i := 0; i < n; i++ {
-		fs, err := OpenFS(context.Background(), fmt.Sprintf("%s/test-%d", tempDir, i))
+		name := sstPath(uint64(i + 1))
+		fs, err := OpenFS(context.Background(), fmt.Sprintf("%s/%s", tempDir, name))
 		assert.NoError(t, err)
 
 		// Write initial content if provided for this index
@@ -281,7 +282,7 @@ func populateMemtable(cfg Config, pairs ...[2]Bytes) Memtable {
 func createSSTable(t *testing.T, cfg Config, fs *FileSystem, pairs ...[2]Bytes) SStable {
 	t.Helper() // Mark this as a test helper function
 	mem := populateMemtable(cfg, pairs...)
-	sstable, err := flush(context.Background(), cfg, mem, fs)
+	sstable, _, err := flush(context.Background(), cfg, mem, fs)
 	assert.NoError(t, err, "Failed to flush memtable to create SSTable")
 	return sstable
 }

--- a/wal.go
+++ b/wal.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"sync/atomic"
@@ -23,7 +24,23 @@ type WAL struct {
 
 // DefaultNewWALFunc provides the default WAL initialization logic.
 func DefaultNewWALFunc(ctx context.Context, cfg Config) (*WAL, error) {
-	id := cfg.fileNumberAllocator.Next()
+	// Attempt to reuse the highest-numbered WAL if it exists.
+	entries, err := os.ReadDir(cfg.databaseDir)
+	var maxID uint64
+	if err == nil {
+		for _, e := range entries {
+			name := e.Name()
+			if strings.HasSuffix(name, ".wal") {
+				if n, nerr := fileNum(name); nerr == nil && n > maxID {
+					maxID = n
+				}
+			}
+		}
+	}
+	id := maxID
+	if id == 0 {
+		id = cfg.fileNumberAllocator.Next()
+	}
 	wp := path.Join(cfg.databaseDir, walPath(id))
 	fs, err := OpenFS(ctx, wp)
 	if err != nil {

--- a/wal.go
+++ b/wal.go
@@ -26,14 +26,16 @@ type WAL struct {
 func DefaultNewWALFunc(ctx context.Context, cfg Config) (*WAL, error) {
 	// Attempt to reuse the highest-numbered WAL if it exists.
 	entries, err := os.ReadDir(cfg.databaseDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read database directory %s: %w", cfg.databaseDir, err)
+	}
+
 	var maxID uint64
-	if err == nil {
-		for _, e := range entries {
-			name := e.Name()
-			if strings.HasSuffix(name, ".wal") {
-				if n, nerr := fileNum(name); nerr == nil && n > maxID {
-					maxID = n
-				}
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasSuffix(name, ".wal") {
+			if n, nerr := fileNum(name); nerr == nil && n > maxID {
+				maxID = n
 			}
 		}
 	}

--- a/wal_test.go
+++ b/wal_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -169,6 +171,18 @@ func TestWALCrashRecovery(t *testing.T) {
 	v2, err := mem.Get(k2)
 	assert.NoError(t, err)
 	assert.Equal(t, Bytes("v2"), v2)
+}
+
+func TestDefaultNewWALFunc_ReadDirError(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "notadir")
+	assert.NoError(t, os.WriteFile(file, []byte(""), 0o644))
+
+	cfg := testConfig()
+	cfg.databaseDir = file
+
+	_, err := DefaultNewWALFunc(context.Background(), cfg)
+	assert.Error(t, err)
 }
 
 // TestWALCrashRecovery_PartialWrite tests WAL recovery after a crash during a partial write.


### PR DESCRIPTION
## Summary
- centralize persistence file naming and expose file number parser
- extend SSTableBuilder to emit FileMeta and track key/sequence bounds
- integrate manifest writer and record flushes via VersionEdit
- add helper to remove SSTable files by metadata
- reuse existing WAL on startup to preserve unflushed data

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b3e08e3b94832581342d30e519cde1