### PR TITLE
refactor: track opened sstables by file number

### DIFF
--- a/docs/dev/53/overall_plan.md
+++ b/docs/dev/53/overall_plan.md
@@ -187,7 +187,7 @@ func InitSSTableManager(ctx context.Context, cfg Config) (*SSTableManager, error
 - Replace the current level list with a `VersionSet` reference.
 ```go
 type SSTableManager struct {
-    openedFs map[*FileSystem]struct{}
+    openedFs map[uint64]*FileSystem
 -   levels   []*LinkedList[*FileSystem]
     config   Config
     mu       sync.RWMutex

--- a/docs/dev/53/sstablemgmt_version_plan.md
+++ b/docs/dev/53/sstablemgmt_version_plan.md
@@ -9,7 +9,7 @@ so that `VersionSet` becomes the sole source of truth.
 // levels field deleted; versionSet drives all metadata.
 type SSTableManager struct {
     openedFsMu  sync.Mutex
-    openedFs    map[*FileSystem]struct{}
+    openedFs    map[uint64]*FileSystem
     openedByNum map[uint64]*SStable
 
     versionSet *VersionSet
@@ -30,7 +30,7 @@ func InitSSTableManager(ctx context.Context, cfg Config, vs *VersionSet, mw Mani
         // to build a proper FileMeta entry for recovery
     }
     return &SSTableManager{
-        openedFs:    make(map[*FileSystem]struct{}),
+        openedFs:    make(map[uint64]*FileSystem),
         openedByNum: make(map[uint64]*SStable),
         versionSet:  vs,
         manifest:    mw,

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -28,8 +28,8 @@ const writeRateAlpha = 0.2
 // - Coordinates concurrent access with read/write locks
 type SSTableManager struct {
 	openedFsMu  sync.Mutex
-	openedFs    map[*FileSystem]struct{} // legacy tracking for compaction paths
-	openedByNum map[uint64]*SStable      // open SSTables keyed by file number
+	openedFs    map[uint64]*FileSystem // legacy tracking for compaction paths
+	openedByNum map[uint64]*SStable    // open SSTables keyed by file number
 	levels      []*LinkedList[*FileSystem]
 	versionSet  *VersionSet
 	manifest    ManifestWriter
@@ -75,15 +75,20 @@ func (h *SSTableManager) openAndLoadSSTable(ctx context.Context, fs *FileSystem)
 		_ = fs.Close() // Ensure file is closed on SSTable creation error
 		return nil, fmt.Errorf("failed to create sstable object for %s: %w", fs.Path(), err)
 	}
+	num, err := fileNum(fs.Path())
+	if err != nil {
+		_ = fs.Close()
+		return nil, fmt.Errorf("invalid sstable path %s: %w", fs.Path(), err)
+	}
 	h.openedFsMu.Lock()
-	h.openedFs[fs] = struct{}{} // Track opened file system
+	h.openedFs[num] = fs // Track opened file system
 	h.openedFsMu.Unlock()
 	return &sstable, nil
 }
 
 func InitSSTableManager(ctx context.Context, config Config, vs *VersionSet, mw ManifestWriter) (*SSTableManager, error) {
 	h := &SSTableManager{
-		openedFs:          make(map[*FileSystem]struct{}),
+		openedFs:          make(map[uint64]*FileSystem),
 		openedByNum:       make(map[uint64]*SStable),
 		versionSet:        vs,
 		manifest:          mw,
@@ -289,7 +294,7 @@ func (h *SSTableManager) NewSSTableFS(ctx context.Context, levelNumb int) (*File
 	}
 
 	h.openedFsMu.Lock()
-	h.openedFs[fs] = struct{}{}
+	h.openedFs[id] = fs
 	h.openedFsMu.Unlock()
 	return fs, nil
 }
@@ -308,7 +313,7 @@ func (h *SSTableManager) Close(ctx context.Context) {
 	}
 	h.openedByNum = make(map[uint64]*SStable)
 	filesToClose := make([]*FileSystem, 0, len(h.openedFs))
-	for fs := range h.openedFs {
+	for _, fs := range h.openedFs {
 		filesToClose = append(filesToClose, fs)
 	}
 
@@ -325,13 +330,16 @@ func (h *SSTableManager) Close(ctx context.Context) {
 				ERROR(ctx, "Error iterating through level: %v", err)
 				continue
 			}
-			if _, exists := h.openedFs[fs]; exists {
-				continue
+			num, nerr := fileNum(fs.Path())
+			if nerr == nil {
+				if _, exists := h.openedFs[num]; exists {
+					continue
+				}
 			}
 			filesToClose = append(filesToClose, fs)
 		}
 	}
-	h.openedFs = make(map[*FileSystem]struct{})
+	h.openedFs = make(map[uint64]*FileSystem)
 	h.openedFsMu.Unlock()
 	h.mu.Unlock()
 
@@ -594,8 +602,12 @@ func (h *SSTableManager) closeSSTables(sstables []SStable) {
 }
 
 func (h *SSTableManager) removeOpenedFS(target *FileSystem) {
+	num, err := fileNum(target.Path())
+	if err != nil {
+		return
+	}
 	h.openedFsMu.Lock()
-	delete(h.openedFs, target)
+	delete(h.openedFs, num)
 	h.openedFsMu.Unlock()
 }
 

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1336,7 +1336,7 @@ func TestSSTableManager_DynamicShouldCompact(t *testing.T) {
 			ioVal := uint64(0)
 
 			sm := &SSTableManager{
-				openedFs:       make(map[*FileSystem]struct{}),
+				openedFs:       make(map[uint64]*FileSystem),
 				levels:         []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()},
 				config:         cfg,
 				now:            func() time.Time { return current },


### PR DESCRIPTION
## Summary
- key opened SSTables by file number instead of filesystem pointer
- update SSTable loading and cleanup to convert paths to file numbers
- adjust unit tests for new `openedFs` layout

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b63753fc7c8325abbf2773eca7cf77