### PR TITLE
refactor: drop legacy levels lists

### DIFF
--- a/docs/dev/53/sstablemgmt_version_plan.md
+++ b/docs/dev/53/sstablemgmt_version_plan.md
@@ -313,9 +313,9 @@ func (ts *testRindbSetup) createSSTable(level int, kv map[string]string) (FileMe
 }
 ```
 Tests in `sstablemgmt_test.go` and helpers in `utils_test.go` seed files via `AddSSTable` and assert against
-`Manager.versionSet.Levels`. Other tests such as `rindb_test.go` and `range_test.go` drop `AddSSTableToLevel` and direct
-`manager.levels` access. The helper carries the opened database via `RinDB`, builds SSTables through `createSSTable`, registers
-them, and lets tests verify placement through the public API only.
+`Manager.versionSet.Levels`. Other tests such as `rindb_test.go` and `range_test.go` interact with the `VersionSet`
+directly. The helper carries the opened database via `RinDB`, builds SSTables through `createSSTable`, registers them,
+and lets tests verify placement through the public API only.
 
 ## Implementation Tasks
 
@@ -348,5 +348,5 @@ them, and lets tests verify placement through the public API only.
 
 8. **Clean up obsolete code and docs.**
    - Remove the `levels` linked lists once no code depends on them, making `VersionSet` the single source of metadata.
-   - Delete unused methods and comments tied to `levels` (e.g., `AddSSTableToLevel`).
+   - Delete unused methods and comments tied to `levels`.
    - Refresh documentation to reflect `VersionSet` as the sole metadata source.

--- a/docs/dev/53/sstablemgmt_version_plan.md
+++ b/docs/dev/53/sstablemgmt_version_plan.md
@@ -313,9 +313,9 @@ func (ts *testRindbSetup) createSSTable(level int, kv map[string]string) (FileMe
 }
 ```
 Tests in `sstablemgmt_test.go` and helpers in `utils_test.go` seed files via `AddSSTable` and assert against
-`Manager.versionSet.Levels`. Other tests such as `rindb_test.go` and `range_test.go` interact with the `VersionSet`
-directly. The helper carries the opened database via `RinDB`, builds SSTables through `createSSTable`, registers them,
-and lets tests verify placement through the public API only.
+`Manager.versionSet.Levels`. Other tests such as `rindb_test.go` and `range_test.go` access the `VersionSet` through
+these helpers and the `SSTableManager`. The helper carries the opened database via `RinDB`, builds SSTables through
+`createSSTable`, registers them, and lets tests verify placement through the public API only.
 
 ## Implementation Tasks
 

--- a/range_test.go
+++ b/range_test.go
@@ -89,7 +89,7 @@ func TestIRangeCloseReleasesSSTables(t *testing.T) {
 	mem1.Put(newRecord(Bytes("a"), Bytes("sstA"), 1))
 	sst1, _, err := flush(ctx, cfg, mem1, ts.newSSTableFS(0))
 	assert.NoError(t, err)
-	ts.AddSSTableToLevel(0, &sst1)
+	ts.AddSSTable(0, &sst1)
 
 	iter, err := ts.RinDB.IRange(ctx, Bytes("a"), Bytes("z"))
 	assert.NoError(t, err)

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -107,7 +107,7 @@ func TestRindb_IRange(t *testing.T) {
 	mem1.Put(newRecord(Bytes("b"), Bytes("sstB"), 2))
 	sst1, _, err := flush(ctx, cfg, mem1, ts.newSSTableFS(0))
 	assert.NoError(t, err)
-	ts.AddSSTableToLevel(0, &sst1)
+	ts.AddSSTable(0, &sst1)
 
 	// Create SSTable with tombstone and another record
 	mem2 := InitMemtable(cfg)
@@ -115,7 +115,7 @@ func TestRindb_IRange(t *testing.T) {
 	mem2.Put(newRecord(Bytes("z"), Bytes("sstZ"), 4))
 	sst2, _, err := flush(ctx, cfg, mem2, ts.newSSTableFS(0))
 	assert.NoError(t, err)
-	ts.AddSSTableToLevel(0, &sst2)
+	ts.AddSSTable(0, &sst2)
 
 	// Memtable with latest updates
 	mem := ts.RinDB.memtable

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -27,9 +27,8 @@ const writeRateAlpha = 0.2
 // - Coordinates concurrent access with read/write locks
 type SSTableManager struct {
 	openedFsMu  sync.Mutex
-	openedFs    map[uint64]*FileSystem     // legacy tracking for compaction paths
-	openedByNum map[uint64]*SStable        // open SSTables keyed by file number
-	levels      []*LinkedList[*FileSystem] // temporary shim; metadata lives in versionSet
+	openedFs    map[uint64]*FileSystem // legacy tracking for compaction paths
+	openedByNum map[uint64]*SStable    // open SSTables keyed by file number
 	versionSet  *VersionSet
 	manifest    ManifestWriter
 	config      Config
@@ -180,22 +179,6 @@ func InitSSTableManager(ctx context.Context, config Config, vs *VersionSet, mw M
 		},
 	}
 
-	if vs != nil {
-		levels := make([]*LinkedList[*FileSystem], len(vs.Levels))
-		for lvl, files := range vs.Levels {
-			if len(files) == 0 {
-				continue
-			}
-			ll := InitLinkedList[*FileSystem]()
-			for _, f := range files {
-				fs := &FileSystem{filePath: path.Join(config.databaseDir, sstPath(f.Number))}
-				ll.PushBack(fs)
-			}
-			levels[lvl] = ll
-		}
-		h.levels = levels
-	}
-
 	h.ioSamplerWG.Add(1)
 	go h.startIOLoadSampler()
 
@@ -290,8 +273,7 @@ func (h *SSTableManager) dynamicTriggerHit() bool {
 }
 
 // AddSSTable registers a new SSTable's metadata, persists it to the manifest,
-// and updates the in-memory VersionSet. It keeps the legacy `levels` list in
-// sync until all call sites migrate to VersionSet usage only.
+// and updates the in-memory VersionSet.
 func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
 	ctx, span := sstableMgmtTracer.Start(ctx, "SSTableManager.AddSSTable")
 	start := time.Now()
@@ -321,17 +303,7 @@ func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
 		return err
 	}
 	h.config.fileNumberAllocator.Apply(edit)
-
-	// Maintain legacy levels list for existing compaction code paths.
-	for len(h.levels) <= meta.Level {
-		h.levels = append(h.levels, nil)
-	}
-	if h.levels[meta.Level] == nil {
-		h.levels[meta.Level] = InitLinkedList[*FileSystem]()
-	}
-	fs := &FileSystem{filePath: path.Join(h.config.databaseDir, sstPath(meta.Number))}
-	h.levels[meta.Level].PushBack(fs)
-	INFO(ctx, "Registered new SSTable %s at level %d", fs.Path(), meta.Level)
+	INFO(ctx, "Registered new SSTable %s at level %d", path.Join(h.config.databaseDir, sstPath(meta.Number)), meta.Level)
 	return nil
 }
 
@@ -365,31 +337,6 @@ func (h *SSTableManager) Close(ctx context.Context) {
 	filesToClose := make([]*FileSystem, 0, len(h.openedFs))
 	for _, fs := range h.openedFs {
 		filesToClose = append(filesToClose, fs)
-	}
-
-	for _, level := range h.levels {
-		// Usually, the levels are fully populated
-		// but it's possible that some levels are nil when testing
-		if level == nil {
-			continue
-		}
-		levelIterator := level.Iterator()
-		for levelIterator.HasNext() {
-			fs, err := levelIterator.Next()
-			if err != nil {
-				ERROR(ctx, "Error iterating through level: %v", err)
-				continue
-			}
-			num, nerr := fileNum(fs.Path())
-			alreadyOpened := false
-			if nerr == nil {
-				_, alreadyOpened = h.openedFs[num]
-			}
-			if alreadyOpened {
-				continue
-			}
-			filesToClose = append(filesToClose, fs)
-		}
 	}
 	h.openedFs = make(map[uint64]*FileSystem)
 	h.openedFsMu.Unlock()
@@ -526,27 +473,6 @@ func (h *SSTableManager) findOverlaps(ctx context.Context, level int, inputs []F
 	return over, nil
 }
 
-func (h *SSTableManager) removeFromLevel(ctx context.Context, level int, num uint64) {
-	if level >= len(h.levels) || h.levels[level] == nil {
-		return
-	}
-	target := path.Join(h.config.databaseDir, sstPath(num))
-	it := h.levels[level].Iterator()
-	for it.HasNext() {
-		fs, err := it.Next()
-		if err != nil {
-			ERROR(ctx, "Error iterating in removeFromLevel: %v", err)
-			return
-		}
-		if fs.Path() == target {
-			if err := it.RemoveCurrent(); err != nil {
-				ERROR(ctx, "Error removing file %s from level %d: %v", target, level, err)
-			}
-			return
-		}
-	}
-}
-
 func (h *SSTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []FileMeta) error {
 	if len(inputs) == 0 {
 		return nil
@@ -592,14 +518,6 @@ func (h *SSTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []F
 		return err
 	}
 
-	for len(h.levels) <= dst {
-		h.levels = append(h.levels, nil)
-	}
-	if h.levels[dst] == nil {
-		h.levels[dst] = InitLinkedList[*FileSystem]()
-	}
-	h.levels[dst].PushBack(newFS)
-
 	var (
 		dels     []FileMeta
 		delMetas []DeletedFileMeta
@@ -607,7 +525,6 @@ func (h *SSTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []F
 	for _, fm := range inputs {
 		dels = append(dels, FileMeta{Number: fm.Number})
 		delMetas = append(delMetas, DeletedFileMeta{Level: fm.Level, Number: fm.Number})
-		h.removeFromLevel(ctx, fm.Level, fm.Number)
 	}
 
 	meta.Level = dst

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -33,8 +33,8 @@ func TestSSTableManager_SearchKeyPrevIteration(t *testing.T) {
 	newer := ts.createSSTable(0, map[string]string{"otherKey": "otherVal"})
 
 	// Add to level 0 (older first, then newer)
-	ts.AddSSTableToLevel(0, older)
-	ts.AddSSTableToLevel(0, newer)
+	ts.AddSSTable(0, older)
+	ts.AddSSTable(0, newer)
 
 	// Verify search finds the key in older SSTable
 	result, err := ts.Manager.searchKey(ctx, Bytes("targetKey"))
@@ -183,19 +183,19 @@ func TestSSTableManager_MergeSSTables(t *testing.T) {
 			"2": "3", // Will be tombstoned by sstable2
 			"3": "4",
 		}, 1)
-		ts.AddSSTableToLevel(0, sstable1)
+		ts.AddSSTable(0, sstable1)
 
 		sstable2 := ts.createSSTableWithSequence(0, map[string]string{
 			"1": "3", // Overrides sstable1
 			"2": "",  // Tombstone overrides sstable1
 			"4": "5",
 		}, 10)
-		ts.AddSSTableToLevel(0, sstable2)
+		ts.AddSSTable(0, sstable2)
 
 		sstable3 := ts.createSSTableWithSequence(0, map[string]string{
 			"5": "6",
 		}, 20)
-		ts.AddSSTableToLevel(0, sstable3)
+		ts.AddSSTable(0, sstable3)
 
 		assert.Equal(t, 3, len(ts.Manager.versionSet.Levels[0]))
 
@@ -263,7 +263,7 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		key := Bytes("level0-key")
 		value := Bytes("level0-value")
 		sst := ts.createSSTable(0, map[string]string{string(key): string(value)})
-		ts.AddSSTableToLevel(0, sst)
+		ts.AddSSTable(0, sst)
 
 		result, err := ts.Manager.searchKey(ctx, key)
 		assert.NoError(t, err)
@@ -278,11 +278,11 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		key := randStringBytes(10)
 		oldValue := Bytes("old-value")
 		sst1 := ts.createSSTable(1, map[string]string{string(key): string(oldValue)})
-		ts.AddSSTableToLevel(1, sst1)
+		ts.AddSSTable(1, sst1)
 
 		newValue := Bytes("new-value")
 		sst0 := ts.createSSTable(0, map[string]string{string(key): string(newValue)})
-		ts.AddSSTableToLevel(0, sst0)
+		ts.AddSSTable(0, sst0)
 
 		result, err := ts.Manager.searchKey(ctx, key)
 		assert.NoError(t, err)
@@ -295,7 +295,7 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		defer ts.Cleanup()
 
 		sst := ts.createSSTable(0, map[string]string{"some-key": "some-value"})
-		ts.AddSSTableToLevel(0, sst)
+		ts.AddSSTable(0, sst)
 
 		missingKey := randStringBytes(10)
 		result, err := ts.Manager.searchKey(ctx, missingKey)
@@ -323,7 +323,7 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		key := Bytes("single-key")
 		value := Bytes("single-value")
 		sst := ts.createSSTable(0, map[string]string{string(key): string(value)})
-		ts.AddSSTableToLevel(0, sst)
+		ts.AddSSTable(0, sst)
 
 		result, err := ts.Manager.searchKey(ctx, key)
 		assert.NoError(t, err)
@@ -338,11 +338,11 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		key := Bytes("tombstone-key")
 		value := Bytes("original-value")
 		sst1 := ts.createSSTable(1, map[string]string{string(key): string(value)})
-		ts.AddSSTableToLevel(1, sst1)
+		ts.AddSSTable(1, sst1)
 
 		fs0 := ts.newSSTableFS(0)
 		sst0 := createSSTable(t, cfg, fs0, [2]Bytes{key, nil})
-		ts.AddSSTableToLevel(0, &sst0)
+		ts.AddSSTable(0, &sst0)
 
 		result, err := ts.Manager.searchKey(ctx, key)
 		assert.ErrorIs(t, err, ErrKeyNotFound)
@@ -355,7 +355,7 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		defer ts.Cleanup()
 
 		sst := ts.createSSTable(0, map[string]string{"present-key": "present-value"})
-		ts.AddSSTableToLevel(0, sst)
+		ts.AddSSTable(0, sst)
 
 		result, err := ts.Manager.searchKey(ctx, Bytes("absent-key"))
 		assert.ErrorIs(t, err, ErrKeyNotFound)
@@ -370,7 +370,7 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		key := Bytes("lost-key")
 		value := Bytes("lost-value")
 		sst := ts.createSSTable(0, map[string]string{string(key): string(value)})
-		ts.AddSSTableToLevel(0, sst)
+		ts.AddSSTable(0, sst)
 
 		path := sst.Path()
 		err := os.Remove(path)
@@ -398,7 +398,7 @@ func TestSSTableManager_CompactThreshold(t *testing.T) {
 				fmt.Sprintf("key%d", i): "value",
 			})
 			sstable := ts.createSSTable(0, map[string]string{fmt.Sprintf("key%d", i): "value"})
-			ts.AddSSTableToLevel(0, sstable) // Add the created sstable's FS to the level
+			ts.AddSSTable(0, sstable) // Register the created SSTable
 		}
 
 		assert.True(t, ts.Manager.shouldCompact(ctx, 0, ts.Manager.versionSet.Levels[0]))
@@ -421,7 +421,7 @@ func TestSSTableManager_CompactThreshold(t *testing.T) {
 		initialLevel0Nums := make([]uint64, 0, level0FileCount)
 		for i := 0; i < level0FileCount; i++ {
 			sstable := ts.createSSTable(0, map[string]string{fmt.Sprintf("l0-key%d", i): "value"})
-			ts.AddSSTableToLevel(0, sstable)
+			ts.AddSSTable(0, sstable)
 			num, err := fileNum(sstable.Path())
 			require.NoError(t, err)
 			initialLevel0Nums = append(initialLevel0Nums, num)
@@ -432,7 +432,7 @@ func TestSSTableManager_CompactThreshold(t *testing.T) {
 		level1FileCount := 1
 		initialLevel1Nums := make([]uint64, level1FileCount)
 		sstable1 := ts.createSSTable(1, map[string]string{"l1-key": "small-value"})
-		ts.AddSSTableToLevel(1, sstable1)
+		ts.AddSSTable(1, sstable1)
 		num1, err := fileNum(sstable1.Path())
 		require.NoError(t, err)
 		initialLevel1Nums[0] = num1
@@ -488,7 +488,7 @@ func TestSSTableManager_CompactThreshold(t *testing.T) {
 				kvs[string(p[0])] = string(p[1])
 			}
 			sstable := ts.createSSTable(1, kvs) // Create in level 1
-			ts.AddSSTableToLevel(1, sstable)
+			ts.AddSSTable(1, sstable)
 
 			level1Paths[i] = sstable.Path()
 			info, statErr := os.Stat(sstable.Path())
@@ -540,8 +540,8 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 
 		older := ts.createSSTable(0, map[string]string{"a": "1"})
 		newer := ts.createSSTable(0, map[string]string{"b": "2"})
-		ts.AddSSTableToLevel(0, older)
-		ts.AddSSTableToLevel(0, newer)
+		ts.AddSSTable(0, older)
+		ts.AddSSTable(0, newer)
 
 		nOlder, err := fileNum(older.Path())
 		require.NoError(t, err)
@@ -559,8 +559,8 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 
 		older := ts.createSSTable(1, map[string]string{"b": "1"})
 		newer := ts.createSSTable(1, map[string]string{"c": "2"})
-		ts.AddSSTableToLevel(1, older)
-		ts.AddSSTableToLevel(1, newer)
+		ts.AddSSTable(1, older)
+		ts.AddSSTable(1, newer)
 
 		nOlder, err := fileNum(older.Path())
 		require.NoError(t, err)
@@ -577,7 +577,7 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		defer ts.Cleanup()
 
 		sst := ts.createSSTable(1, map[string]string{"x": "1"})
-		ts.AddSSTableToLevel(1, sst)
+		ts.AddSSTable(1, sst)
 
 		nums := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("b"))
 		assert.Len(t, nums, 0)
@@ -599,7 +599,7 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		defer ts.Cleanup()
 
 		sst := ts.createSSTable(1, map[string]string{"b": "1"})
-		ts.AddSSTableToLevel(1, sst)
+		ts.AddSSTable(1, sst)
 		assert.NoError(t, os.Remove(sst.Path()))
 
 		nums := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("z"))
@@ -614,14 +614,14 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		// Level 0
 		l0a := ts.createSSTable(0, map[string]string{"a": "1"}) // older
 		l0b := ts.createSSTable(0, map[string]string{"b": "2"}) // newer
-		ts.AddSSTableToLevel(0, l0a)
-		ts.AddSSTableToLevel(0, l0b)
+		ts.AddSSTable(0, l0a)
+		ts.AddSSTable(0, l0b)
 
 		// Level 1
 		l1Overlap := ts.createSSTable(1, map[string]string{"b": "1", "c": "2"})
 		l1Non := ts.createSSTable(1, map[string]string{"x": "1"})
-		ts.AddSSTableToLevel(1, l1Overlap)
-		ts.AddSSTableToLevel(1, l1Non)
+		ts.AddSSTable(1, l1Overlap)
+		ts.AddSSTable(1, l1Non)
 
 		nL0b, err := fileNum(l0b.Path())
 		require.NoError(t, err)
@@ -659,7 +659,6 @@ func TestSSTableManager_DynamicShouldCompact(t *testing.T) {
 
 			sm := &SSTableManager{
 				openedFs:       make(map[uint64]*FileSystem),
-				levels:         []*LinkedList[*FileSystem]{InitLinkedList[*FileSystem]()},
 				versionSet:     &VersionSet{Levels: [][]FileMeta{{{Number: 1, Level: 0}}}},
 				config:         cfg,
 				now:            func() time.Time { return current },
@@ -865,8 +864,8 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		sst2, _, err := flush(ctx, *ts.Config, mem2, ts.newSSTableFS(0))
 		assert.NoError(t, err)
 
-		ts.AddSSTableToLevel(0, &sst1)
-		ts.AddSSTableToLevel(0, &sst2)
+		ts.AddSSTable(0, &sst1)
+		ts.AddSSTable(0, &sst2)
 
 		target := ts.newSSTableFS(1)
 		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2}, false, math.MaxUint64)
@@ -1064,8 +1063,8 @@ func TestSSTableManager_compactLevel0(t *testing.T) {
 
 		l0a := ts.createSSTable(0, map[string]string{"a": "1"})
 		l0b := ts.createSSTable(0, map[string]string{"b": "2"})
-		ts.AddSSTableToLevel(0, l0a)
-		ts.AddSSTableToLevel(0, l0b)
+		ts.AddSSTable(0, l0a)
+		ts.AddSSTable(0, l0b)
 		require.NoError(t, l0a.Close())
 		require.NoError(t, l0b.Close())
 
@@ -1085,11 +1084,11 @@ func TestSSTableManager_compactLevel0(t *testing.T) {
 		defer ts.Cleanup()
 
 		l0 := ts.createSSTable(0, map[string]string{"b": "1"})
-		ts.AddSSTableToLevel(0, l0)
+		ts.AddSSTable(0, l0)
 		overlap := ts.createSSTable(1, map[string]string{"b": "old"})
-		ts.AddSSTableToLevel(1, overlap)
+		ts.AddSSTable(1, overlap)
 		non := ts.createSSTable(1, map[string]string{"z": "1"})
-		ts.AddSSTableToLevel(1, non)
+		ts.AddSSTable(1, non)
 		require.NoError(t, l0.Close())
 		require.NoError(t, overlap.Close())
 		require.NoError(t, non.Close())
@@ -1120,7 +1119,7 @@ func TestSSTableManager_compactLevel0(t *testing.T) {
 		defer ts.Cleanup()
 
 		l0 := ts.createSSTable(0, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(0, l0)
+		ts.AddSSTable(0, l0)
 		require.NoError(t, l0.Close())
 		require.NoError(t, os.Remove(l0.FileSystem.Path()))
 		require.NoError(t, os.Mkdir(l0.FileSystem.Path(), 0o700))
@@ -1136,9 +1135,9 @@ func TestSSTableManager_compactLevel0(t *testing.T) {
 		defer ts.Cleanup()
 
 		l0 := ts.createSSTable(0, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(0, l0)
+		ts.AddSSTable(0, l0)
 		overlap := ts.createSSTable(1, map[string]string{"a": "old"})
-		ts.AddSSTableToLevel(1, overlap)
+		ts.AddSSTable(1, overlap)
 		require.NoError(t, l0.Close())
 		require.NoError(t, overlap.Close())
 		require.NoError(t, os.Remove(overlap.FileSystem.Path()))
@@ -1158,7 +1157,7 @@ func TestSSTableManager_compactLevel0(t *testing.T) {
 		defer ts.Cleanup()
 
 		l0 := ts.createSSTable(0, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(0, l0)
+		ts.AddSSTable(0, l0)
 		require.NoError(t, l0.Close())
 
 		next := ts.Manager.config.fileNumberAllocator.Peek()
@@ -1180,11 +1179,11 @@ func TestSSTableManager_compactHigherLevel(t *testing.T) {
 		defer ts.Cleanup()
 
 		src := ts.createSSTable(1, map[string]string{"b": "1"})
-		ts.AddSSTableToLevel(1, src)
+		ts.AddSSTable(1, src)
 		overlap := ts.createSSTable(2, map[string]string{"b": "old"})
-		ts.AddSSTableToLevel(2, overlap)
+		ts.AddSSTable(2, overlap)
 		non := ts.createSSTable(2, map[string]string{"z": "1"})
-		ts.AddSSTableToLevel(2, non)
+		ts.AddSSTable(2, non)
 		require.NoError(t, src.Close())
 		require.NoError(t, overlap.Close())
 		require.NoError(t, non.Close())
@@ -1215,9 +1214,9 @@ func TestSSTableManager_compactHigherLevel(t *testing.T) {
 		defer ts.Cleanup()
 
 		src := ts.createSSTable(1, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(1, src)
+		ts.AddSSTable(1, src)
 		l2 := ts.createSSTable(2, map[string]string{"z": "1"})
-		ts.AddSSTableToLevel(2, l2)
+		ts.AddSSTable(2, l2)
 		require.NoError(t, src.Close())
 		require.NoError(t, l2.Close())
 
@@ -1244,7 +1243,7 @@ func TestSSTableManager_compactHigherLevel(t *testing.T) {
 		defer ts.Cleanup()
 
 		src := ts.createSSTable(1, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(1, src)
+		ts.AddSSTable(1, src)
 		require.NoError(t, src.Close())
 		require.NoError(t, os.Remove(src.FileSystem.Path()))
 		require.NoError(t, os.Mkdir(src.FileSystem.Path(), 0o700))
@@ -1260,9 +1259,9 @@ func TestSSTableManager_compactHigherLevel(t *testing.T) {
 		defer ts.Cleanup()
 
 		src := ts.createSSTable(1, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(1, src)
+		ts.AddSSTable(1, src)
 		overlap := ts.createSSTable(2, map[string]string{"a": "old"})
-		ts.AddSSTableToLevel(2, overlap)
+		ts.AddSSTable(2, overlap)
 		require.NoError(t, src.Close())
 		require.NoError(t, overlap.Close())
 		require.NoError(t, os.Remove(overlap.FileSystem.Path()))
@@ -1282,7 +1281,7 @@ func TestSSTableManager_compactHigherLevel(t *testing.T) {
 		defer ts.Cleanup()
 
 		src := ts.createSSTable(1, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(1, src)
+		ts.AddSSTable(1, src)
 		require.NoError(t, src.Close())
 
 		next := ts.Manager.config.fileNumberAllocator.Peek()
@@ -1304,7 +1303,7 @@ func TestSSTableManager_mergeIntoLevel(t *testing.T) {
 		defer ts.Cleanup()
 
 		src := ts.createSSTable(0, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(0, src)
+		ts.AddSSTable(0, src)
 		require.NoError(t, src.Close())
 		srcPath := src.FileSystem.Path()
 
@@ -1327,7 +1326,7 @@ func TestSSTableManager_mergeIntoLevel(t *testing.T) {
 		defer ts.Cleanup()
 
 		src := ts.createSSTable(0, map[string]string{"a": "1"})
-		ts.AddSSTableToLevel(0, src)
+		ts.AddSSTable(0, src)
 		require.NoError(t, src.Close())
 		srcPath := src.FileSystem.Path()
 
@@ -1351,7 +1350,7 @@ func TestSSTableManager_mergeIntoLevel(t *testing.T) {
 		mem.Put(newRecord(Bytes("a"), nil, 1))
 		sst, _, err := flush(ctx, *ts.Config, mem, fs)
 		require.NoError(t, err)
-		ts.AddSSTableToLevel(0, &sst)
+		ts.AddSSTable(0, &sst)
 		require.NoError(t, sst.Close())
 
 		ts.Manager.minSnapshotSeq = 1
@@ -1477,11 +1476,11 @@ func TestSSTableManager_findOverlappingSSTables(t *testing.T) {
 		defer ts.Cleanup()
 
 		l0 := ts.createSSTable(0, map[string]string{"b": "1"})
-		ts.AddSSTableToLevel(0, l0)
+		ts.AddSSTable(0, l0)
 		overlap := ts.createSSTable(1, map[string]string{"b": "old"})
-		ts.AddSSTableToLevel(1, overlap)
+		ts.AddSSTable(1, overlap)
 		non := ts.createSSTable(1, map[string]string{"z": "1"})
-		ts.AddSSTableToLevel(1, non)
+		ts.AddSSTable(1, non)
 		require.NoError(t, l0.Close())
 		require.NoError(t, overlap.Close())
 		require.NoError(t, non.Close())

--- a/utils_test.go
+++ b/utils_test.go
@@ -172,8 +172,8 @@ func (ts *testRindbSetup) createSSTableWithSequence(level int, kvs map[string]st
 	return &sstable
 }
 
-// AddSSTableToLevel adds an SSTable to the specified level.
-func (ts *testRindbSetup) AddSSTableToLevel(level int, sstable *SStable) {
+// AddSSTable registers an SSTable at the specified level.
+func (ts *testRindbSetup) AddSSTable(level int, sstable *SStable) {
 	if ts.Manager.versionSet == nil {
 		ts.Manager.versionSet = &VersionSet{}
 	}


### PR DESCRIPTION
## Summary
- drop legacy `levels` linked lists so `VersionSet` owns SSTable metadata
- rename test helper to `AddSSTable` and update tests
- clarify version plan docs that `VersionSet` is the sole metadata source

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b70d5b87c88325a874706ef954ce84