### PR TITLE
fix: avoid recreating missing sstables

### DIFF
--- a/filesystem.go
+++ b/filesystem.go
@@ -32,6 +32,15 @@ func OpenFS(ctx context.Context, filePath string) (*FileSystem, error) {
 	return fs, nil
 }
 
+// OpenExistingFS opens a file system for an existing file without creating it if missing.
+func OpenExistingFS(ctx context.Context, filePath string) (*FileSystem, error) {
+	fs := &FileSystem{filePath: filePath}
+	if err := fs.OpenExisting(ctx); err != nil {
+		return nil, err
+	}
+	return fs, nil
+}
+
 func NewFS(file *os.File) *FileSystem {
 	return &FileSystem{filePath: file.Name(), file: file}
 }
@@ -52,6 +61,25 @@ func (fs *FileSystem) Open(ctx context.Context) error {
 	}
 
 	file, err := os.OpenFile(filepath.Clean(fs.filePath), os.O_RDWR|os.O_CREATE, fileSystemPermission)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s: %w", fs.filePath, err)
+	}
+	fs.file = file
+	return nil
+}
+
+// OpenExisting opens the file system assuming the file already exists.
+// It returns an error if the file does not exist.
+func (fs *FileSystem) OpenExisting(ctx context.Context) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if fs.file != nil {
+		WARN(ctx, "File %s is already opened. Consider close and re-open again", fs.Path())
+		return nil
+	}
+
+	file, err := os.OpenFile(filepath.Clean(fs.filePath), os.O_RDWR, fileSystemPermission)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", fs.filePath, err)
 	}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -151,5 +152,34 @@ func TestFileSystem_CursorPos(t *testing.T) {
 		position, err := fs.CursorPos()
 		assert.NoError(t, err)
 		assert.Equal(t, int64(5), position)
+	})
+}
+
+func TestOpenExistingFS(t *testing.T) {
+	t.Run("missing file returns error and remains absent", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "missing.sst")
+
+		fs, err := OpenExistingFS(ctx, filePath)
+		assert.Error(t, err)
+		assert.Nil(t, fs)
+
+		_, statErr := os.Stat(filePath)
+		assert.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("opens existing file", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "existing.sst")
+		f, err := os.Create(filePath)
+		assert.NoError(t, err)
+		assert.NoError(t, f.Close())
+
+		fs, err := OpenExistingFS(ctx, filePath)
+		assert.NoError(t, err)
+		assert.NotNil(t, fs)
+		assert.NoError(t, fs.Close())
 	})
 }

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -588,7 +588,7 @@ func (h *SSTableManager) openByNumber(ctx context.Context, num uint64) (*SStable
 	}
 
 	path := path.Join(h.config.databaseDir, sstPath(num))
-	fs, err := OpenFS(ctx, path)
+	fs, err := OpenExistingFS(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -752,21 +752,39 @@ func (h *SSTableManager) findLevel(num uint64) int {
 func (h *SSTableManager) searchKey(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
 	maxSeq := getMaxSeq(seq...)
 
-	nums := h.GetRelevantSSTables(ctx, key, key)
-	for _, num := range nums {
-		sst, err := h.openByNumber(ctx, num)
-		if err != nil {
-			continue
+	// Compaction may remove SSTables while a lookup is in progress. If we
+	// encounter a missing file, retry the search with a fresh view of the
+	// levels to pick up the replacement SSTables. A small retry budget keeps
+	// us from looping indefinitely in pathological cases.
+	const maxRetries = 2
+
+	for retries := 0; retries <= maxRetries; retries++ {
+		nums := h.GetRelevantSSTables(ctx, key, key)
+		missing := false
+		for _, num := range nums {
+			sst, err := h.openByNumber(ctx, num)
+			if err != nil {
+				WARN(ctx, "Failed to open SSTable %d: %v", num, err)
+				if errors.Is(err, os.ErrNotExist) {
+					// SSTable was removed, likely due to a concurrent compaction.
+					missing = true
+					break
+				}
+				continue
+			}
+			val, err := sst.GetValue(ctx, key, maxSeq)
+			if err == nil {
+				return val, nil
+			}
+			if errors.Is(err, ErrTombstoneFound) {
+				return nil, ErrKeyNotFound
+			}
+			if !errors.Is(err, ErrKeyNotFound) {
+				return nil, err
+			}
 		}
-		val, err := sst.GetValue(ctx, key, maxSeq)
-		if err == nil {
-			return val, nil
-		}
-		if errors.Is(err, ErrTombstoneFound) {
+		if !missing {
 			return nil, ErrKeyNotFound
-		}
-		if !errors.Is(err, ErrKeyNotFound) {
-			return nil, err
 		}
 	}
 	return nil, ErrKeyNotFound

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -27,6 +27,7 @@ const writeRateAlpha = 0.2
 // - Manages file handles for SSTables
 // - Coordinates concurrent access with read/write locks
 type SSTableManager struct {
+	openedFsMu  sync.Mutex
 	openedFs    map[*FileSystem]struct{} // legacy tracking for compaction paths
 	openedByNum map[uint64]*SStable      // open SSTables keyed by file number
 	levels      []*LinkedList[*FileSystem]
@@ -74,7 +75,9 @@ func (h *SSTableManager) openAndLoadSSTable(ctx context.Context, fs *FileSystem)
 		_ = fs.Close() // Ensure file is closed on SSTable creation error
 		return nil, fmt.Errorf("failed to create sstable object for %s: %w", fs.Path(), err)
 	}
+	h.openedFsMu.Lock()
 	h.openedFs[fs] = struct{}{} // Track opened file system
+	h.openedFsMu.Unlock()
 	return &sstable, nil
 }
 
@@ -266,7 +269,9 @@ func (h *SSTableManager) NewSSTableFS(ctx context.Context, levelNumb int) (*File
 		return nil, err
 	}
 
+	h.openedFsMu.Lock()
 	h.openedFs[fs] = struct{}{}
+	h.openedFsMu.Unlock()
 	return fs, nil
 }
 
@@ -277,6 +282,7 @@ func (h *SSTableManager) Close(ctx context.Context) {
 	}
 
 	h.mu.Lock()
+	h.openedFsMu.Lock()
 	sstablesToClose := make([]*SStable, 0, len(h.openedByNum))
 	for _, s := range h.openedByNum {
 		sstablesToClose = append(sstablesToClose, s)
@@ -307,6 +313,7 @@ func (h *SSTableManager) Close(ctx context.Context) {
 		}
 	}
 	h.openedFs = make(map[*FileSystem]struct{})
+	h.openedFsMu.Unlock()
 	h.mu.Unlock()
 
 	for _, s := range sstablesToClose {
@@ -568,7 +575,9 @@ func (h *SSTableManager) closeSSTables(sstables []SStable) {
 }
 
 func (h *SSTableManager) removeOpenedFS(target *FileSystem) {
+	h.openedFsMu.Lock()
 	delete(h.openedFs, target)
+	h.openedFsMu.Unlock()
 }
 
 // openByNumber returns an opened SSTable for the given file number. The

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -482,6 +482,28 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		assert.ErrorIs(t, err, ErrKeyNotFound)
 		assert.Nil(t, result)
 	})
+
+	t.Run("Missing SSTable is not recreated", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		key := Bytes("lost-key")
+		value := Bytes("lost-value")
+		sst := ts.createSSTable(0, map[string]string{string(key): string(value)})
+		ts.AddSSTableToLevel(0, sst)
+
+		path := sst.Path()
+		err := os.Remove(path)
+		assert.NoError(t, err)
+
+		result, err := ts.Manager.searchKey(ctx, key)
+		assert.ErrorIs(t, err, ErrKeyNotFound)
+		assert.Nil(t, result)
+
+		_, statErr := os.Stat(path)
+		assert.True(t, os.IsNotExist(statErr))
+	})
 }
 
 func TestSSTableManager_CompactThreshold(t *testing.T) {


### PR DESCRIPTION
## Summary
- add OpenExistingFS to open files without creating them
- use OpenExistingFS in SSTableManager and log missing SSTable errors
- retry searchKey when SSTables disappear during compaction
- add regression tests for missing SSTables and OpenExistingFS

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`
- `go test -tags=integration ./integration -run TestConcurrentPutGet -v -count=10`


------
https://chatgpt.com/codex/tasks/task_e_68b53def407c8325a1f19e3d7b36a35d