### PR TITLE
perf: rotate manifest in background

### DIFF
--- a/manifest_rotation.go
+++ b/manifest_rotation.go
@@ -79,15 +79,17 @@ func (r *Rindb) maybeRotateManifest(ctx context.Context) error {
 	if fi.Size() <= r.config.manifestSizeThreshold {
 		return nil
 	}
+
+	r.ssTableManager.mu.Lock()
 	mw, newPath, err := rotateManifest(ctx, r.config, r.versionSet, r.manifestPath)
 	if err != nil {
+		r.ssTableManager.mu.Unlock()
 		return err
 	}
 
 	old := r.manifest
 	r.manifest = mw
 	r.manifestPath = newPath
-	r.ssTableManager.mu.Lock()
 	r.ssTableManager.manifest = mw
 	r.ssTableManager.mu.Unlock()
 	if old != nil {

--- a/rindb.go
+++ b/rindb.go
@@ -362,10 +362,6 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			WARN(ctx, "Failed to close FileSystem %s: %v", fs.Path(), err)
 		}
 
-		if err := r.maybeRotateManifest(ctx); err != nil {
-			return err
-		}
-
 		// Clear the memtable and clean the WAL *after* successful flush and registration
 		r.memtable.Clear()
 		snapMin := r.minSnapshotSeq()
@@ -382,11 +378,11 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 		// Capture the sequence number at flush time for later cleanup.
 		flushSeq := r.sequenceNumber
 
-		// Trigger compaction in a goroutine *after* flushing
+		// Trigger compaction and manifest rotation in a goroutine *after* flushing
 		INFO(ctx, "Triggering background compaction check.")
 		r.wg.Add(1)
 		compactionCtx := trace.ContextWithSpan(context.Background(), trace.SpanFromContext(ctx))
-		go func(ctx context.Context) {
+		go func(ctx context.Context, flushSeq uint64) {
 			defer r.wg.Done()
 			INFO(ctx, "Background compaction goroutine started.")
 			if err := r.ssTableManager.Compact(ctx); err != nil {
@@ -395,11 +391,14 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 				INFO(ctx, "Background compaction goroutine finished.")
 			}
 			r.mu.Lock()
+			if err := r.maybeRotateManifest(ctx); err != nil {
+				ERROR(ctx, "Manifest rotation failed: %v", err)
+			}
 			if err := r.cleanupObsoleteLocked(ctx, flushSeq); err != nil {
 				ERROR(ctx, "Post-compaction cleanup failed: %v", err)
 			}
 			r.mu.Unlock()
-		}(compactionCtx)
+		}(compactionCtx, flushSeq)
 	}
 
 	r.mu.Unlock()


### PR DESCRIPTION
## Summary
- defer manifest rotation to background goroutine with compaction and cleanup
- avoid blocking puts on manifest rotation

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b7a6ca04f4832590eddaf900a98ddc