### PR TITLE
fix: enforce lock ordering and optimize sparse scan

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -373,12 +373,13 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 			go func(ctx context.Context, flushSeq uint64) {
 				defer r.wg.Done()
 				INFO(ctx, "Background compaction goroutine started.")
+				r.mu.Lock()
+				defer r.mu.Unlock()
 				if err := r.ssTableManager.Compact(ctx); err != nil {
 					ERROR(ctx, "Background compaction failed: %v", err)
 				} else {
 					INFO(ctx, "Background compaction goroutine finished.")
 				}
-				r.mu.Lock()
 
 				if err := r.maybeRotateManifest(ctx); err != nil {
 					ERROR(ctx, "Manifest rotation failed: %v", err)
@@ -387,7 +388,6 @@ func (r *Rindb) Put(ctx context.Context, key, value Bytes) error {
 				if err := r.cleanupObsoleteLocked(ctx, flushSeq); err != nil {
 					ERROR(ctx, "Post-compaction cleanup failed: %v", err)
 				}
-				r.mu.Unlock()
 			}(compactionCtx, flushSeq)
 		}
 		return nil

--- a/sstable.go
+++ b/sstable.go
@@ -102,7 +102,17 @@ func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes,
 
 	offset, err := s.SparseIndex.GetOffset(key)
 	if err != nil {
-		offset = 0
+		if !errors.Is(err, ErrKeyNotFound) {
+			return nil, err
+		}
+		idx := sort.Search(len(s.SparseIndex), func(i int) bool {
+			return Compare(s.SparseIndex[i].key, key) >= 0
+		})
+		if idx > 0 {
+			offset = s.SparseIndex[idx-1].offset
+		} else {
+			offset = 0
+		}
 	}
 
 	reader := newOffsetReader(s.FileSystem, offset)

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -340,6 +340,84 @@ func TestSStable(t *testing.T) {
 	})
 }
 
+// TestSStable_GetValueSparseIndexFallback ensures GetValue can retrieve keys
+// when they are absent from the sparse index by scanning from the nearest
+// preceding entry.
+func TestSStable_GetValueSparseIndexFallback(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	data := []struct{ key, value Bytes }{
+		{Bytes("a"), Bytes("1")},
+		{Bytes("b"), Bytes("2")},
+		{Bytes("c"), Bytes("3")},
+		{Bytes("d"), Bytes("4")},
+		{Bytes("e"), Bytes("5")},
+	}
+	mem := InitMemtable(cfg)
+	for i, v := range data {
+		mem.Put(newRecord(v.key, v.value, uint64(i)))
+	}
+	sst, meta, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+	require.NotZero(t, meta.Number)
+
+	// Reduce sparse index to only a subset of keys to simulate sparsity.
+	orig := sst.SparseIndex
+	sst.SparseIndex = SparseIndex{}
+	for _, ko := range orig {
+		if Compare(ko.key, Bytes("c")) == CmpEqual || Compare(ko.key, Bytes("e")) == CmpEqual {
+			sst.SparseIndex = append(sst.SparseIndex, ko)
+		}
+	}
+
+	// Insert a non-existent key into the Bloom filter to force a scan.
+	sst.Bloom.Insert(Bytes("da"))
+
+	tests := []struct {
+		name    string
+		key     Bytes
+		value   Bytes
+		wantErr error
+	}{
+		{
+			name:  "existing key before first index entry",
+			key:   Bytes("a"),
+			value: Bytes("1"),
+		},
+		{
+			name:  "existing key between index entries",
+			key:   Bytes("d"),
+			value: Bytes("4"),
+		},
+		{
+			name:    "missing key between index entries",
+			key:     Bytes("da"),
+			wantErr: ErrKeyNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			off, err := sst.SparseIndex.GetOffset(tt.key)
+			assert.ErrorIs(t, err, ErrKeyNotFound)
+			assert.Equal(t, int64(0), off)
+
+			val, err := sst.GetValue(ctx, tt.key)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, val)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.value, val)
+			}
+		})
+	}
+}
+
 // TestSparseIndex_GetOffset tests the GetOffset method of SparseIndex.
 func TestSparseIndex_GetOffset(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Summary
- guard compaction with DB mutex before taking SSTable manager lock to avoid lock inversion
- start SSTable lookups from the preceding sparse index entry when key is missing
- add unit tests covering sparse index fallback in SSTable lookups

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b8519294ac8325b58722b5f7da1790