### PR TITLE
refactor: remove manifest path field

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -17,6 +17,7 @@ type ManifestWriter interface {
 	Append(VersionEdit) error
 	Sync() error
 	Close() error
+	Path() string
 }
 
 // ManifestReader iterates over manifest records.
@@ -66,6 +67,7 @@ func (w *fileManifestWriter) Append(edit VersionEdit) error {
 
 func (w *fileManifestWriter) Sync() error  { return w.fs.Sync() }
 func (w *fileManifestWriter) Close() error { return w.fs.Close() }
+func (w *fileManifestWriter) Path() string { return w.fs.Path() }
 
 // NewManifestReader opens a reader for the manifest at path.
 func NewManifestReader(ctx context.Context, path string) (ManifestReader, error) {

--- a/manifest_rotation.go
+++ b/manifest_rotation.go
@@ -68,10 +68,11 @@ func rotateManifest(ctx context.Context, cfg Config, vs *VersionSet, currentPath
 // it exceeds the configured threshold. It swaps r.manifest and updates related
 // fields atomically.
 func (r *Rindb) maybeRotateManifest(ctx context.Context) error {
-	if r.manifestPath == "" {
+	path := r.manifest.Path()
+	if path == "" {
 		return nil
 	}
-	fi, err := os.Stat(r.manifestPath)
+	fi, err := os.Stat(path)
 	if err != nil {
 		return err
 	}
@@ -80,7 +81,7 @@ func (r *Rindb) maybeRotateManifest(ctx context.Context) error {
 	}
 
 	r.ssTableManager.mu.Lock()
-	mw, newPath, err := rotateManifest(ctx, r.config, r.versionSet, r.manifestPath)
+	mw, _, err := rotateManifest(ctx, r.config, r.versionSet, path)
 	if err != nil {
 		r.ssTableManager.mu.Unlock()
 		return err
@@ -88,7 +89,6 @@ func (r *Rindb) maybeRotateManifest(ctx context.Context) error {
 
 	old := r.manifest
 	r.manifest = mw
-	r.manifestPath = newPath
 	r.ssTableManager.manifest = mw
 	r.ssTableManager.mu.Unlock()
 	if old != nil {

--- a/manifest_rotation_test.go
+++ b/manifest_rotation_test.go
@@ -53,17 +53,17 @@ func TestMaybeRotateManifest(t *testing.T) {
 	require.NoError(t, err)
 	mw := NewManifestWriterMock(fs)
 	vs := &VersionSet{}
-	rin := &Rindb{config: cfg, versionSet: vs, manifest: mw, manifestPath: fs.Path(), ssTableManager: &SSTableManager{manifest: mw, versionSet: vs, config: cfg}}
+	rin := &Rindb{config: cfg, versionSet: vs, manifest: mw, ssTableManager: &SSTableManager{manifest: mw, versionSet: vs, config: cfg}}
 
 	// Below threshold
 	require.NoError(t, rin.maybeRotateManifest(ctx))
-	require.Equal(t, fs.Path(), rin.manifestPath)
+	require.Equal(t, fs.Path(), rin.manifest.Path())
 
 	// Exceed threshold
 	_, err = fs.Write([]byte(strings.Repeat("x", int(cfg.manifestSizeThreshold+1))))
 	require.NoError(t, err)
 	require.NoError(t, rin.maybeRotateManifest(ctx))
-	require.NotEqual(t, fs.Path(), rin.manifestPath)
+	require.NotEqual(t, fs.Path(), rin.manifest.Path())
 }
 
 type manifestWriterMock struct{ *FileSystem }
@@ -73,3 +73,4 @@ func NewManifestWriterMock(fs *FileSystem) *manifestWriterMock { return &manifes
 func (m *manifestWriterMock) Append(VersionEdit) error { return nil }
 func (m *manifestWriterMock) Sync() error              { return nil }
 func (m *manifestWriterMock) Close() error             { return m.FileSystem.Close() }
+func (m *manifestWriterMock) Path() string             { return m.FileSystem.Path() }

--- a/rindb.go
+++ b/rindb.go
@@ -25,7 +25,6 @@ type Rindb struct {
 	ssTableManager    *SSTableManager
 	versionSet        *VersionSet
 	manifest          ManifestWriter
-	manifestPath      string
 	config            Config
 	shutdownTelemetry func(context.Context) error
 	mu                sync.RWMutex   // Mutex for thread-safe access
@@ -146,7 +145,6 @@ func InitRinDB(ctx context.Context, opts ...Option) (_ *Rindb, err error) {
 		ssTableManager:    ssTableManager,
 		versionSet:        vs,
 		manifest:          mw,
-		manifestPath:      manifestPath,
 		config:            cfg,
 		shutdownTelemetry: shutdownTelemetry,
 		sequenceNumber:    maxSeqNum,

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -86,8 +86,9 @@ func TestSStable(t *testing.T) {
 		mem.Put(newRecord(Bytes("2"), Bytes("3"), 1))
 		mem.Put(newRecord(Bytes("1"), Bytes("2"), 2))
 		mem.Put(newRecord(Bytes("3"), Bytes("4"), 3))
-		sstable1, _, err := flush(ctx, cfg, mem, fs)
+		sstable1, meta, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
+		require.NotZero(t, meta.Number)
 		sstable2, err := NewSSTable(ctx, cfg, fs)
 		assert.NoError(t, err)
 		assert.Equal(t, sstable1.SparseIndex, sstable2.SparseIndex)
@@ -101,8 +102,9 @@ func TestSStable(t *testing.T) {
 		mem.Put(newRecord(Bytes("2"), Bytes("3"), 1))
 		mem.Put(newRecord(Bytes("1"), Bytes("2"), 2))
 		mem.Put(newRecord(Bytes("3"), Bytes("4"), 3))
-		_, _, err := flush(ctx, cfg, mem, fs)
+		_, meta, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
+		require.NotZero(t, meta.Number)
 		sstable, err := NewSSTable(ctx, cfg, fs)
 		assert.NoError(t, err)
 		sparseIndex := sstable.SparseIndex
@@ -124,8 +126,9 @@ func TestSStable(t *testing.T) {
 		mem.Put(newRecord(Bytes("1"), Bytes("2"), 2))
 		mem.Put(newRecord(Bytes("3"), Bytes("4"), 3))
 		assert.Equal(t, uint(3), mem.data.Len())
-		sstable, _, err := flush(ctx, cfg, mem, fs)
+		sstable, meta, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
+		require.NotZero(t, meta.Number)
 		assert.Equal(t, uint(0), mem.data.Len())
 		value, err := sstable.GetValue(ctx, Bytes("2"))
 		assert.NoError(t, err)
@@ -148,8 +151,9 @@ func TestSStable(t *testing.T) {
 		mem := InitMemtable(cfg)
 		mem.Put(newRecord(Bytes("a"), Bytes("old"), 1))
 		mem.Put(newRecord(Bytes("a"), Bytes("new"), 2))
-		sstable, _, err := flush(ctx, cfg, mem, fs)
+		sstable, meta, err := flush(ctx, cfg, mem, fs)
 		assert.NoError(t, err)
+		require.NotZero(t, meta.Number)
 		value, err := sstable.GetValue(ctx, Bytes("a"), 1)
 		assert.NoError(t, err)
 		assert.Equal(t, Bytes("old"), value)
@@ -212,8 +216,9 @@ func TestSStable(t *testing.T) {
 		for i, v := range data {
 			mem.Put(newRecord(v.key, v.value, uint64(i)))
 		}
-		sstable, _, err := flush(context.Background(), cfg, mem, fs)
+		sstable, meta, err := flush(context.Background(), cfg, mem, fs)
 		assert.NoError(t, err)
+		require.NotZero(t, meta.Number)
 
 		tests := []struct {
 			name         string
@@ -470,8 +475,9 @@ func TestFlushWithTombstones(t *testing.T) {
 	mem := InitMemtable(cfg)
 	mem.Put(newRecord(k1, Bytes("v1"), 1))
 	mem.Put(newRecord(k2, nil, 2))
-	sstable, _, err := flush(ctx, cfg, mem, fs)
+	sstable, meta, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
+	require.NotZero(t, meta.Number)
 	v1, err := sstable.GetValue(ctx, k1)
 	assert.NoError(t, err)
 	assert.Equal(t, Bytes("v1"), v1)
@@ -489,8 +495,9 @@ func TestBloomFilterSkipsReads(t *testing.T) {
 	fs := fss[0]
 	mem := InitMemtable(cfg)
 	mem.Put(newRecord(Bytes("k1"), Bytes("v1"), 2))
-	sstable, _, err := flush(ctx, cfg, mem, fs)
+	sstable, meta, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
+	require.NotZero(t, meta.Number)
 	posBefore, err := fs.CursorPos()
 	assert.NoError(t, err)
 	_, err = sstable.GetValue(ctx, Bytes("k2"))
@@ -510,8 +517,9 @@ func TestSStableChecksumMismatch(t *testing.T) {
 	mem := InitMemtable(cfg)
 	rec := newRecord(Bytes("a"), Bytes("1"), 1)
 	mem.Put(rec)
-	sstable, _, err := flush(ctx, cfg, mem, fs)
+	sstable, meta, err := flush(ctx, cfg, mem, fs)
 	assert.NoError(t, err)
+	require.NotZero(t, meta.Number)
 
 	offset := int64(CalOnDiskSize(rec)) - checksumSize
 	_, err = fs.file.WriteAt([]byte{0}, offset)

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -21,6 +21,7 @@ type failingManifest struct{}
 func (failingManifest) Append(VersionEdit) error { return errors.New("append fail") }
 func (failingManifest) Sync() error              { return nil }
 func (failingManifest) Close() error             { return nil }
+func (failingManifest) Path() string             { return "" }
 
 func TestSSTableManager_SearchKeyPrevIteration(t *testing.T) {
 	cfg := testConfig()


### PR DESCRIPTION
## Summary
- derive manifest path from writer via new Path method
- assert FileMeta metadata in SSTable tests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b83f8666508325ab1265fa169396df