### PR TITLE
refactor: return SSTables from GetRelevantSSTables

### DIFF
--- a/docs/dev/53/read_path_plan.md
+++ b/docs/dev/53/read_path_plan.md
@@ -3,31 +3,38 @@
 Now that `VersionSet` tracks SSTables, migrate lookup helpers to operate on its metadata rather than legacy linked lists. The prose-to-code ratio is roughly 3:7.
 
 ## Plan
-- Iterate `VersionSet.Levels` and return file numbers overlapping a key range.
+- Iterate `VersionSet.Levels` and return opened SSTables overlapping a key range.
 - Track open files by number instead of pointer identity.
 - Drop linked-list based bookkeeping.
 
 ```go
-// GetRelevantSSTables gathers file numbers whose ranges overlap [start, end].
-func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, start, end InternalKey) []uint64 {
+// GetRelevantSSTables gathers SSTables whose ranges overlap [start, end].
+func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, start, end InternalKey) ([]*SSTable, error) {
     h.mu.RLock()
     defer h.mu.RUnlock()
-    var out []uint64
+    var out []*SSTable
     for _, level := range h.versionSet.Levels {
         for _, f := range level {
             if !end.Before(f.Smallest) && !start.After(f.Largest) {
-                out = append(out, f.Number)
+                sst, err := h.openByNumber(ctx, f.Number)
+                if err != nil {
+                    return nil, err
+                }
+                out = append(out, sst)
             }
         }
     }
-    return out
+    return out, nil
 }
 
 // searchKey walks the candidates and stops at the first match.
 func (h *SSTableManager) searchKey(ctx context.Context, key InternalKey) ([]byte, error) {
-    for _, num := range h.GetRelevantSSTables(ctx, key, key) {
-        fs := h.openByNumber(num)
-        if v, ok := fs.Lookup(key); ok {
+    ssts, err := h.GetRelevantSSTables(ctx, key, key)
+    if err != nil {
+        return nil, err
+    }
+    for _, sst := range ssts {
+        if v, err := sst.Lookup(key); err == nil {
             return v, nil
         }
     }

--- a/rindb.go
+++ b/rindb.go
@@ -255,8 +255,11 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 
 	iterators := []Iterator[Record]{r.memtable.IRange(start, end, maxSeq)}
 
-	nums := r.ssTableManager.GetRelevantSSTables(ctx, start, end)
-	var opened []*SStable
+	ssts, err := r.ssTableManager.GetRelevantSSTables(ctx, start, end)
+	if err != nil {
+		return nil, err
+	}
+	opened := ssts
 
 	cleanupOpened := func() {
 		for _, o := range opened {
@@ -264,13 +267,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 		}
 	}
 
-	for _, n := range nums {
-		sst, err := r.ssTableManager.openByNumber(ctx, n)
-		if err != nil {
-			cleanupOpened()
-			return nil, err
-		}
-		opened = append(opened, sst)
+	for _, sst := range ssts {
 		rangeIter, err := sst.IRange(start, end, maxSeq)
 		if err != nil {
 			cleanupOpened()

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -108,8 +108,8 @@ func TestTombstoneRemovedAfterSnapshotRelease(t *testing.T) {
 	require.NoError(t, rin.Put(ctx, Bytes("k2"), large))
 	require.NoError(t, rin.Put(ctx, Bytes("k3"), large))
 	require.Eventually(t, func() bool {
-		nums := rin.ssTableManager.GetRelevantSSTables(ctx, Bytes("k"), Bytes("k"))
-		return len(nums) == 0
+		ssts, err := rin.ssTableManager.GetRelevantSSTables(ctx, Bytes("k"), Bytes("k"))
+		return err == nil && len(ssts) == 0
 	}, 5*time.Second, 100*time.Millisecond)
 }
 

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -567,10 +567,12 @@ func (h *SSTableManager) openByNumber(ctx context.Context, num uint64) (*SStable
 	return &sst, nil
 }
 
-// GetRelevantSSTables gathers file numbers whose ranges overlap [startKey, endKey].
+// GetRelevantSSTables gathers SSTables whose ranges overlap [startKey, endKey].
 // Level 0 files are returned in newest-first order while higher levels retain
-// their existing ordering.
-func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endKey Bytes) []uint64 {
+// their existing ordering. If an SSTable referenced in the current version is
+// missing on disk, the function returns the error so callers can retry with a
+// fresh view.
+func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endKey Bytes) ([]*SStable, error) {
 	ctx, span := sstableMgmtTracer.Start(ctx, "SSTableManager.GetRelevantSSTables")
 	start := time.Now()
 	defer func() {
@@ -580,9 +582,7 @@ func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 	}()
 
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-
-	var out []uint64
+	nums := make([]uint64, 0)
 	for lvl, files := range h.versionSet.Levels {
 		if len(files) == 0 {
 			continue
@@ -593,7 +593,7 @@ func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 				if endKey.Compare(f.Smallest.UserKey) >= 0 && startKey.Compare(f.Largest.UserKey) <= 0 {
 					info, err := h.sstInfo(f.Number)
 					if err == nil && info.Size() > 0 {
-						out = append(out, f.Number)
+						nums = append(nums, f.Number)
 					}
 				}
 			}
@@ -603,13 +603,27 @@ func (h *SSTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 			if endKey.Compare(f.Smallest.UserKey) >= 0 && startKey.Compare(f.Largest.UserKey) <= 0 {
 				info, err := h.sstInfo(f.Number)
 				if err == nil && info.Size() > 0 {
-					out = append(out, f.Number)
+					nums = append(nums, f.Number)
 				}
 			}
 		}
 	}
+	h.mu.RUnlock()
+
+	out := make([]*SStable, 0, len(nums))
+	for _, num := range nums {
+		sst, err := h.openByNumber(ctx, num)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, err
+			}
+			WARN(ctx, "Failed to open SSTable %d: %v", num, err)
+			continue
+		}
+		out = append(out, sst)
+	}
 	getRelevantSSTables.Add(ctx, int64(len(out)))
-	return out
+	return out, nil
 }
 
 func (h *SSTableManager) searchKey(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
@@ -622,19 +636,15 @@ func (h *SSTableManager) searchKey(ctx context.Context, key Bytes, seq ...uint64
 	const maxRetries = 2
 
 	for retries := 0; retries <= maxRetries; retries++ {
-		nums := h.GetRelevantSSTables(ctx, key, key)
-		missing := false
-		for _, num := range nums {
-			sst, err := h.openByNumber(ctx, num)
-			if err != nil {
-				WARN(ctx, "Failed to open SSTable %d: %v", num, err)
-				if errors.Is(err, os.ErrNotExist) {
-					// SSTable was removed, likely due to a concurrent compaction.
-					missing = true
-					break
-				}
+		ssts, err := h.GetRelevantSSTables(ctx, key, key)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// SSTable was removed, likely due to a concurrent compaction.
 				continue
 			}
+			return nil, err
+		}
+		for _, sst := range ssts {
 			val, err := sst.GetValue(ctx, key, maxSeq)
 			if err == nil {
 				return val, nil
@@ -646,9 +656,7 @@ func (h *SSTableManager) searchKey(ctx context.Context, key Bytes, seq ...uint64
 				return nil, err
 			}
 		}
-		if !missing {
-			return nil, ErrKeyNotFound
-		}
+		return nil, ErrKeyNotFound
 	}
 	return nil, ErrKeyNotFound
 }

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -549,7 +549,13 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		nNewer, err := fileNum(newer.Path())
 		require.NoError(t, err)
 
-		nums := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("z"))
+		ssts, err := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("z"))
+		require.NoError(t, err)
+		nums := make([]uint64, len(ssts))
+		for i, s := range ssts {
+			nums[i], err = fileNum(s.Path())
+			require.NoError(t, err)
+		}
 		assert.Equal(t, []uint64{nNewer, nOlder}, nums)
 	})
 
@@ -568,7 +574,13 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		nNewer, err := fileNum(newer.Path())
 		require.NoError(t, err)
 
-		nums := ts.Manager.GetRelevantSSTables(ctx, Bytes("b"), Bytes("d"))
+		ssts, err := ts.Manager.GetRelevantSSTables(ctx, Bytes("b"), Bytes("d"))
+		require.NoError(t, err)
+		nums := make([]uint64, len(ssts))
+		for i, s := range ssts {
+			nums[i], err = fileNum(s.Path())
+			require.NoError(t, err)
+		}
 		assert.Equal(t, []uint64{nOlder, nNewer}, nums)
 	})
 
@@ -580,8 +592,9 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		sst := ts.createSSTable(1, map[string]string{"x": "1"})
 		ts.AddSSTable(1, sst)
 
-		nums := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("b"))
-		assert.Len(t, nums, 0)
+		ssts, err := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("b"))
+		require.NoError(t, err)
+		assert.Len(t, ssts, 0)
 	})
 
 	t.Run("Error opening SSTable", func(t *testing.T) {
@@ -593,8 +606,9 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		ts.AddSSTable(1, sst)
 		assert.NoError(t, os.Remove(sst.Path()))
 
-		nums := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("z"))
-		assert.Len(t, nums, 0)
+		ssts, err := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("z"))
+		require.NoError(t, err)
+		assert.Len(t, ssts, 0)
 	})
 
 	t.Run("Mixed levels with overlapping and non-overlapping", func(t *testing.T) {
@@ -621,7 +635,13 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		nL1, err := fileNum(l1Overlap.Path())
 		require.NoError(t, err)
 
-		nums := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("d"))
+		ssts, err := ts.Manager.GetRelevantSSTables(ctx, Bytes("a"), Bytes("d"))
+		require.NoError(t, err)
+		nums := make([]uint64, len(ssts))
+		for i, s := range ssts {
+			nums[i], err = fileNum(s.Path())
+			require.NoError(t, err)
+		}
 		assert.Equal(t, []uint64{nL0b, nL0a, nL1}, nums)
 	})
 }


### PR DESCRIPTION
## Summary
- refactor GetRelevantSSTables to return opened SSTables instead of file numbers
- update range and search to use SSTables directly
- adjust tests and docs for new API

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b8ede010648325a966d1369517e078