### PR TITLE
docs: refine sstable manager version plan

### DIFF
--- a/docs/dev/53/sstablemgmt_version_plan.md
+++ b/docs/dev/53/sstablemgmt_version_plan.md
@@ -33,9 +33,10 @@ func InitSSTableManager(ctx context.Context, cfg Config, vs *VersionSet, mw Mani
             if err != nil { return err }
             fs, err := OpenExistingFS(ctx, path)
             if err != nil { return err }
+            defer fs.Close()
             sst, err := NewSSTable(ctx, cfg, fs)
-            fs.Close()
             if err != nil { return err }
+            defer sst.Close()
             lo, hi := sst.GetKeyRange()
             seqHi, err := sst.MaxSequenceNumber()
             if err != nil { return err }

--- a/docs/dev/53/sstablemgmt_version_plan.md
+++ b/docs/dev/53/sstablemgmt_version_plan.md
@@ -25,20 +25,31 @@ func InitSSTableManager(ctx context.Context, cfg Config, vs *VersionSet, mw Mani
     }
     if cfg.repairMode {
         vs = &VersionSet{}
-        entries := map[int][]FileMeta{}
+        var metas []FileMeta
         err := filepath.WalkDir(cfg.databaseDir, func(path string, d fs.DirEntry, err error) error {
             if err != nil { return err }
             if filepath.Ext(path) != ".sst" { return nil }
-            fs, err := OpenFileSystem(path)
+            num, err := fileNum(path)
             if err != nil { return err }
-            defer fs.Close()
-            meta, err := loadFileMeta(fs) // reads size and key/seq ranges
+            fs, err := OpenExistingFS(ctx, path)
             if err != nil { return err }
-            entries[meta.Level] = append(entries[meta.Level], meta)
+            sst, err := NewSSTable(ctx, cfg, fs)
+            fs.Close()
+            if err != nil { return err }
+            lo, hi := sst.GetKeyRange()
+            seqHi, err := sst.MaxSequenceNumber()
+            if err != nil { return err }
+            metas = append(metas, FileMeta{
+                Number:   num,
+                Level:    0,
+                Smallest: InternalKey{UserKey: lo},
+                Largest:  InternalKey{UserKey: hi},
+                SeqHi:    seqHi,
+            })
             return nil
         })
         if err != nil { return nil, err }
-        vs.Levels = entries
+        vs.Levels = [][]FileMeta{metas}
     }
     return &SSTableManager{
         openedFs:    make(map[uint64]*FileSystem),
@@ -55,8 +66,8 @@ func InitSSTableManager(ctx context.Context, cfg Config, vs *VersionSet, mw Mani
 ```
 
 The previous repair-mode `LoadLevels` function is removed; the directory scan above populates `VersionSet` directly. Each SSTable
-is opened just long enough to pull its metadata and then closed so recovery does not exhaust descriptors. The metadata is placed
-into `vs.Levels` keyed by level number, yielding the same layout as a healthy manifest would have produced.
+is opened just long enough to pull its metadata and then closed so recovery does not exhaust descriptors. The metadata is gathered
+into a slice and assigned to `vs.Levels` (all files start in Level 0), mirroring the layout a healthy manifest would have produced.
 
 ## SSTable Registration
 ```go
@@ -71,12 +82,16 @@ func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
     }
     h.mu.Lock() // lock only to update in-memory versionSet
     defer h.mu.Unlock()
-    return edit.Apply(h.versionSet)
+    if err := edit.Apply(h.versionSet); err != nil {
+        return err
+    }
+    h.config.fileNumberAllocator.Apply(edit) // keep allocator consistent with manifest
+    return nil
 }
 ```
 
 AddSSTable first appends a `VersionEdit` to the manifest so the on-disk log matches memory even if the process crashes. The mutex
-only guards the in-memory `versionSet` mutation; readers proceed concurrently. `NextFileNumber` keeps the allocator in sync with
+only guards the in-memory `versionSet` mutation and allocator update; readers proceed concurrently. `NextFileNumber` keeps the allocator in sync with
 files registered in the manifest.
 
 ## Compaction Flow
@@ -105,7 +120,7 @@ func (h *SSTableManager) Compact(ctx context.Context) error {
         if err != nil { return err }
         edit := VersionEdit{
             AddFiles:    metas,
-            DeleteFiles: metasOf(append(picked, overlaps...)),
+            DeleteFiles: toDeleted(append(picked, overlaps...)),
             NextFileNumber: h.config.fileNumberAllocator.Peek(),
         }
         if h.manifest != nil {
@@ -113,7 +128,11 @@ func (h *SSTableManager) Compact(ctx context.Context) error {
             if err := h.manifest.Sync(); err != nil { return err }
         }
         func() {
-            h.mu.Lock(); defer h.mu.Unlock(); err = edit.Apply(h.versionSet)
+            h.mu.Lock()
+            defer h.mu.Unlock()
+            if err = edit.Apply(h.versionSet); err == nil {
+                h.config.fileNumberAllocator.Apply(edit)
+            }
         }()
         if err != nil { return err }
     }
@@ -170,19 +189,19 @@ func (h *SSTableManager) merge(ctx context.Context, level int, inputs []FileMeta
     for _, fm := range inputs {
         sst, err := h.openByNumber(ctx, fm.Number)
         if err != nil {
-            h.closeSSTables(tbls)
+            h.closeSSTables(ctx, tbls)
             return nil, err
         }
         tbls = append(tbls, *sst)
     }
     out, err := h.NewSSTableFS(ctx, level)
     if err != nil {
-        h.closeSSTables(tbls)
+        h.closeSSTables(ctx, tbls)
         return nil, err
     }
     bottom := level == len(h.versionSet.Levels)-1
     _, meta, err := mergeSSTablesV2(ctx, h.config, out, tbls, bottom, h.minSnapshotSeq)
-    h.closeSSTables(tbls)
+    h.closeSSTables(ctx, tbls)
     if err != nil {
         _ = out.Close()
         return nil, err
@@ -190,14 +209,24 @@ func (h *SSTableManager) merge(ctx context.Context, level int, inputs []FileMeta
     meta.Level = level
     return []FileMeta{meta}, out.Close()
 }
+
+func toDeleted(files []FileMeta) []DeletedFileMeta {
+    dels := make([]DeletedFileMeta, len(files))
+    for i, f := range files {
+        dels[i] = DeletedFileMeta{Level: f.Level, Number: f.Number}
+    }
+    return dels
+}
 ```
-Helpers resolve `FileMeta.Number` to a `FileSystem` lazily; no `levels` linked lists remain. Legacy helpers `compactLevel0`, `compactHigherLevel`, `findOverlappingSSTables`, and `removeOverlappingFromLevel` are removed. `shouldCompact` mirrors current thresholds—Level 0 triggers on file count while higher levels use cumulative size. `pickFiles` removes chosen file numbers from `VersionSet` (all files at Level 0 or the first file at higher levels) so they are not compacted twice; `findOverlaps` compares key spans in the next level, and `merge` opens each SSTable by file number before writing the merged output.
+Helpers resolve `FileMeta.Number` to a `FileSystem` lazily; no `levels` linked lists remain. Legacy helpers `compactLevel0`, `compactHigherLevel`, `findOverlappingSSTables`, and `removeOverlappingFromLevel` are removed. `shouldCompact` mirrors current thresholds—Level 0 triggers on file count while higher levels use cumulative size. `pickFiles` removes chosen file numbers from `VersionSet` (all files at Level 0 or the first file at higher levels) so they are not compacted twice; `findOverlaps` compares key spans in the next level, `toDeleted` converts them to `DeletedFileMeta`, and `merge` opens each SSTable by file number before writing the merged output.
 
 ## Sequence Number Scan
 ```go
 func getMaxSequenceNumber(ctx context.Context, vs *VersionSet, wal *WAL) (uint64, error) {
     maxSeq := vs.LastSequence
-    walSeq, err := wal.MaxSequenceNumber()
+    mem, err := wal.Load(ctx)
+    if err != nil { return 0, err }
+    walSeq, err := getMaxSequenceNumberFromMemtable(mem)
     if err != nil { return 0, err }
     return max(maxSeq, walSeq), nil
 }
@@ -207,9 +236,9 @@ func getMaxSequenceNumber(ctx context.Context, vs *VersionSet, wal *WAL) (uint64
 
 ```go
 func InitRinDB(ctx context.Context, cfg Config) (*Rindb, error) {
-    vs, err := RecoverVersionSet(cfg.databaseDir)
+    vs, err := RecoverVersionSet(ctx, cfg.databaseDir, cfg.fileNumberAllocator)
     if err != nil { return nil, err }
-    wal, err := OpenWAL(cfg.databaseDir)
+    wal, err := cfg.newWALFunc(ctx, cfg)
     if err != nil { return nil, err }
     seq, err := getMaxSequenceNumber(ctx, vs, wal)
     if err != nil { return nil, err }
@@ -219,7 +248,7 @@ func InitRinDB(ctx context.Context, cfg Config) (*Rindb, error) {
 ```
 
 During startup the database first recovers the `VersionSet` from the manifest and then opens the WAL. `getMaxSequenceNumber`
-compares the manifest's `LastSequence` with the WAL's max to avoid a Level‑0 scan. The resulting value seeds
+loads the WAL and compares its highest sequence with the manifest's `LastSequence`, avoiding an SSTable scan. The resulting value seeds
 `Rindb.sequenceNumber` so new writes continue the sequence monotonically after recovery.
 
 ## Stats Gathering
@@ -250,6 +279,7 @@ and makes it easier to surface new metrics atop immutable metadata.
 type testRindbSetup struct {
     T       *testing.T
     Config  *Config
+    RinDB   *Rindb
     Manager *SSTableManager
     Version *VersionSet
     // ... other fields
@@ -283,5 +313,5 @@ func (ts *testRindbSetup) createSSTable(level int, kv map[string]string) (FileMe
 ```
 Tests in `sstablemgmt_test.go` and helpers in `utils_test.go` seed files via `AddSSTable` and assert against
 `Manager.versionSet.Levels`. Other tests such as `rindb_test.go` and `range_test.go` drop `AddSSTableToLevel` and direct
-`manager.levels` access. The helper builds SSTables through `createSSTable`, registers them, and lets tests verify placement
-through the public API only.
+`manager.levels` access. The helper carries the opened database via `RinDB`, builds SSTables through `createSSTable`, registers
+them, and lets tests verify placement through the public API only.


### PR DESCRIPTION
## Summary
- Align InitSSTableManager repair-mode example with current APIs
- Note allocator updates in AddSSTable and compaction snippets
- Clarify compaction helpers and recovery initialization

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b652c8553c8325a2d2c8e334390f7b