### PR TITLE
refactor: use version set for level metadata

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -195,10 +195,10 @@ func (r *Rindb) Stats() Stats {
 
 	// Lock separately for SSTable manager stats.
 	r.ssTableManager.mu.RLock()
-	stats.SSTablesPerLevel = make([]int, len(r.ssTableManager.levels))
-	for i, level := range r.ssTableManager.levels {
-		if level != nil {
-			stats.SSTablesPerLevel[i] = level.Len()
+	if r.ssTableManager.versionSet != nil {
+		stats.SSTablesPerLevel = make([]int, len(r.ssTableManager.versionSet.Levels))
+		for i, files := range r.ssTableManager.versionSet.Levels {
+			stats.SSTablesPerLevel[i] = len(files)
 		}
 	}
 	r.ssTableManager.mu.RUnlock()

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -28,9 +28,9 @@ const writeRateAlpha = 0.2
 // - Coordinates concurrent access with read/write locks
 type SSTableManager struct {
 	openedFsMu  sync.Mutex
-	openedFs    map[uint64]*FileSystem // legacy tracking for compaction paths
-	openedByNum map[uint64]*SStable    // open SSTables keyed by file number
-	levels      []*LinkedList[*FileSystem]
+	openedFs    map[uint64]*FileSystem     // legacy tracking for compaction paths
+	openedByNum map[uint64]*SStable        // open SSTables keyed by file number
+	levels      []*LinkedList[*FileSystem] // temporary shim; metadata lives in versionSet
 	versionSet  *VersionSet
 	manifest    ManifestWriter
 	config      Config
@@ -846,32 +846,27 @@ func (h *SSTableManager) searchKey(ctx context.Context, key Bytes, seq ...uint64
 // that tracks global sequence number metadata across all levels.
 func getMaxSequenceNumberFromSSTables(ctx context.Context, ssTableManager *SSTableManager) (uint64, error) {
 	var maxSeqNum uint64
-	if len(ssTableManager.levels) > 0 && ssTableManager.levels[0] != nil {
-		level0 := ssTableManager.levels[0]
-		levelIterator := level0.Iterator()
-		for levelIterator.HasNext() {
-			fs, err := levelIterator.Next()
-			if err != nil {
-				return 0, err
-			}
-			sstable, err := ssTableManager.openAndLoadSSTable(ctx, fs)
-			if err != nil {
-				return 0, err
-			}
-			sstSeqNum, err := sstable.MaxSequenceNumber()
-			if err != nil {
-				return 0, err
-			}
+	if ssTableManager.versionSet == nil || len(ssTableManager.versionSet.Levels) == 0 {
+		return 0, nil
+	}
+	for _, meta := range ssTableManager.versionSet.Levels[0] {
+		fs := &FileSystem{filePath: path.Join(ssTableManager.config.databaseDir, sstPath(meta.Number))}
+		sstable, err := ssTableManager.openAndLoadSSTable(ctx, fs)
+		if err != nil {
+			return 0, err
+		}
+		sstSeqNum, err := sstable.MaxSequenceNumber()
+		if err != nil {
+			return 0, err
+		}
+		maxSeqNum = max(maxSeqNum, sstSeqNum)
 
-			maxSeqNum = max(maxSeqNum, sstSeqNum)
-
-			closeErr := fs.Close()
-			if rmErr := ssTableManager.removeOpenedFS(fs); rmErr != nil {
-				WARN(ctx, "Failed to remove opened file %s: %v", fs.Path(), rmErr)
-			}
-			if closeErr != nil {
-				return 0, closeErr
-			}
+		closeErr := fs.Close()
+		if rmErr := ssTableManager.removeOpenedFS(fs); rmErr != nil {
+			WARN(ctx, "Failed to remove opened file %s: %v", fs.Path(), rmErr)
+		}
+		if closeErr != nil {
+			return 0, closeErr
 		}
 	}
 	return maxSeqNum, nil

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -141,7 +141,7 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 		// Case 3: Level 0 exists but is empty
 		ts.Manager.levels = []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()}
 		if ts.Manager.versionSet != nil {
-			ts.Manager.versionSet.Levels = [][]FileMeta{{}}
+			ts.Manager.versionSet.Levels = [][]FileMeta{[]FileMeta{}}
 		}
 		maxSeqNum, err = getMaxSequenceNumberFromSSTables(ctx, ts.Manager)
 		assert.NoError(t, err)

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -120,20 +120,29 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 		ts := newTestRindbSetup(t, ctx, &cfg)
 		defer ts.Cleanup()
 
-		// Case 1: ssTableManager.levels is nil
+		// Case 1: no levels exist
 		ts.Manager.levels = nil
+		if ts.Manager.versionSet != nil {
+			ts.Manager.versionSet.Levels = nil
+		}
 		maxSeqNum, err := getMaxSequenceNumberFromSSTables(ctx, ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), maxSeqNum)
 
-		// Case 2: ssTableManager.levels is empty slice
+		// Case 2: empty slice of levels
 		ts.Manager.levels = []*LinkedList[*FileSystem]{}
+		if ts.Manager.versionSet != nil {
+			ts.Manager.versionSet.Levels = [][]FileMeta{}
+		}
 		maxSeqNum, err = getMaxSequenceNumberFromSSTables(ctx, ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), maxSeqNum)
 
 		// Case 3: Level 0 exists but is empty
 		ts.Manager.levels = []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()}
+		if ts.Manager.versionSet != nil {
+			ts.Manager.versionSet.Levels = [][]FileMeta{{}}
+		}
 		maxSeqNum, err = getMaxSequenceNumberFromSSTables(ctx, ts.Manager)
 		assert.NoError(t, err)
 		assert.Equal(t, uint64(0), maxSeqNum)
@@ -187,14 +196,15 @@ func Test_getMaxSequenceNumberFromSSTables(t *testing.T) {
 		ts := newTestRindbSetup(t, ctx, &cfg)
 		defer ts.Cleanup()
 
-		// Create a dummy FS that will return an error on Open
-		badFs := &FileSystem{filePath: "/non/existent/path.sst"}
-		ts.Manager.levels = []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()}
-		ts.Manager.levels[0].PushBack(badFs)
+		// Inject metadata pointing to a missing SSTable file
+		if ts.Manager.versionSet == nil {
+			ts.Manager.versionSet = &VersionSet{}
+		}
+		ts.Manager.versionSet.Levels = [][]FileMeta{{{Number: 999}}}
 
 		maxSeqNum, err := getMaxSequenceNumberFromSSTables(ctx, ts.Manager)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no such file or directory")
+		assert.Contains(t, err.Error(), "malformed sstable")
 		assert.Equal(t, uint64(0), maxSeqNum)
 	})
 


### PR DESCRIPTION
## Summary
- derive stats from VersionSet instead of legacy levels lists
- scan VersionSet to recover max sequence number
- adapt tests for VersionSet-backed metadata

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b67b7d01dc8325aec51146682b0d36