### PR TITLE
feat: register SSTables via manifest

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -367,17 +367,20 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			return fmt.Errorf("failed to flush memtable: %w", err)
 		}
 
-		// Register the new SSTable with ssTableManager
-		if err := r.ssTableManager.AddSSTable(ctx, 0, fs); err != nil {
+		if err := r.ssTableManager.AddSSTable(ctx, meta); err != nil {
+			_ = fs.Close()
 			ERROR(ctx, "Failed to register new SSTable %s: %v", fs.Path(), err)
 			return fmt.Errorf("failed to register new SSTable %s: %w", fs.Path(), err)
 		}
-
-		edit := VersionEdit{
-			AddFiles:       []FileMeta{meta},
-			LastSequence:   r.sequenceNumber,
-			NextFileNumber: r.config.fileNumberAllocator.Peek(),
+		// Close and deregister the writable FileSystem now that metadata is persisted.
+		if err := fs.Close(); err != nil {
+			WARN(ctx, "Failed to close FileSystem %s: %v", fs.Path(), err)
 		}
+		if err := r.ssTableManager.removeOpenedFS(fs); err != nil {
+			WARN(ctx, "Failed to remove opened file %s: %v", fs.Path(), err)
+		}
+
+		edit := VersionEdit{LastSequence: r.sequenceNumber}
 		if err := r.manifest.Append(edit); err != nil {
 			ERROR(ctx, "Failed to append manifest edit: %v", err)
 			return err
@@ -389,7 +392,6 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 		if err := edit.Apply(r.versionSet); err != nil {
 			return err
 		}
-		r.config.fileNumberAllocator.Apply(edit)
 		if err := r.maybeRotateManifest(ctx); err != nil {
 			return err
 		}

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -506,12 +506,13 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 		mem.Put(newRecord(Bytes("sk2"), Bytes("sv2"), 60))
 		_, meta, err := flush(ctx, rin.config, mem, fs)
 		assert.NoError(t, err)
-		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, 0, fs))
-		edit := VersionEdit{AddFiles: []FileMeta{meta}, LastSequence: meta.SeqHi}
+		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta))
+		assert.NoError(t, fs.Close())
+		assert.NoError(t, rin.ssTableManager.removeOpenedFS(fs))
+		edit := VersionEdit{LastSequence: meta.SeqHi}
 		assert.NoError(t, rin.manifest.Append(edit))
 		assert.NoError(t, rin.manifest.Sync())
 		assert.NoError(t, edit.Apply(rin.versionSet))
-		rin.config.fileNumberAllocator.Apply(edit)
 
 		// Also create a WAL with a lower sequence number to ensure SSTable takes precedence
 		wp := path.Join(rin.config.databaseDir, walPath(1))
@@ -547,9 +548,15 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 
 		mem := InitMemtable(rin.config)
 		mem.Put(newRecord(Bytes("sk1"), Bytes("sv1"), 70))
-		_, _, err = flush(ctx, rin.config, mem, fs)
+		_, meta, err := flush(ctx, rin.config, mem, fs)
 		assert.NoError(t, err)
-		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, 0, fs))
+		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta))
+		assert.NoError(t, fs.Close())
+		assert.NoError(t, rin.ssTableManager.removeOpenedFS(fs))
+		edit := VersionEdit{LastSequence: meta.SeqHi}
+		assert.NoError(t, rin.manifest.Append(edit))
+		assert.NoError(t, rin.manifest.Sync())
+		assert.NoError(t, edit.Apply(rin.versionSet))
 
 		// Create a WAL with the same highest sequence number
 		// The database directory is already created by initRinDBWithCleanup

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -285,8 +285,10 @@ func (h *SSTableManager) dynamicTriggerHit() bool {
 	return h.writeRate > h.config.writeRateTrigger && h.ioLoad < h.config.ioLoadMax
 }
 
-// AddSSTable registers a new SSTable file system with the manager at the specified level.
-func (h *SSTableManager) AddSSTable(ctx context.Context, levelNumb int, fs *FileSystem) error {
+// AddSSTable registers a new SSTable's metadata, persists it to the manifest,
+// and updates the in-memory VersionSet. It keeps the legacy `levels` list in
+// sync until all call sites migrate to VersionSet usage only.
+func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
 	ctx, span := sstableMgmtTracer.Start(ctx, "SSTableManager.AddSSTable")
 	start := time.Now()
 	defer func() {
@@ -295,20 +297,37 @@ func (h *SSTableManager) AddSSTable(ctx context.Context, levelNumb int, fs *File
 		addSSTableCalls.Add(ctx, 1)
 	}()
 
+	edit := VersionEdit{
+		AddFiles:       []FileMeta{meta},
+		NextFileNumber: h.config.fileNumberAllocator.Peek(),
+	}
+	if h.manifest != nil {
+		if err := h.manifest.Append(edit); err != nil {
+			return err
+		}
+		if err := h.manifest.Sync(); err != nil {
+			return err
+		}
+	}
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	// Ensure the level exists
-	for len(h.levels) <= levelNumb {
+	if err := edit.Apply(h.versionSet); err != nil {
+		return err
+	}
+	h.config.fileNumberAllocator.Apply(edit)
+
+	// Maintain legacy levels list for existing compaction code paths.
+	for len(h.levels) <= meta.Level {
 		h.levels = append(h.levels, nil)
 	}
-	if h.levels[levelNumb] == nil {
-		h.levels[levelNumb] = InitLinkedList[*FileSystem]()
+	if h.levels[meta.Level] == nil {
+		h.levels[meta.Level] = InitLinkedList[*FileSystem]()
 	}
-
-	// Add the new SSTable to the end of the level list
-	h.levels[levelNumb].PushBack(fs)
-	INFO(ctx, "Registered new SSTable %s at level %d", fs.Path(), levelNumb)
+	fs := &FileSystem{filePath: path.Join(h.config.databaseDir, sstPath(meta.Number))}
+	h.levels[meta.Level].PushBack(fs)
+	INFO(ctx, "Registered new SSTable %s at level %d", fs.Path(), meta.Level)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- register new SSTables through manifest-backed `AddSSTable`
- wire flush path to use manifest-backed registration and persist sequence numbers
- adapt tests to new SSTable registration flow

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b68d6d92d48325af9714dcf8326f5b