### PR TITLE
refactor: switch manifest encoding to gob

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -1,8 +1,9 @@
 package rindb
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
+	"encoding/gob"
 	"errors"
 	"io"
 	"os"
@@ -48,10 +49,11 @@ func NewManifestWriter(ctx context.Context, path string) (ManifestWriter, error)
 }
 
 func (w *fileManifestWriter) Append(edit VersionEdit) error {
-	data, err := json.Marshal(edit)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(edit); err != nil {
 		return err
 	}
+	data := buf.Bytes()
 	var header [manifestRecordHeaderSize]byte
 	byteOrder.PutUint32(header[0:checksumSize], uint32(len(data)))
 	crc := checksum(data)
@@ -93,7 +95,7 @@ func (r *fileManifestReader) Next() (VersionEdit, error) {
 		return VersionEdit{}, ErrChecksumMismatch
 	}
 	var edit VersionEdit
-	if err := json.Unmarshal(data, &edit); err != nil {
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&edit); err != nil {
 		return VersionEdit{}, err
 	}
 	return edit, nil

--- a/version.go
+++ b/version.go
@@ -21,14 +21,14 @@ type DeletedFileMeta struct {
 
 // VersionEdit describes a change to the VersionSet.
 type VersionEdit struct {
-	ComparatorName string `json:",omitempty"`
-	LastSequence   uint64 `json:",omitempty"`
-	NextFileNumber uint64 `json:",omitempty"`
-	LogNumber      uint64 `json:",omitempty"`
-	PrevLogNumber  uint64 `json:",omitempty"`
+	ComparatorName string
+	LastSequence   uint64
+	NextFileNumber uint64
+	LogNumber      uint64
+	PrevLogNumber  uint64
 
-	AddFiles    []FileMeta        `json:",omitempty"`
-	DeleteFiles []DeletedFileMeta `json:",omitempty"`
+	AddFiles    []FileMeta
+	DeleteFiles []DeletedFileMeta
 }
 
 // VersionSet represents the in-memory state of levels and file numbering.


### PR DESCRIPTION
## Summary
- replace JSON manifest encoding with Gob
- drop JSON tags from version edits

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b8e9ac154c8325a73a78238a4350fa