### PR TITLE
feat: add repair mode option and conditional level loading

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,6 +18,10 @@ type Config struct {
 	// databaseDir specifies the directory where WAL and SSTables are stored
 	databaseDir string
 
+	// repairMode forces a full directory scan of SSTables during startup,
+	// bypassing the manifest's VersionSet.
+	repairMode bool
+
 	// maxMemtableSize triggers memtable flush to SSTable when this number of entries is reached
 	maxMemtableSize uint
 
@@ -115,6 +119,7 @@ func DefaultConfig() Config {
 		fileNumberAllocator:        NewFileNumberAllocator(1),
 		newFileNumberAllocatorFunc: NewFileNumberAllocator,
 		newManifestWriterFunc:      NewManifestWriter,
+		repairMode:                 false,
 	}
 }
 
@@ -186,6 +191,10 @@ func WithConfig(cfg Config) Option {
 // Option functions
 func WithDatabaseDir(dir string) Option {
 	return func(c *Config) { c.databaseDir = dir }
+}
+
+func WithRepairMode(v bool) Option {
+	return func(c *Config) { c.repairMode = v }
 }
 
 func WithMaxMemtableSize(size uint) Option {

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,7 @@ func TestDefaultConfig(t *testing.T) {
 		{"level0CompactionThreshold", cfg.level0CompactionThreshold, 2},
 		{"baseCompactionSizeMB", cfg.baseCompactionSizeMB, 10},
 		{"levelSizeMultiplier", cfg.levelSizeMultiplier, 10},
+		{"repairMode", cfg.repairMode, false},
 		{"bloomFalsePositiveRate", cfg.bloomFalsePositiveRate, 0.01},
 		{"skipListDefaultLevel", cfg.skipListDefaultLevel, uint(2)},
 		{"skipListMaxLevel", cfg.skipListMaxLevel, uint(32)},
@@ -49,6 +50,15 @@ func TestNewConfigWithOptions(t *testing.T) {
 			verify: func(t *testing.T, cfg Config) {
 				if cfg.databaseDir != "/custom/path" {
 					t.Errorf("databaseDir = %v, want %v", cfg.databaseDir, "/custom/path")
+				}
+			},
+		},
+		{
+			name: "WithRepairMode",
+			opts: []Option{WithRepairMode(true)},
+			verify: func(t *testing.T, cfg Config) {
+				if !cfg.repairMode {
+					t.Errorf("repairMode = %v, want %v", cfg.repairMode, true)
 				}
 			},
 		},

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -504,9 +504,13 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 		mem := InitMemtable(rin.config)
 		mem.Put(newRecord(Bytes("sk1"), Bytes("sv1"), 50))
 		mem.Put(newRecord(Bytes("sk2"), Bytes("sv2"), 60))
-		_, _, err = flush(ctx, rin.config, mem, fs)
+		_, meta, err := flush(ctx, rin.config, mem, fs)
 		assert.NoError(t, err)
 		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, 0, fs))
+		edit := VersionEdit{AddFiles: []FileMeta{meta}, LastSequence: meta.SeqHi}
+		assert.NoError(t, rin.manifest.Append(edit))
+		assert.NoError(t, rin.manifest.Sync())
+		assert.NoError(t, edit.Apply(rin.versionSet))
 
 		// Also create a WAL with a lower sequence number to ensure SSTable takes precedence
 		wp := path.Join(rin.config.databaseDir, walPath(1))

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -107,8 +107,24 @@ func InitSSTableManager(ctx context.Context, config Config, vs *VersionSet, mw M
 		},
 	}
 
-	if err := h.LoadLevels(config.databaseDir); err != nil {
-		return nil, err
+	if config.repairMode {
+		if err := h.LoadLevels(config.databaseDir); err != nil {
+			return nil, err
+		}
+	} else if vs != nil {
+		levels := make([]*LinkedList[*FileSystem], len(vs.Levels))
+		for lvl, files := range vs.Levels {
+			if len(files) == 0 {
+				continue
+			}
+			ll := InitLinkedList[*FileSystem]()
+			for _, f := range files {
+				fs := &FileSystem{filePath: path.Join(config.databaseDir, sstPath(f.Number))}
+				ll.PushBack(fs)
+			}
+			levels[lvl] = ll
+		}
+		h.levels = levels
 	}
 
 	h.ioSamplerWG.Add(1)

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -63,6 +63,48 @@ func TestSSTableManager_LoadLevels(t *testing.T) {
 	})
 }
 
+func TestInitSSTableManagerRepairMode(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Create two SSTable files on disk.
+	createDummyFile(t, dir, sstPath(1), 1)
+	createDummyFile(t, dir, sstPath(2), 1)
+
+	vs := &VersionSet{Levels: [][]FileMeta{{{Number: 1, Level: 0}}}}
+
+	cfg := testConfig()
+	cfg.databaseDir = dir
+
+	t.Run("normal startup uses manifest", func(t *testing.T) {
+		sm, err := InitSSTableManager(ctx, cfg, vs, nil)
+		assert.NoError(t, err)
+		defer sm.Close(ctx)
+
+		if assert.Len(t, sm.levels, 1) {
+			iter := sm.levels[0].Iterator()
+			var names []string
+			for iter.HasNext() {
+				fs, err := iter.Next()
+				assert.NoError(t, err)
+				names = append(names, path.Base(fs.Path()))
+			}
+			assert.Equal(t, []string{sstPath(1)}, names)
+		}
+	})
+
+	t.Run("repair mode scans directory", func(t *testing.T) {
+		cfg.repairMode = true
+		sm, err := InitSSTableManager(ctx, cfg, &VersionSet{}, nil)
+		assert.NoError(t, err)
+		defer sm.Close(ctx)
+
+		if assert.Len(t, sm.levels, 1) {
+			assert.Equal(t, 2, sm.levels[0].Len())
+		}
+	})
+}
+
 func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 	cfg := testConfig()
 


### PR DESCRIPTION
## Summary
- allow forcing SSTable directory scans with `WithRepairMode`
- build levels from manifest by default and only scan when repair mode is enabled
- test normal start-up vs repair mode and manifest sequence recovery

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b54e4c2c74832583e39b98263212ae