### PR TITLE
fix: support larger manifest records and improve compaction cleanup

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/gob"
 	"errors"
+	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,6 +96,9 @@ func (r *fileManifestReader) Next() (VersionEdit, error) {
 		return VersionEdit{}, err
 	}
 	n := byteOrder.Uint64(header[0:manifestRecordLengthSize])
+	if n > uint64(math.MaxInt) {
+		return VersionEdit{}, fmt.Errorf("manifest record size %d exceeds max slice size on this architecture", n)
+	}
 	crc := byteOrder.Uint32(header[manifestRecordLengthSize:])
 	data := make([]byte, int(n))
 	if _, err := io.ReadFull(r.fs, data); err != nil {

--- a/manifest.go
+++ b/manifest.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 )
 
-const manifestRecordHeaderSize = 2 * checksumSize
+const (
+	manifestRecordLengthSize = 8
+	manifestRecordHeaderSize = manifestRecordLengthSize + checksumSize
+)
 
 // ManifestWriter appends edits to a MANIFEST file.
 type ManifestWriter interface {
@@ -60,9 +63,9 @@ func (w *fileManifestWriter) Append(edit VersionEdit) error {
 	}
 	data := w.buf.Bytes()
 	var header [manifestRecordHeaderSize]byte
-	byteOrder.PutUint32(header[0:checksumSize], uint32(len(data)))
+	byteOrder.PutUint64(header[0:manifestRecordLengthSize], uint64(len(data)))
 	crc := checksum(data)
-	byteOrder.PutUint32(header[checksumSize:manifestRecordHeaderSize], crc)
+	byteOrder.PutUint32(header[manifestRecordLengthSize:], crc)
 	if _, err := w.fs.Write(header[:]); err != nil {
 		return err
 	}
@@ -90,9 +93,9 @@ func (r *fileManifestReader) Next() (VersionEdit, error) {
 	if _, err := io.ReadFull(r.fs, header[:]); err != nil {
 		return VersionEdit{}, err
 	}
-	n := byteOrder.Uint32(header[0:checksumSize])
-	crc := byteOrder.Uint32(header[checksumSize:manifestRecordHeaderSize])
-	data := make([]byte, n)
+	n := byteOrder.Uint64(header[0:manifestRecordLengthSize])
+	crc := byteOrder.Uint32(header[manifestRecordLengthSize:])
+	data := make([]byte, int(n))
 	if _, err := io.ReadFull(r.fs, data); err != nil {
 		return VersionEdit{}, err
 	}

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -44,13 +44,13 @@ func TestManifest(t *testing.T) {
 
 		f, err := os.OpenFile(mf, os.O_RDWR, 0)
 		require.NoError(t, err)
-		_, err = f.Seek(8, io.SeekStart)
+		_, err = f.Seek(int64(manifestRecordHeaderSize), io.SeekStart)
 		require.NoError(t, err)
 		b := []byte{0}
 		_, err = f.Read(b)
 		require.NoError(t, err)
 		b[0] ^= 0xff
-		_, err = f.Seek(8, io.SeekStart)
+		_, err = f.Seek(int64(manifestRecordHeaderSize), io.SeekStart)
 		require.NoError(t, err)
 		_, err = f.Write(b)
 		require.NoError(t, err)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -3,6 +3,7 @@ package rindb
 import (
 	"context"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,6 +82,27 @@ func TestManifest(t *testing.T) {
 		require.NoError(t, err)
 		_, err = r.Next()
 		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("ReaderLengthOverflow", func(t *testing.T) {
+		ctx := context.Background()
+		dir := t.TempDir()
+		mf := filepath.Join(dir, DefaultManifestFile)
+		f, err := os.Create(mf)
+		require.NoError(t, err)
+		var header [manifestRecordHeaderSize]byte
+		byteOrder.PutUint64(header[0:manifestRecordLengthSize], uint64(math.MaxInt)+1)
+		byteOrder.PutUint32(header[manifestRecordLengthSize:], 0)
+		_, err = f.Write(header[:])
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		r, err := NewManifestReader(ctx, mf)
+		require.NoError(t, err)
+		_, err = r.Next()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds max slice size")
 		require.NoError(t, r.Close())
 	})
 

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1224,6 +1224,27 @@ func TestSSTableManager_compactLevel0(t *testing.T) {
 		assert.Error(t, err)
 		_ = os.Remove(path.Join(ts.Config.databaseDir, sstPath(next)))
 	})
+
+	t.Run("cleans up target on compaction error", func(t *testing.T) {
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		l0a := ts.createSSTable(0, map[string]string{"a": "1"})
+		l0b := ts.createSSTable(0, map[string]string{"b": "2"})
+		ts.AddSSTable(0, l0a)
+		ts.AddSSTable(0, l0b)
+		require.NoError(t, l0a.Close())
+		require.NoError(t, l0b.Close())
+
+		next := ts.Manager.config.fileNumberAllocator.Peek()
+		cancelCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := ts.Manager.Compact(cancelCtx)
+		assert.Error(t, err)
+
+		_, statErr := os.Stat(path.Join(ts.Config.databaseDir, sstPath(next)))
+		assert.True(t, os.IsNotExist(statErr), "orphaned target file exists: %v", statErr)
+	})
 }
 
 func TestSSTableManager_compactHigherLevel(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -1,6 +1,9 @@
 package rindb
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // FileMeta holds metadata about an SSTable file.
 type FileMeta struct {
@@ -69,9 +72,12 @@ func (e VersionEdit) Apply(vs *VersionSet) error {
 	vs.NextFileNumber = coalesceNonZero(vs.NextFileNumber, e.NextFileNumber)
 	vs.LogNumber = coalesceNonZero(vs.LogNumber, e.LogNumber)
 	vs.PrevLogNumber = coalesceNonZero(vs.PrevLogNumber, e.PrevLogNumber)
+
+	affected := make(map[int]struct{})
 	for _, f := range e.AddFiles {
 		vs.ensureLevel(f.Level)
 		vs.Levels[f.Level] = append(vs.Levels[f.Level], f)
+		affected[f.Level] = struct{}{}
 	}
 	if len(e.DeleteFiles) > 0 {
 		deletionsByLevel := make(map[int]map[uint64]struct{})
@@ -87,14 +93,23 @@ func (e VersionEdit) Apply(vs *VersionSet) error {
 				continue
 			}
 			files := vs.Levels[level]
-			filtered := files[:0]
+			filtered := make([]FileMeta, 0, len(files))
 			for _, f := range files {
 				if _, ok := toDelete[f.Number]; !ok {
 					filtered = append(filtered, f)
 				}
 			}
 			vs.Levels[level] = filtered
+			affected[level] = struct{}{}
 		}
+	}
+
+	for level := range affected {
+		files := vs.Levels[level]
+		sort.Slice(files, func(i, j int) bool {
+			return files[i].Smallest.Compare(files[j].Smallest) == CmpLess
+		})
+		vs.Levels[level] = files
 	}
 	return nil
 }

--- a/version_test.go
+++ b/version_test.go
@@ -27,6 +27,17 @@ func TestVersionEdit(t *testing.T) {
 		require.Empty(t, vs.Levels[1])
 	})
 
+	t.Run("AddFilesSorted", func(t *testing.T) {
+		vs := &VersionSet{}
+		fm1 := FileMeta{Number: 1, Level: 0, Smallest: InternalKey{UserKey: Bytes("b"), Seq: 1, Type: TypeValue}}
+		fm2 := FileMeta{Number: 2, Level: 0, Smallest: InternalKey{UserKey: Bytes("a"), Seq: 1, Type: TypeValue}}
+		edit := VersionEdit{AddFiles: []FileMeta{fm1, fm2}}
+		require.NoError(t, edit.Apply(vs))
+		require.Len(t, vs.Levels[0], 2)
+		require.Equal(t, uint64(2), vs.Levels[0][0].Number)
+		require.Equal(t, uint64(1), vs.Levels[0][1].Number)
+	})
+
 	t.Run("DeleteNonExistent", func(t *testing.T) {
 		vs := &VersionSet{}
 		edit := VersionEdit{DeleteFiles: []DeletedFileMeta{{Level: 2, Number: 5}}}

--- a/wal.go
+++ b/wal.go
@@ -259,6 +259,9 @@ func (w *WAL) Clean(ctx context.Context, minSeq uint64) error {
 		cleanupTemp(tmpFS, tmpPath)
 		return fmt.Errorf("failed to replace WAL: %w", err)
 	}
+	if err := tmpFS.Close(); err != nil {
+		return fmt.Errorf("failed to close temp WAL: %w", err)
+	}
 	if err := w.Open(ctx); err != nil {
 		return fmt.Errorf("failed to reopen WAL: %w", err)
 	}


### PR DESCRIPTION
## Summary
- allow manifest records over 4GB by switching length field to uint64
- keep level file metadata sorted and avoid slice aliasing
- close temporary WAL files after replacement
- add test ensuring Compact cleans up target files on errors

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b95ca919b88325a204b95359419217