### PR TITLE
test: add coverage for sstable manager and config validation edge cases

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,8 @@ package rindb
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestDefaultConfig verifies that DefaultConfig returns the expected default values.
@@ -189,6 +191,43 @@ func TestNewConfigWithOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := NewConfig(tt.opts...)
 			tt.verify(t, cfg)
+		})
+	}
+}
+
+func TestConfigValidatePanics(t *testing.T) {
+	base := DefaultConfig()
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"empty databaseDir", func(c *Config) { c.databaseDir = "" }},
+		{"zero maxMemtableSize", func(c *Config) { c.maxMemtableSize = 0 }},
+		{"non-positive level0CompactionThreshold", func(c *Config) { c.level0CompactionThreshold = 0 }},
+		{"non-positive baseCompactionSizeMB", func(c *Config) { c.baseCompactionSizeMB = 0 }},
+		{"non-positive levelSizeMultiplier", func(c *Config) { c.levelSizeMultiplier = 0 }},
+		{"negative writeRateTrigger", func(c *Config) { c.writeRateTrigger = -1 }},
+		{"ioLoadMax out of range", func(c *Config) { c.ioLoadMax = 2 }},
+		{"bloomFalsePositiveRate out of range", func(c *Config) { c.bloomFalsePositiveRate = 1 }},
+		{"skipListDefaultLevel zero", func(c *Config) { c.skipListDefaultLevel = 0 }},
+		{"skipListMaxLevel zero", func(c *Config) { c.skipListMaxLevel = 0 }},
+		{"skipListDefaultLevel greater than max", func(c *Config) { c.skipListDefaultLevel = 5; c.skipListMaxLevel = 4 }},
+		{"skipListP out of range", func(c *Config) { c.skipListP = 1 }},
+		{"telemetry enabled without endpoint", func(c *Config) { c.enableTelemetry = true; c.exporterEndpoint = "" }},
+		{"telemetrySamplingRate out of range", func(c *Config) { c.telemetrySamplingRate = 1.1 }},
+		{"nil newWALFunc", func(c *Config) { c.newWALFunc = nil }},
+		{"nil newSSTableManagerFunc", func(c *Config) { c.newSSTableManagerFunc = nil }},
+		{"nil fileNumberAllocator", func(c *Config) { c.fileNumberAllocator = nil }},
+		{"nil newFileNumberAllocatorFunc", func(c *Config) { c.newFileNumberAllocatorFunc = nil }},
+		{"nil newManifestWriterFunc", func(c *Config) { c.newManifestWriterFunc = nil }},
+		{"manifestSizeThreshold non-positive", func(c *Config) { c.manifestSizeThreshold = 0 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			tt.mutate(&cfg)
+			assert.Panics(t, func() { cfg.Validate() })
 		})
 	}
 }

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1359,6 +1359,38 @@ func TestSSTableManager_mergeIntoLevel(t *testing.T) {
 		assert.ErrorIs(t, err, ErrTombstoneFound)
 	})
 
+	t.Run("keeps tombstone when higher level exists", func(t *testing.T) {
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		// Add dummy file to higher level to force bottom=false
+		ts.Manager.versionSet.ensureLevel(2)
+		ts.Manager.versionSet.Levels[2] = []FileMeta{{Number: 99, Level: 2, Smallest: InternalKey{UserKey: Bytes("x")}, Largest: InternalKey{UserKey: Bytes("x")}}}
+
+		fs := ts.newSSTableFS(0)
+		mem := InitMemtable(*ts.Config)
+		mem.Put(newRecord(Bytes("a"), nil, 1))
+		sst, _, err := flush(ctx, *ts.Config, mem, fs)
+		require.NoError(t, err)
+		ts.AddSSTable(0, &sst)
+		require.NoError(t, sst.Close())
+
+		ts.Manager.minSnapshotSeq = 2
+
+		inputs := append([]FileMeta(nil), ts.Manager.versionSet.Levels[0]...)
+		err = ts.Manager.mergeIntoLevel(ctx, 1, inputs)
+		require.NoError(t, err)
+
+		meta := ts.Manager.versionSet.Levels[1][0]
+		fsMerged, err := OpenExistingFS(ctx, path.Join(ts.Manager.config.databaseDir, sstPath(meta.Number)))
+		require.NoError(t, err)
+		merged, err := NewSSTable(ctx, cfg, fsMerged)
+		require.NoError(t, err)
+
+		_, err = merged.GetValue(ctx, Bytes("a"))
+		assert.ErrorIs(t, err, ErrTombstoneFound)
+	})
+
 	t.Run("no-op on empty sources", func(t *testing.T) {
 		ts := newTestRindbSetup(t, ctx, &cfg)
 		defer ts.Cleanup()
@@ -1500,6 +1532,19 @@ func TestSSTableManager_findOverlappingSSTables(t *testing.T) {
 		assert.Nil(t, overlaps)
 	})
 
+	t.Run("Only empty source sstables", func(t *testing.T) {
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		ts.Manager.versionSet.ensureLevel(1)
+		ts.Manager.versionSet.Levels[1] = []FileMeta{{Number: 1, Level: 1, Smallest: ik("a"), Largest: ik("b")}}
+
+		empty := FileMeta{Smallest: InternalKey{}, Largest: InternalKey{}}
+		overlaps, err := ts.Manager.findOverlaps(ctx, 1, []FileMeta{empty})
+		require.NoError(t, err)
+		assert.Nil(t, overlaps)
+	})
+
 	t.Run("With empty and non-empty source sstables", func(t *testing.T) {
 		ts := newTestRindbSetup(t, ctx, &cfg)
 		defer ts.Cleanup()
@@ -1517,20 +1562,51 @@ func TestSSTableManager_findOverlappingSSTables(t *testing.T) {
 }
 
 func TestRemoveFiles(t *testing.T) {
-	dir := t.TempDir()
-	paths := []string{
-		filepath.Join(dir, sstPath(1)),
-		filepath.Join(dir, sstPath(2)),
-	}
-	for _, p := range paths {
-		f, err := os.Create(p)
+	t.Run("ignores missing files", func(t *testing.T) {
+		dir := t.TempDir()
+		paths := []string{
+			filepath.Join(dir, sstPath(1)),
+			filepath.Join(dir, sstPath(2)),
+		}
+		for _, p := range paths {
+			f, err := os.Create(p)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+		}
+		files := []FileMeta{{Number: 1}, {Number: 2}, {Number: 3}}
+		require.NoError(t, removeFiles(dir, files))
+		for _, p := range paths {
+			_, err := os.Stat(p)
+			require.ErrorIs(t, err, os.ErrNotExist)
+		}
+	})
+
+	t.Run("returns first error", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Create a non-empty directory for file 1 so os.Remove fails.
+		errDir := filepath.Join(dir, sstPath(1))
+		require.NoError(t, os.Mkdir(errDir, 0o755))
+		f, err := os.Create(filepath.Join(errDir, "child"))
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
-	}
-	files := []FileMeta{{Number: 1}, {Number: 2}, {Number: 3}}
-	require.NoError(t, removeFiles(dir, files))
-	for _, p := range paths {
-		_, err := os.Stat(p)
-		require.ErrorIs(t, err, os.ErrNotExist)
-	}
+
+		// Create a regular file for file 2 which should be removed.
+		okPath := filepath.Join(dir, sstPath(2))
+		f, err = os.Create(okPath)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		files := []FileMeta{{Number: 1}, {Number: 2}}
+		err = removeFiles(dir, files)
+		assert.Error(t, err)
+
+		// File 2 should be removed
+		_, statErr := os.Stat(okPath)
+		assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+		// Directory for file 1 should remain
+		_, statErr = os.Stat(errDir)
+		assert.NoError(t, statErr)
+	})
 }


### PR DESCRIPTION
## Summary
- test removeFiles returns first error instead of nil
- verify findOverlaps and mergeIntoLevel handle special cases
- ensure Config.Validate panics for invalid options

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b84e0322808325b6115a168c593a0c