### PR TITLE
fix: delay sstable deletion until metadata is persisted

### DIFF
--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -658,9 +658,6 @@ func (h *SSTableManager) mergeSSTables(ctx context.Context, newLevelNumb int, pi
 			delMetas = append(delMetas, DeletedFileMeta{Level: level, Number: num})
 		}
 	}
-	if err := removeFiles(h.config.databaseDir, dels); err != nil {
-		ERROR(ctx, "Error removing files: %v", err)
-	}
 
 	meta.Level = newLevelNumb
 	edit := VersionEdit{
@@ -678,6 +675,10 @@ func (h *SSTableManager) mergeSSTables(ctx context.Context, newLevelNumb int, pi
 	}
 	if err := edit.Apply(h.versionSet); err != nil {
 		return err
+	}
+
+	if err := removeFiles(h.config.databaseDir, dels); err != nil {
+		ERROR(ctx, "Error removing files: %v", err)
 	}
 
 	return nil

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -15,6 +15,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type failingManifestWriter struct{}
+
+func (f failingManifestWriter) Append(VersionEdit) error { return fmt.Errorf("append fail") }
+func (f failingManifestWriter) Sync() error              { return nil }
+func (f failingManifestWriter) Close() error             { return nil }
+
 func TestSSTableManager_LoadLevels(t *testing.T) {
 	cfg := testConfig()
 	t.Run("LoadLevels validates file names", func(t *testing.T) {
@@ -1627,6 +1633,34 @@ func TestSSTableManager_mergeSSTables(t *testing.T) {
 		assert.Error(t, err)
 		_, err = os.Stat(sst2.Path())
 		assert.Error(t, err)
+	})
+
+	t.Run("retains sources on manifest failure", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		mem1 := InitMemtable(*ts.Config)
+		mem1.Put(newRecord(Bytes("a"), Bytes("1"), 1))
+		sst1, _, err := flush(ctx, *ts.Config, mem1, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		mem2 := InitMemtable(*ts.Config)
+		mem2.Put(newRecord(Bytes("b"), Bytes("2"), 2))
+		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
+		assert.NoError(t, err)
+
+		ts.Manager.manifest = failingManifestWriter{}
+
+		ts.Manager.mu.Lock()
+		err = ts.Manager.mergeSSTables(ctx, 1, []SStable{sst1, sst2})
+		ts.Manager.mu.Unlock()
+		assert.Error(t, err)
+
+		_, err = os.Stat(sst1.Path())
+		assert.NoError(t, err)
+		_, err = os.Stat(sst2.Path())
+		assert.NoError(t, err)
 	})
 
 	t.Run("keeps tombstone with active snapshot", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- move SSTable cleanup until after manifest sync and version set update
- add test ensuring source SSTables remain if manifest update fails

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b53379cd488325aef2a6167aa732cf