### PR TITLE
test: add manifest rotation recovery integration test

### DIFF
--- a/docs/dev/53/overall_plan.md
+++ b/docs/dev/53/overall_plan.md
@@ -175,7 +175,7 @@ func (a *FileNumberAllocator) Apply(edit VersionEdit) {
 ```go
 func InitSSTableManager(ctx context.Context, cfg Config) (*SSTableManager, error) {
     if cfg.repairMode { return loadByScan(ctx, cfg) }
-    vs, err := recoverVersionSet(ctx, cfg.databaseDir)
+    vs, err := RecoverVersionSet(ctx, cfg.databaseDir)
     if err != nil { return nil, err }
     return &SSTableManager{versionSet: vs, config: cfg}, nil
 }
@@ -211,7 +211,7 @@ func (h *SSTableManager) LoadLevels(dir string) error {
 ### `rindb.go`
 - `InitRinDB` now bootstraps from the MANIFEST, which dictates both live SSTables and WAL identifiers.
 - Flow:
-  1. `recoverVersionSet` reads `CURRENT` and replays the manifest to rebuild levels and allocator state.
+  1. `RecoverVersionSet` reads `CURRENT` and replays the manifest to rebuild levels and allocator state.
   2. Seed a `FileNumberAllocator` and WAL plumbing from `vs.NextFileNumber`, `vs.LogNumber`, and `vs.PrevLogNumber`.
   3. Replay the WAL files referenced by those log numbers to restore the memtable and determine `lastSeq`.
   4. Construct `SSTableManager` directly from the recovered `VersionSet`—no directory scan.
@@ -219,7 +219,7 @@ func (h *SSTableManager) LoadLevels(dir string) error {
 func InitRinDB(ctx context.Context, opts ...Option) (*Rindb, error) {
     cfg := NewConfig(opts...)
 
-    vs, err := recoverVersionSet(ctx, cfg.databaseDir)
+    vs, err := RecoverVersionSet(ctx, cfg.databaseDir)
     if err != nil { return nil, err }
 
     allocator := cfg.newFileNumberAllocatorFunc(vs.NextFileNumber)

--- a/integration/manifest_rotation_recovery_test.go
+++ b/integration/manifest_rotation_recovery_test.go
@@ -27,8 +27,8 @@ func TestManifestRotationRecovery(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	puts := 11
-	for i := 0; i < puts; i++ {
+	const numPuts = 11
+	for i := 0; i < numPuts; i++ {
 		key := rindb.Bytes(fmt.Sprintf("k%02d", i))
 		require.NoError(t, db.Put(ctx, key, rindb.Bytes("v")))
 	}
@@ -42,5 +42,5 @@ func TestManifestRotationRecovery(t *testing.T) {
 	vs, manifestPath, err := rindb.RecoverVersionSet(ctx, dir)
 	require.NoError(t, err)
 	require.Equal(t, filepath.Join(dir, mf), manifestPath)
-	require.Len(t, vs.Levels[0], puts)
+	require.Len(t, vs.Levels[0], numPuts)
 }

--- a/integration/manifest_rotation_recovery_test.go
+++ b/integration/manifest_rotation_recovery_test.go
@@ -1,0 +1,46 @@
+//go:build integration && smoke
+
+package rindb_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestManifestRotationRecovery(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	db, err := rindb.InitRinDB(ctx,
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(1),
+		rindb.WithLevel0CompactionThreshold(1000),
+		rindb.WithManifestSizeThreshold(1024),
+	)
+	require.NoError(t, err)
+
+	puts := 11
+	for i := 0; i < puts; i++ {
+		key := rindb.Bytes(fmt.Sprintf("k%02d", i))
+		require.NoError(t, db.Put(ctx, key, rindb.Bytes("v")))
+	}
+	require.NoError(t, db.Close())
+
+	data, err := os.ReadFile(filepath.Join(dir, "CURRENT"))
+	require.NoError(t, err)
+	mf := strings.TrimSpace(string(data))
+	require.NotEqual(t, "MANIFEST-000001", mf)
+
+	vs, manifestPath, err := rindb.RecoverVersionSet(ctx, dir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, mf), manifestPath)
+	require.Len(t, vs.Levels[0], puts)
+}

--- a/manifest.go
+++ b/manifest.go
@@ -130,8 +130,8 @@ func syncDir(dir string) error {
 	return d.Sync()
 }
 
-// recoverVersionSet rebuilds the VersionSet by replaying the MANIFEST.
-func recoverVersionSet(ctx context.Context, dir string) (*VersionSet, string, error) {
+// RecoverVersionSet rebuilds the VersionSet by replaying the MANIFEST.
+func RecoverVersionSet(ctx context.Context, dir string) (*VersionSet, string, error) {
 	vs := &VersionSet{}
 	curr := filepath.Join(dir, "CURRENT")
 	data, err := os.ReadFile(curr)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -97,7 +97,7 @@ func TestManifest(t *testing.T) {
 		require.NoError(t, w.Close())
 		require.NoError(t, WriteCURRENT(ctx, dir, mf))
 
-		vs, _, err := recoverVersionSet(ctx, dir)
+		vs, _, err := RecoverVersionSet(ctx, dir)
 		require.NoError(t, err)
 		require.Equal(t, seq, vs.LastSequence)
 	})
@@ -105,7 +105,7 @@ func TestManifest(t *testing.T) {
 	t.Run("RecoverVersionSetNoManifest", func(t *testing.T) {
 		ctx := context.Background()
 		dir := t.TempDir()
-		vs, _, err := recoverVersionSet(ctx, dir)
+		vs, _, err := RecoverVersionSet(ctx, dir)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), vs.LastSequence)
 	})

--- a/rindb.go
+++ b/rindb.go
@@ -92,7 +92,7 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 		return nil, fmt.Errorf("failed to create database directory %s: %w", cfg.databaseDir, err)
 	}
 
-	vs, manifestPath, err := recoverVersionSet(ctx, cfg.databaseDir)
+	vs, manifestPath, err := RecoverVersionSet(ctx, cfg.databaseDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- add smoke integration test for manifest rotation and recovery via RecoverVersionSet
- export RecoverVersionSet instead of an integration-only wrapper

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b637af7d588325bf02756943c2ad15