### PR TITLE
refactor: fold last sequence into AddSSTable

### DIFF
--- a/docs/dev/53/overall_plan.md
+++ b/docs/dev/53/overall_plan.md
@@ -187,11 +187,9 @@ func InitSSTableManager(ctx context.Context, cfg Config) (*SSTableManager, error
 - Replace the current level list with a `VersionSet` reference.
 ```go
 type SSTableManager struct {
-    openedFs map[uint64]*FileSystem
--   levels   []*LinkedList[*FileSystem]
     config   Config
     mu       sync.RWMutex
-+   versionSet *VersionSet // replaces levels as the source of truth
+    versionSet *VersionSet // replaces levels as the source of truth
     // ...
 }
 ```

--- a/docs/dev/53/read_path_plan.md
+++ b/docs/dev/53/read_path_plan.md
@@ -36,5 +36,5 @@ func (h *SSTableManager) searchKey(ctx context.Context, key InternalKey) ([]byte
 ```
 
 ## Follow Ups
-- `removeOpenedFS` switches to `map[uint64]*FileSystem`.
+- Legacy `openedFs` tracking has been removed; callers close file systems directly.
 - Tests seed `VersionSet` fixtures and assert lookups by file number.

--- a/docs/dev/53/sstablemgmt_version_plan.md
+++ b/docs/dev/53/sstablemgmt_version_plan.md
@@ -8,8 +8,6 @@ so that `VersionSet` becomes the sole source of truth.
 ```go
 // levels field deleted; versionSet drives all metadata.
 type SSTableManager struct {
-    openedFsMu  sync.Mutex
-    openedFs    map[uint64]*FileSystem
     openedByNum map[uint64]*SStable
 
     versionSet *VersionSet
@@ -53,11 +51,10 @@ func InitSSTableManager(ctx context.Context, cfg Config, vs *VersionSet, mw Mani
         vs.Levels = [][]FileMeta{metas}
     }
     return &SSTableManager{
-        openedFs:    make(map[uint64]*FileSystem),
-        openedByNum: make(map[uint64]*SStable),
-        versionSet:  vs,
-        manifest:    mw,
-        config:      cfg,
+        openedByNum:       make(map[uint64]*SStable),
+        versionSet:        vs,
+        manifest:          mw,
+        config:            cfg,
         stopIOLoadSampler: make(chan struct{}),
         now:               time.Now,
         minSnapshotSeq:    math.MaxUint64,
@@ -72,10 +69,11 @@ into a slice and assigned to `vs.Levels` (all files start in Level 0), mirrorin
 
 ## SSTable Registration
 ```go
-func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
+func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta, lastSeq uint64) error {
     edit := VersionEdit{
         AddFiles:       []FileMeta{meta},
         NextFileNumber: h.config.fileNumberAllocator.Peek(),
+        LastSequence:   lastSeq,
     }
     if h.manifest != nil {
         if err := h.manifest.Append(edit); err != nil { return err }
@@ -91,9 +89,7 @@ func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
 }
 ```
 
-AddSSTable first appends a `VersionEdit` to the manifest so the on-disk log matches memory even if the process crashes. The mutex
-only guards the in-memory `versionSet` mutation and allocator update; readers proceed concurrently. `NextFileNumber` keeps the allocator in sync with
-files registered in the manifest.
+AddSSTable first appends a `VersionEdit` to the manifest so the on-disk log matches memory even if the process crashes. The edit carries the caller's `lastSeq`, persisting the new `LastSequence` alongside file registration. The mutex only guards the in-memory `versionSet` mutation and allocator update; readers proceed concurrently. `NextFileNumber` keeps the allocator in sync with files registered in the manifest.
 
 ## Compaction Flow
 ```go
@@ -295,7 +291,7 @@ func newTestRindbSetup(t *testing.T, ctx context.Context, cfg *Config) *testRind
 }
 
 func (ts *testRindbSetup) AddSSTable(meta FileMeta) {
-    require.NoError(ts.T, ts.Manager.AddSSTable(context.Background(), meta))
+    require.NoError(ts.T, ts.Manager.AddSSTable(context.Background(), meta, meta.SeqHi))
 }
 
 func (ts *testRindbSetup) createSSTable(level int, kv map[string]string) (FileMeta, *SStable) {
@@ -328,7 +324,7 @@ these helpers and the `SSTableManager`. The helper carries the opened database v
    - Remove the legacy `LoadLevels` function and update all call sites.
 
 3. **Introduce manifest-backed SSTable registration.**
-   - Add `AddSSTable(ctx, meta FileMeta)` which appends a `VersionEdit` to the manifest, syncs it, then updates `versionSet` and the file-number allocator under lock.
+   - Add `AddSSTable(ctx, meta FileMeta, lastSeq uint64)` which appends a `VersionEdit` to the manifest with `LastSequence`, syncs it, then updates `versionSet` and the file-number allocator under lock.
 
 4. **Overhaul compaction logic.**
    - Replace `compactLevel0`, `compactHigherLevel`, `findOverlappingSSTables`, and `removeOverlappingFromLevel` with a version-set driven pipeline that picks compaction candidates, locates overlaps, merges them, and applies the resulting `VersionEdit`.

--- a/rindb.go
+++ b/rindb.go
@@ -352,31 +352,16 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			return fmt.Errorf("failed to flush memtable: %w", err)
 		}
 
-		if err := r.ssTableManager.AddSSTable(ctx, meta); err != nil {
+		if err := r.ssTableManager.AddSSTable(ctx, meta, r.sequenceNumber); err != nil {
 			_ = fs.Close()
 			ERROR(ctx, "Failed to register new SSTable %s: %v", fs.Path(), err)
 			return fmt.Errorf("failed to register new SSTable %s: %w", fs.Path(), err)
 		}
-		// Close and deregister the writable FileSystem now that metadata is persisted.
+		// Close the writable FileSystem now that metadata is persisted.
 		if err := fs.Close(); err != nil {
 			WARN(ctx, "Failed to close FileSystem %s: %v", fs.Path(), err)
 		}
-		if err := r.ssTableManager.removeOpenedFS(fs); err != nil {
-			WARN(ctx, "Failed to remove opened file %s: %v", fs.Path(), err)
-		}
 
-		edit := VersionEdit{LastSequence: r.sequenceNumber}
-		if err := r.manifest.Append(edit); err != nil {
-			ERROR(ctx, "Failed to append manifest edit: %v", err)
-			return err
-		}
-		if err := r.manifest.Sync(); err != nil {
-			ERROR(ctx, "Failed to sync manifest: %v", err)
-			return err
-		}
-		if err := edit.Apply(r.versionSet); err != nil {
-			return err
-		}
 		if err := r.maybeRotateManifest(ctx); err != nil {
 			return err
 		}

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -287,8 +287,10 @@ func TestRindb_GetPrecedence(t *testing.T) {
 	info, err := os.Stat(fs.Path())
 	assert.NoError(t, err)
 	small, large := sst.GetKeyRange()
-	meta := FileMeta{Number: num, Level: 0, Smallest: InternalKey{UserKey: small}, Largest: InternalKey{UserKey: large}, Size: uint64(info.Size())}
-	assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta, meta.SeqHi))
+	seqHi, err := sst.MaxSequenceNumber()
+	assert.NoError(t, err)
+	meta := FileMeta{Number: num, Level: 0, Smallest: InternalKey{UserKey: small}, Largest: InternalKey{UserKey: large}, Size: uint64(info.Size()), SeqHi: seqHi}
+	assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta, seqHi))
 	err = rin.Put(ctx, Bytes("k1"), Bytes("v1-mem")) // Put the value into the memtable
 	assert.NoError(t, err)
 	v, err := rin.Get(ctx, Bytes("k1"))

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -288,7 +288,7 @@ func TestRindb_GetPrecedence(t *testing.T) {
 	assert.NoError(t, err)
 	small, large := sst.GetKeyRange()
 	meta := FileMeta{Number: num, Level: 0, Smallest: InternalKey{UserKey: small}, Largest: InternalKey{UserKey: large}, Size: uint64(info.Size())}
-	assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta))
+	assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta, meta.SeqHi))
 	err = rin.Put(ctx, Bytes("k1"), Bytes("v1-mem")) // Put the value into the memtable
 	assert.NoError(t, err)
 	v, err := rin.Get(ctx, Bytes("k1"))
@@ -505,13 +505,8 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 		mem.Put(newRecord(Bytes("sk2"), Bytes("sv2"), 60))
 		_, meta, err := flush(ctx, rin.config, mem, fs)
 		assert.NoError(t, err)
-		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta))
+		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta, meta.SeqHi))
 		assert.NoError(t, fs.Close())
-		assert.NoError(t, rin.ssTableManager.removeOpenedFS(fs))
-		edit := VersionEdit{LastSequence: meta.SeqHi}
-		assert.NoError(t, rin.manifest.Append(edit))
-		assert.NoError(t, rin.manifest.Sync())
-		assert.NoError(t, edit.Apply(rin.versionSet))
 
 		// Also create a WAL with a lower sequence number to ensure SSTable takes precedence
 		wp := path.Join(rin.config.databaseDir, walPath(1))
@@ -549,13 +544,8 @@ func TestInitRinDB_MaxSequenceNumber(t *testing.T) {
 		mem.Put(newRecord(Bytes("sk1"), Bytes("sv1"), 70))
 		_, meta, err := flush(ctx, rin.config, mem, fs)
 		assert.NoError(t, err)
-		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta))
+		assert.NoError(t, rin.ssTableManager.AddSSTable(ctx, meta, meta.SeqHi))
 		assert.NoError(t, fs.Close())
-		assert.NoError(t, rin.ssTableManager.removeOpenedFS(fs))
-		edit := VersionEdit{LastSequence: meta.SeqHi}
-		assert.NoError(t, rin.manifest.Append(edit))
-		assert.NoError(t, rin.manifest.Sync())
-		assert.NoError(t, edit.Apply(rin.versionSet))
 
 		// Create a WAL with the same highest sequence number
 		// The database directory is already created by initRinDBWithCleanup

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -26,9 +26,7 @@ const writeRateAlpha = 0.2
 // - Manages file handles for SSTables
 // - Coordinates concurrent access with read/write locks
 type SSTableManager struct {
-	openedFsMu  sync.Mutex
-	openedFs    map[uint64]*FileSystem // legacy tracking for compaction paths
-	openedByNum map[uint64]*SStable    // open SSTables keyed by file number
+	openedByNum map[uint64]*SStable // open SSTables keyed by file number
 	versionSet  *VersionSet
 	manifest    ManifestWriter
 	config      Config
@@ -61,8 +59,7 @@ type SSTableManager struct {
 	diskSampler func() (uint64, error)
 }
 
-// openAndLoadSSTable opens a FileSystem, creates an SSTable object from it,
-// and adds the FileSystem to the manager's list of opened file systems.
+// openAndLoadSSTable opens a FileSystem and creates an SSTable object from it.
 // It returns the created *SSTable or an error.
 func (h *SSTableManager) openAndLoadSSTable(ctx context.Context, fs *FileSystem) (*SStable, error) {
 	if err := fs.Open(ctx); err != nil {
@@ -73,14 +70,6 @@ func (h *SSTableManager) openAndLoadSSTable(ctx context.Context, fs *FileSystem)
 		_ = fs.Close() // Ensure file is closed on SSTable creation error
 		return nil, fmt.Errorf("failed to create sstable object for %s: %w", fs.Path(), err)
 	}
-	num, err := fileNum(fs.Path())
-	if err != nil {
-		_ = fs.Close()
-		return nil, fmt.Errorf("invalid sstable path %s: %w", fs.Path(), err)
-	}
-	h.openedFsMu.Lock()
-	h.openedFs[num] = fs // Track opened file system
-	h.openedFsMu.Unlock()
 	return &sstable, nil
 }
 
@@ -155,7 +144,6 @@ func InitSSTableManager(ctx context.Context, config Config, vs *VersionSet, mw M
 	}
 
 	h := &SSTableManager{
-		openedFs:          make(map[uint64]*FileSystem),
 		openedByNum:       make(map[uint64]*SStable),
 		versionSet:        vs,
 		manifest:          mw,
@@ -274,7 +262,7 @@ func (h *SSTableManager) dynamicTriggerHit() bool {
 
 // AddSSTable registers a new SSTable's metadata, persists it to the manifest,
 // and updates the in-memory VersionSet.
-func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
+func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta, lastSeq uint64) error {
 	ctx, span := sstableMgmtTracer.Start(ctx, "SSTableManager.AddSSTable")
 	start := time.Now()
 	defer func() {
@@ -286,6 +274,7 @@ func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta) error {
 	edit := VersionEdit{
 		AddFiles:       []FileMeta{meta},
 		NextFileNumber: h.config.fileNumberAllocator.Peek(),
+		LastSequence:   lastSeq,
 	}
 	if h.manifest != nil {
 		if err := h.manifest.Append(edit); err != nil {
@@ -314,10 +303,6 @@ func (h *SSTableManager) NewSSTableFS(ctx context.Context, levelNumb int) (*File
 	if err != nil {
 		return nil, err
 	}
-
-	h.openedFsMu.Lock()
-	h.openedFs[id] = fs
-	h.openedFsMu.Unlock()
 	return fs, nil
 }
 
@@ -328,34 +313,16 @@ func (h *SSTableManager) Close(ctx context.Context) {
 	}
 
 	h.mu.Lock()
-	h.openedFsMu.Lock()
 	sstablesToClose := make([]*SStable, 0, len(h.openedByNum))
 	for _, s := range h.openedByNum {
 		sstablesToClose = append(sstablesToClose, s)
 	}
 	h.openedByNum = make(map[uint64]*SStable)
-	filesToClose := make([]*FileSystem, 0, len(h.openedFs))
-	for _, fs := range h.openedFs {
-		filesToClose = append(filesToClose, fs)
-	}
-	h.openedFs = make(map[uint64]*FileSystem)
-	h.openedFsMu.Unlock()
 	h.mu.Unlock()
 
 	for _, s := range sstablesToClose {
 		if err := s.Close(); err != nil {
 			WARN(ctx, "Error closing sstable %s: %v", s.Path(), err)
-		}
-	}
-	for _, fs := range filesToClose {
-		if !fs.IsOpened() {
-			WARN(ctx, "File %s is already closed", fs.Path())
-			continue
-		}
-		if err := fs.Close(); err != nil {
-			ERROR(ctx, "Error closing file %s: %v", fs.Path(), err)
-		} else {
-			INFO(ctx, "Closed %s successfully", fs.Path())
 		}
 	}
 }
@@ -509,9 +476,6 @@ func (h *SSTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []F
 	h.closeSSTables(ctx, sources)
 	if err != nil || merged == nil {
 		_ = newFS.Close()
-		if rmErr := h.removeOpenedFS(newFS); rmErr != nil {
-			WARN(ctx, "Failed to remove opened file %s: %v", newFS.Path(), rmErr)
-		}
 		if rmErr := os.Remove(newFS.Path()); rmErr != nil && err == nil {
 			ERROR(ctx, "Error removing file %s: %v", newFS.Path(), rmErr)
 		}
@@ -553,23 +517,8 @@ func (h *SSTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []F
 
 func (h *SSTableManager) closeSSTables(ctx context.Context, sstables []SStable) {
 	for i := range sstables {
-		fs := sstables[i].FileSystem
 		_ = sstables[i].Close()
-		if err := h.removeOpenedFS(fs); err != nil {
-			WARN(ctx, "Failed to remove opened file %s: %v", fs.Path(), err)
-		}
 	}
-}
-
-func (h *SSTableManager) removeOpenedFS(target *FileSystem) error {
-	num, err := fileNum(target.Path())
-	if err != nil {
-		return err
-	}
-	h.openedFsMu.Lock()
-	delete(h.openedFs, num)
-	h.openedFsMu.Unlock()
-	return nil
 }
 
 // openByNumber returns an opened SSTable for the given file number. The

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -271,6 +271,10 @@ func (h *SSTableManager) AddSSTable(ctx context.Context, meta FileMeta, lastSeq 
 		addSSTableCalls.Add(ctx, 1)
 	}()
 
+	if lastSeq == 0 {
+		return fmt.Errorf("lastSeq must be greater than zero")
+	}
+
 	edit := VersionEdit{
 		AddFiles:       []FileMeta{meta},
 		NextFileNumber: h.config.fileNumberAllocator.Peek(),
@@ -517,7 +521,9 @@ func (h *SSTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []F
 
 func (h *SSTableManager) closeSSTables(ctx context.Context, sstables []SStable) {
 	for i := range sstables {
-		_ = sstables[i].Close()
+		if err := sstables[i].Close(); err != nil {
+			WARN(ctx, "Error closing sstable %s: %v", sstables[i].Path(), err)
+		}
 	}
 }
 

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -658,7 +658,6 @@ func TestSSTableManager_DynamicShouldCompact(t *testing.T) {
 			ioVal := uint64(0)
 
 			sm := &SSTableManager{
-				openedFs:       make(map[uint64]*FileSystem),
 				versionSet:     &VersionSet{Levels: [][]FileMeta{{{Number: 1, Level: 0}}}},
 				config:         cfg,
 				now:            func() time.Time { return current },
@@ -1485,10 +1484,6 @@ func TestSSTableManager_findOverlappingSSTables(t *testing.T) {
 		require.NoError(t, overlap.Close())
 		require.NoError(t, non.Close())
 
-		ts.Manager.openedFsMu.Lock()
-		ts.Manager.openedFs = make(map[uint64]*FileSystem)
-		ts.Manager.openedFsMu.Unlock()
-
 		picked := append([]FileMeta(nil), ts.Manager.versionSet.Levels[0]...)
 		overlaps, err := ts.Manager.findOverlaps(ctx, 1, picked)
 		require.NoError(t, err)
@@ -1500,10 +1495,6 @@ func TestSSTableManager_findOverlappingSSTables(t *testing.T) {
 
 		err = ts.Manager.mergeIntoLevel(ctx, 1, append(overlaps, picked...))
 		assert.Error(t, err)
-
-		ts.Manager.openedFsMu.Lock()
-		defer ts.Manager.openedFsMu.Unlock()
-		assert.Empty(t, ts.Manager.openedFs)
 	})
 
 	t.Run("Empty sources", func(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -185,7 +185,7 @@ func (ts *testRindbSetup) AddSSTable(level int, sstable *SStable) {
 	assert.NoError(ts.T, err)
 	small, large := sstable.GetKeyRange()
 	meta := FileMeta{Number: num, Level: level, Smallest: InternalKey{UserKey: small}, Largest: InternalKey{UserKey: large}, Size: uint64(info.Size())}
-	assert.NoError(ts.T, ts.Manager.AddSSTable(context.Background(), meta))
+	assert.NoError(ts.T, ts.Manager.AddSSTable(context.Background(), meta, meta.SeqHi))
 }
 
 // initTempFileSystems creates n temporary FileSystem instances for testing and returns a cleanup function.

--- a/utils_test.go
+++ b/utils_test.go
@@ -184,8 +184,10 @@ func (ts *testRindbSetup) AddSSTable(level int, sstable *SStable) {
 	info, err := os.Stat(sstable.Path())
 	assert.NoError(ts.T, err)
 	small, large := sstable.GetKeyRange()
-	meta := FileMeta{Number: num, Level: level, Smallest: InternalKey{UserKey: small}, Largest: InternalKey{UserKey: large}, Size: uint64(info.Size())}
-	assert.NoError(ts.T, ts.Manager.AddSSTable(context.Background(), meta, meta.SeqHi))
+	seqHi, err := sstable.MaxSequenceNumber()
+	assert.NoError(ts.T, err)
+	meta := FileMeta{Number: num, Level: level, Smallest: InternalKey{UserKey: small}, Largest: InternalKey{UserKey: large}, Size: uint64(info.Size()), SeqHi: seqHi}
+	assert.NoError(ts.T, ts.Manager.AddSSTable(context.Background(), meta, seqHi))
 }
 
 // initTempFileSystems creates n temporary FileSystem instances for testing and returns a cleanup function.


### PR DESCRIPTION
## Summary
- include last sequence in SSTable registration to avoid redundant manifest edits
- drop legacy opened file tracking in SSTableManager
- update docs and tests for new API

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b713d3194c8325b00df7b575d728f2