### PR TITLE
docs: expand sstable manager refactor plan

### DIFF
--- a/docs/dev/53/sstablemgmt_version_plan.md
+++ b/docs/dev/53/sstablemgmt_version_plan.md
@@ -25,9 +25,18 @@ func InitSSTableManager(ctx context.Context, cfg Config, vs *VersionSet, mw Mani
     }
     if cfg.repairMode {
         vs = &VersionSet{}
-        // scan cfg.databaseDir and populate vs.Levels with FileMeta for each *.sst
-        // open each table and read its metadata (key ranges, seq nums, file size)
-        // to build a proper FileMeta entry for recovery
+        entries := map[int][]FileMeta{}
+        err := filepath.WalkDir(cfg.databaseDir, func(path string, d fs.DirEntry, err error) error {
+            if filepath.Ext(path) != ".sst" { return nil }
+            fs, err := OpenFileSystem(path)
+            if err != nil { return err }
+            meta, err := loadFileMeta(fs) // reads size and key/seq ranges
+            if err != nil { return err }
+            entries[meta.Level] = append(entries[meta.Level], meta)
+            return fs.Close()
+        })
+        if err != nil { return nil, err }
+        vs.Levels = entries
     }
     return &SSTableManager{
         openedFs:    make(map[*FileSystem]struct{}),
@@ -42,6 +51,10 @@ func InitSSTableManager(ctx context.Context, cfg Config, vs *VersionSet, mw Mani
     }, nil
 }
 ```
+
+The previous repair-mode `LoadLevels` function is removed; the directory scan above populates `VersionSet` directly. Each SSTable
+is opened just long enough to pull its metadata and then closed so recovery does not exhaust descriptors. The metadata is placed
+into `vs.Levels` keyed by level number, yielding the same layout as a healthy manifest would have produced.
 
 ## SSTable Registration
 ```go
@@ -59,6 +72,10 @@ func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
     return edit.Apply(h.versionSet)
 }
 ```
+
+AddSSTable first appends a `VersionEdit` to the manifest so the on-disk log matches memory even if the process crashes. The mutex
+only guards the in-memory `versionSet` mutation; readers proceed concurrently. `NextFileNumber` keeps the allocator in sync with
+files registered in the manifest.
 
 ## Compaction Flow
 ```go
@@ -94,12 +111,37 @@ func (h *SSTableManager) Compact(ctx context.Context) error {
     return nil
 }
 
-func (h *SSTableManager) shouldCompact(ctx context.Context, level int, files []FileMeta) bool
-func (h *SSTableManager) pickFiles(ctx context.Context, level int, files []FileMeta) []FileMeta
-func (h *SSTableManager) findOverlaps(ctx context.Context, level int, inputs []FileMeta) ([]FileMeta, error)
-func (h *SSTableManager) merge(ctx context.Context, level int, inputs []FileMeta) ([]FileMeta, error)
+func (h *SSTableManager) shouldCompact(ctx context.Context, level int, files []FileMeta) bool {
+    limit := h.config.Levels[level].MaxFileCount
+    return len(files) > limit
+}
+
+func (h *SSTableManager) pickFiles(ctx context.Context, level int, files []FileMeta) []FileMeta {
+    sort.Slice(files, func(i, j int) bool { return files[i].Size < files[j].Size })
+    need := h.config.Levels[level].TargetFileCount
+    if len(files) < need { return files }
+    return append([]FileMeta(nil), files[:need]...)
+}
+
+func (h *SSTableManager) findOverlaps(ctx context.Context, level int, inputs []FileMeta) ([]FileMeta, error) {
+    var overlaps []FileMeta
+    for _, fm := range h.versionSet.Levels[level] {
+        if overlapsRange(inputs, fm) { // overlapsRange compares key ranges
+            overlaps = append(overlaps, fm)
+        }
+    }
+    return overlaps, nil
+}
+
+func (h *SSTableManager) merge(ctx context.Context, level int, inputs []FileMeta) ([]FileMeta, error) {
+    out, err := h.NewSSTableFS(ctx, level)
+    if err != nil { return nil, err }
+    // merge logic elided; write to `out` and build meta
+    meta := FileMeta{Number: out.FileNumber(), Level: level}
+    return []FileMeta{meta}, out.Close()
+}
 ```
-Helpers resolve `FileMeta.Number` to a `FileSystem` lazily; no `levels` linked lists remain.
+Helpers resolve `FileMeta.Number` to a `FileSystem` lazily; no `levels` linked lists remain. Legacy helpers `compactLevel0`, `compactHigherLevel`, `findOverlappingSSTables`, and `removeOverlappingFromLevel` are removed. `shouldCompact` compares the file count against configured limits. `pickFiles` favors smaller tables, `findOverlaps` scans the next level for intersecting ranges, and `merge` writes the new table for the destination level.
 
 ## Sequence Number Scan
 ```go
@@ -110,6 +152,23 @@ func getMaxSequenceNumber(ctx context.Context, vs *VersionSet, wal *WAL) (uint64
     return max(maxSeq, walSeq), nil
 }
 ```
+
+`getMaxSequenceNumberFromSSTables` and its Level‑0 scan are deleted; `InitRinDB` invokes this helper instead.
+
+```go
+func InitRinDB(ctx context.Context, cfg Config) (*Rindb, error) {
+    vs := &VersionSet{}
+    wal, err := OpenWAL(cfg.databaseDir)
+    if err != nil { return nil, err }
+    seq, err := getMaxSequenceNumber(ctx, vs, wal)
+    if err != nil { return nil, err }
+    db := &Rindb{sequenceNumber: seq, versionSet: vs, wal: wal}
+    return db, nil
+}
+```
+
+During startup the database pulls the greater sequence number from the manifest or WAL, avoiding a Level‑0 scan. The resulting
+value seeds `Rindb.sequenceNumber` so new writes continue the sequence monotonically after recovery.
 
 ## Stats Gathering
 ```go
@@ -130,6 +189,9 @@ func (r *Rindb) Stats() Stats {
     return stats
 }
 ```
+
+These stats read directly from `versionSet` rather than iterating linked lists. The approach leaves SSTable internals untouched
+and makes it easier to surface new metrics atop immutable metadata.
 
 ## Test Adjustments
 ```go
@@ -167,5 +229,7 @@ func (ts *testRindbSetup) createSSTable(level int, kv map[string]string) (FileMe
     return meta, &sst
 }
 ```
-Tests in `sstablemgmt_test.go` and helpers in `utils_test.go` seed files via
-`AddSSTable` and assert against `Manager.versionSet.Levels`.
+Tests in `sstablemgmt_test.go` and helpers in `utils_test.go` seed files via `AddSSTable` and assert against
+`Manager.versionSet.Levels`. Other tests such as `rindb_test.go` and `range_test.go` drop `AddSSTableToLevel` and direct
+`manager.levels` access. The helper builds SSTables through `createSSTable`, registers them, and lets tests verify placement
+through the public API only.


### PR DESCRIPTION
## Summary
- add repair-mode directory scanning example
- include skeleton helpers for compaction flow
- show sequence number recovery via getMaxSequenceNumber and InitRinDB

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b634bca91c83259600ba6e1fe72781