### PR TITLE
feat: expose table cache configuration and stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - **Concurrent Access**: Thread-safe operations with transaction support.
 - **Range Queries**: Efficient retrieval of key-value pairs within a specified key range.
 - **Telemetry**: OpenTelemetry integration for metrics and tracing to monitor database performance.
+- **Table Cache**: Reuses open SSTables via a sharded SLRU cache.
 
 ## Installation
 
@@ -123,10 +124,13 @@ it.Close()
 ```go
 s := db.Stats()
 fmt.Println("Active snapshots:", s.ActiveSnapshots)
+tc := db.TableCacheStats()
+fmt.Println("Cache hits:", tc.Hits)
 ```
 
 The `Stats` method reports metrics such as memtable size, sequence number,
 active snapshot count, per-level SSTable counts, WAL usage, and operation counters.
+`TableCacheStats` exposes cache hit/miss ratios and byte usage.
 
 ### Custom Configuration
 
@@ -136,6 +140,8 @@ db, err := rindb.InitRinDB(ctx,
     rindb.WithDatabaseDir("./mydb"),
     rindb.WithMaxMemtableSize(1024*1024), // 1MB
     rindb.WithBloomFalsePositiveRate(0.01),
+    rindb.WithCacheBytes(64<<20), // 64MB table cache
+    rindb.WithCacheShards(8),
 )
 if err != nil {
     fmt.Println("Error:", err)
@@ -143,6 +149,8 @@ if err != nil {
 }
 defer db.Close()
 ```
+
+The sample CLI accepts `--cache-bytes` and `--cache-shards` flags to tune the cache.
 
 ## Building and Testing
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -11,8 +12,19 @@ import (
 )
 
 func main() {
+	cacheBytes := flag.Int64("cache-bytes", 0, "table cache byte budget")
+	cacheShards := flag.Int("cache-shards", 0, "number of table cache shards")
+	flag.Parse()
+
 	ctx := context.Background()
-	db, err := rindb.InitRinDB(ctx)
+	var opts []rindb.Option
+	if *cacheBytes > 0 {
+		opts = append(opts, rindb.WithCacheBytes(*cacheBytes))
+	}
+	if *cacheShards > 0 {
+		opts = append(opts, rindb.WithCacheShards(*cacheShards))
+	}
+	db, err := rindb.InitRinDB(ctx, opts...)
 	if err != nil {
 		fmt.Println("Error initializing database:", err)
 		return
@@ -96,6 +108,10 @@ func main() {
 			fmt.Printf("RemoveCalls: %d\n", s.RemoveCalls)
 			fmt.Printf("IRangeCalls: %d\n", s.IRangeCalls)
 			fmt.Printf("Flushes: %d\n", s.Flushes)
+			tc := db.TableCacheStats()
+			fmt.Printf("TableCacheUsedBytes: %d\n", tc.UsedBytes)
+			fmt.Printf("TableCacheHits: %d\n", tc.Hits)
+			fmt.Printf("TableCacheMisses: %d\n", tc.Misses)
 		case "exit":
 			return
 		default:

--- a/config.go
+++ b/config.go
@@ -85,11 +85,11 @@ type Config struct {
 	manifestSizeThreshold int64
 
 	// table cache configuration
-	tableCacheCapBytes          int64
-	tableCacheShards            int
-	tableCacheProbationFraction float64
-	tableCacheCorruptTTL        time.Duration
-	fdLimiter                   FDLimiter
+	cacheBytes             int64
+	cacheShards            int
+	cacheProbationFraction float64
+	cacheCorruptTTL        time.Duration
+	fdLimiter              FDLimiter
 }
 
 // Option defines a functional option type for Config.
@@ -108,32 +108,32 @@ func NewConfig(opts ...Option) Config {
 // DefaultConfig returns a Config with default values.
 func DefaultConfig() Config {
 	return Config{
-		databaseDir:                 "rindat",
-		maxMemtableSize:             1000,
-		level0CompactionThreshold:   2,
-		baseCompactionSizeMB:        10, // Default: Level 1 threshold = 10MB * (10^1) = 100MB
-		levelSizeMultiplier:         10, // Default: Level N threshold = base * (multiplier^N)
-		writeRateTrigger:            0,
-		ioLoadMax:                   0,
-		bloomFalsePositiveRate:      0.01,
-		skipListDefaultLevel:        2,
-		skipListMaxLevel:            32,
-		skipListP:                   0.5,
-		enableTelemetry:             false,
-		exporterEndpoint:            "",
-		exporterInsecure:            false,
-		telemetrySamplingRate:       0.1, // Default to sample 10% of traces
-		newWALFunc:                  DefaultNewWALFunc,
-		newSSTableManagerFunc:       InitSSTableManager,
-		fileNumberAllocator:         newFileNumberAllocator(1),
-		newManifestWriterFunc:       newManifestWriter,
-		manifestSizeThreshold:       1 << 20, // 1MiB
-		repairMode:                  false,
-		tableCacheCapBytes:          0,
-		tableCacheShards:            0,
-		tableCacheProbationFraction: 0,
-		tableCacheCorruptTTL:        0,
-		fdLimiter:                   nil,
+		databaseDir:               "rindat",
+		maxMemtableSize:           1000,
+		level0CompactionThreshold: 2,
+		baseCompactionSizeMB:      10, // Default: Level 1 threshold = 10MB * (10^1) = 100MB
+		levelSizeMultiplier:       10, // Default: Level N threshold = base * (multiplier^N)
+		writeRateTrigger:          0,
+		ioLoadMax:                 0,
+		bloomFalsePositiveRate:    0.01,
+		skipListDefaultLevel:      2,
+		skipListMaxLevel:          32,
+		skipListP:                 0.5,
+		enableTelemetry:           false,
+		exporterEndpoint:          "",
+		exporterInsecure:          false,
+		telemetrySamplingRate:     0.1, // Default to sample 10% of traces
+		newWALFunc:                DefaultNewWALFunc,
+		newSSTableManagerFunc:     InitSSTableManager,
+		fileNumberAllocator:       newFileNumberAllocator(1),
+		newManifestWriterFunc:     newManifestWriter,
+		manifestSizeThreshold:     1 << 20, // 1MiB
+		repairMode:                false,
+		cacheBytes:                0,
+		cacheShards:               0,
+		cacheProbationFraction:    0,
+		cacheCorruptTTL:           0,
+		fdLimiter:                 nil,
 	}
 }
 
@@ -196,6 +196,18 @@ func (c Config) Validate() {
 	if c.manifestSizeThreshold <= 0 {
 		panic("manifestSizeThreshold must be greater than zero")
 	}
+	if c.cacheBytes < 0 {
+		panic("cacheBytes must be >= 0")
+	}
+	if c.cacheShards < 0 {
+		panic("cacheShards must be >= 0")
+	}
+	if c.cacheProbationFraction < 0 || c.cacheProbationFraction >= 1 {
+		panic("cacheProbationFraction must be between 0 and 1")
+	}
+	if c.cacheCorruptTTL < 0 {
+		panic("cacheCorruptTTL must be >= 0")
+	}
 }
 
 func WithConfig(cfg Config) Option {
@@ -212,24 +224,24 @@ func WithRepairMode(v bool) Option {
 	return func(c *Config) { c.repairMode = v }
 }
 
-// WithTableCacheCapBytes sets the total byte budget for the table cache.
-func WithTableCacheCapBytes(v int64) Option {
-	return func(c *Config) { c.tableCacheCapBytes = v }
+// WithCacheBytes sets the total byte budget for the table cache.
+func WithCacheBytes(v int64) Option {
+	return func(c *Config) { c.cacheBytes = v }
 }
 
-// WithTableCacheShards sets the number of shards for the table cache.
-func WithTableCacheShards(v int) Option {
-	return func(c *Config) { c.tableCacheShards = v }
+// WithCacheShards sets the number of shards for the table cache.
+func WithCacheShards(v int) Option {
+	return func(c *Config) { c.cacheShards = v }
 }
 
-// WithTableCacheProbationFraction sets the probation segment fraction for the table cache.
-func WithTableCacheProbationFraction(v float64) Option {
-	return func(c *Config) { c.tableCacheProbationFraction = v }
+// WithCacheProbationFraction sets the probation segment fraction for the table cache.
+func WithCacheProbationFraction(v float64) Option {
+	return func(c *Config) { c.cacheProbationFraction = v }
 }
 
-// WithTableCacheCorruptTTL sets the corruption quarantine duration for the table cache.
-func WithTableCacheCorruptTTL(d time.Duration) Option {
-	return func(c *Config) { c.tableCacheCorruptTTL = d }
+// WithCacheCorruptTTL sets the corruption quarantine duration for the table cache.
+func WithCacheCorruptTTL(d time.Duration) Option {
+	return func(c *Config) { c.cacheCorruptTTL = d }
 }
 
 // WithFDLimiter sets the file descriptor limiter used by the table cache.

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -28,6 +29,10 @@ func TestDefaultConfig(t *testing.T) {
 		{"EnableTelemetry", cfg.enableTelemetry, false},
 		{"ExporterEndpoint", cfg.exporterEndpoint, ""},
 		{"ExporterInsecure", cfg.exporterInsecure, false},
+		{"cacheBytes", cfg.cacheBytes, int64(0)},
+		{"cacheShards", cfg.cacheShards, 0},
+		{"cacheProbationFraction", cfg.cacheProbationFraction, 0.0},
+		{"cacheCorruptTTL", cfg.cacheCorruptTTL, time.Duration(0)},
 	}
 
 	for _, tt := range tests {
@@ -167,6 +172,42 @@ func TestNewConfigWithOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "WithCacheBytes",
+			opts: []Option{WithCacheBytes(1024)},
+			verify: func(t *testing.T, cfg Config) {
+				if cfg.cacheBytes != 1024 {
+					t.Errorf("cacheBytes = %v, want %v", cfg.cacheBytes, 1024)
+				}
+			},
+		},
+		{
+			name: "WithCacheShards",
+			opts: []Option{WithCacheShards(8)},
+			verify: func(t *testing.T, cfg Config) {
+				if cfg.cacheShards != 8 {
+					t.Errorf("cacheShards = %v, want %v", cfg.cacheShards, 8)
+				}
+			},
+		},
+		{
+			name: "WithCacheProbationFraction",
+			opts: []Option{WithCacheProbationFraction(0.3)},
+			verify: func(t *testing.T, cfg Config) {
+				if cfg.cacheProbationFraction != 0.3 {
+					t.Errorf("cacheProbationFraction = %v, want %v", cfg.cacheProbationFraction, 0.3)
+				}
+			},
+		},
+		{
+			name: "WithCacheCorruptTTL",
+			opts: []Option{WithCacheCorruptTTL(time.Minute)},
+			verify: func(t *testing.T, cfg Config) {
+				if cfg.cacheCorruptTTL != time.Minute {
+					t.Errorf("cacheCorruptTTL = %v, want %v", cfg.cacheCorruptTTL, time.Minute)
+				}
+			},
+		},
+		{
 			name: "MultipleOptions",
 			opts: []Option{
 				WithDatabaseDir("/multi/path"),
@@ -220,6 +261,10 @@ func TestConfigValidatePanics(t *testing.T) {
 		{"nil fileNumberAllocator", func(c *Config) { c.fileNumberAllocator = nil }},
 		{"nil newManifestWriterFunc", func(c *Config) { c.newManifestWriterFunc = nil }},
 		{"manifestSizeThreshold non-positive", func(c *Config) { c.manifestSizeThreshold = 0 }},
+		{"cacheBytes negative", func(c *Config) { c.cacheBytes = -1 }},
+		{"cacheShards negative", func(c *Config) { c.cacheShards = -1 }},
+		{"cacheProbationFraction out of range", func(c *Config) { c.cacheProbationFraction = 1 }},
+		{"cacheCorruptTTL negative", func(c *Config) { c.cacheCorruptTTL = -1 }},
 	}
 
 	for _, tt := range tests {

--- a/rindb.go
+++ b/rindb.go
@@ -189,6 +189,15 @@ func (r *Rindb) Stats() Stats {
 	return stats
 }
 
+func (r *Rindb) TableCacheStats() tableCacheStats {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.SSTableManager == nil {
+		return tableCacheStats{}
+	}
+	return r.SSTableManager.TableCacheStats()
+}
+
 // Get retrieves the value associated with the given key from the database.
 // It first checks the memtable and then the SSTables if the key is not found in the memtable.
 // Parameters:

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -75,6 +75,13 @@ type ssTableManager struct {
 	diskSampler func() (uint64, error)
 }
 
+func (h *ssTableManager) TableCacheStats() tableCacheStats {
+	if h.cache == nil {
+		return tableCacheStats{}
+	}
+	return h.cache.Stats()
+}
+
 func (h *ssTableManager) sstInfo(num uint64) (os.FileInfo, error) {
 	return os.Stat(path.Join(h.config.databaseDir, sstPath(num)))
 }
@@ -164,10 +171,10 @@ func InitSSTableManager(ctx context.Context, config Config, vs *versionSet, mw m
 	}
 
 	tc := newTableCache(tableCacheOptions{
-		CapBytes:          config.tableCacheCapBytes,
-		Shards:            config.tableCacheShards,
-		ProbationFraction: config.tableCacheProbationFraction,
-		CorruptTTL:        config.tableCacheCorruptTTL,
+		CapBytes:          config.cacheBytes,
+		Shards:            config.cacheShards,
+		ProbationFraction: config.cacheProbationFraction,
+		CorruptTTL:        config.cacheCorruptTTL,
 		FDLimiter:         config.fdLimiter,
 		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
 			p := path.Join(config.databaseDir, sstPath(k.FileNum))

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -553,7 +553,7 @@ func (h *ssTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []f
 	for _, fm := range inputs {
 		k := tableKey{FileNum: fm.Number}
 		h.cache.UnpinKey(k)
-		h.cache.Delete(k)
+		h.cache.Delete(ctx, k)
 	}
 
 	if err := removeFiles(h.config.databaseDir, dels); err != nil {

--- a/stats_test.go
+++ b/stats_test.go
@@ -99,3 +99,16 @@ func TestRindb_Stats(t *testing.T) {
 		assert.Zero(t, st.ActiveSnapshots)
 	})
 }
+
+func TestRindb_TableCacheStats(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	cfg.cacheBytes = 1024
+	cfg.cacheShards = 4
+	ts := newTestRindbSetup(t, ctx, &cfg)
+	defer ts.Cleanup()
+
+	st := ts.RinDB.TableCacheStats()
+	assert.Equal(t, 4, st.Shards)
+	assert.Equal(t, int64(1024), st.CapBytes)
+}

--- a/tablecache.go
+++ b/tablecache.go
@@ -161,7 +161,7 @@ func (c *tableCache) TryGet(k tableKey) (h *Handle, ok bool) {
 	}
 	if e, ok := s.items[k]; ok {
 		e.h.Pin()
-		s.promoteOnHit(e)
+		s.promoteOnHit(context.Background(), e)
 		s.hits.Add(1)
 		cacheHits.Add(context.Background(), 1)
 		return e.h, true
@@ -204,7 +204,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 	}
 	if e, ok := s.items[k]; ok {
 		e.h.Pin()
-		s.promoteOnHit(e)
+		s.promoteOnHit(ctx, e)
 		s.hits.Add(1)
 		cacheHits.Add(ctx, 1)
 		s.mu.Unlock()
@@ -291,7 +291,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 	if existing, ok := s.items[k]; ok {
 		// Another goroutine installed first. Use it.
 		existing.h.Pin()
-		s.promoteOnHit(existing)
+		s.promoteOnHit(ctx, existing)
 		s.hits.Add(1)
 		cacheHits.Add(ctx, 1)
 		s.mu.Unlock()
@@ -320,14 +320,14 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 	cacheMisses.Add(ctx, 1)
 
 	// Evict/demote to budget (may close victims outside the lock).
-	s.evictOrDemoteLocked()
+	s.evictOrDemoteLocked(ctx)
 	s.mu.Unlock()
 	return h, nil
 }
 
 // Delete marks a key obsolete and unlinks it from the cache immediately.
 // Actual close happens immediately only if refcount hits zero.
-func (c *tableCache) Delete(k tableKey) {
+func (c *tableCache) Delete(ctx context.Context, k tableKey) {
 	s := c.shardFor(k)
 	var toClose *Handle
 
@@ -347,7 +347,7 @@ func (c *tableCache) Delete(k tableKey) {
 	s.mu.Unlock()
 
 	if toClose != nil {
-		s.closeNow(toClose)
+		s.closeNow(ctx, toClose)
 	}
 }
 
@@ -409,7 +409,7 @@ func (c *tableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 
 	// close the cold ones immediately
 	for _, p := range toClose {
-		p.s.closeNow(p.h)
+		p.s.closeNow(ctx, p.h)
 	}
 
 	// bounded wait for busy ones to drain

--- a/tablecache.go
+++ b/tablecache.go
@@ -163,6 +163,7 @@ func (c *tableCache) TryGet(k tableKey) (h *Handle, ok bool) {
 		e.h.Pin()
 		s.promoteOnHit(e)
 		s.hits.Add(1)
+		cacheHits.Add(context.Background(), 1)
 		return e.h, true
 	}
 	return nil, false
@@ -205,6 +206,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 		e.h.Pin()
 		s.promoteOnHit(e)
 		s.hits.Add(1)
+		cacheHits.Add(ctx, 1)
 		s.mu.Unlock()
 		return e.h, nil
 	}
@@ -225,6 +227,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 			return nil, err
 		}
 		s.opens.Add(1) // count successful open attempts
+		cacheOpens.Add(ctx, 1)
 
 		// checksums on first use
 		if c.opt.Verify != nil {
@@ -272,6 +275,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 		if h.closed.CompareAndSwap(false, true) {
 			_ = c.opt.Close(h.Table)
 			s.closes.Add(1)
+			cacheCloses.Add(ctx, 1)
 		}
 		return nil, ErrClosed
 	}
@@ -280,6 +284,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 		if h.closed.CompareAndSwap(false, true) {
 			_ = c.opt.Close(h.Table)
 			s.closes.Add(1)
+			cacheCloses.Add(ctx, 1)
 		}
 		return nil, ErrObsolete
 	}
@@ -288,18 +293,23 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 		existing.h.Pin()
 		s.promoteOnHit(existing)
 		s.hits.Add(1)
+		cacheHits.Add(ctx, 1)
 		s.mu.Unlock()
 		// Close duplicate we just opened.
 		if h != existing.h && h.closed.CompareAndSwap(false, true) {
 			_ = c.opt.Close(h.Table)
 			s.closes.Add(1)
+			cacheCloses.Add(ctx, 1)
 		}
 		return existing.h, nil
 	}
 
 	e := &entry{key: k, h: h, seg: segProbation}
 	// hook: when handle closes via Unref path, count closes
-	h.onClose = func() { s.closes.Add(1) }
+	h.onClose = func() {
+		s.closes.Add(1)
+		cacheCloses.Add(context.Background(), 1)
+	}
 
 	e.elem = s.prob.PushFront(e)
 	s.items[k] = e
@@ -307,6 +317,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 	s.probBytes += h.actualBytes
 	c.totalBytes.Add(h.actualBytes)
 	s.misses.Add(1)
+	cacheMisses.Add(ctx, 1)
 
 	// Evict/demote to budget (may close victims outside the lock).
 	s.evictOrDemoteLocked()

--- a/tablecache_slru.go
+++ b/tablecache_slru.go
@@ -67,7 +67,7 @@ type shard struct {
 
 // --- SLRU helpers (all require s.mu held unless stated) ---
 
-func (s *shard) promoteOnHit(e *entry) {
+func (s *shard) promoteOnHit(ctx context.Context, e *entry) {
 	switch e.seg {
 	case segProbation:
 		// second hit → promote to protected
@@ -79,7 +79,7 @@ func (s *shard) promoteOnHit(e *entry) {
 		e.seg = segProtected
 		s.protBytes += e.h.actualBytes
 		s.promotions.Add(1)
-		cachePromotions.Add(context.Background(), 1)
+		cachePromotions.Add(ctx, 1)
 
 		// enforce protected cap via demotion if necessary
 		for s.segmentBytes(segProtected) > s.protCapBytes {
@@ -146,7 +146,7 @@ func (s *shard) segmentBytes(seg segment) int64 {
 
 // evictOrDemoteLocked ensures segment splits and capBytes.
 // It closes unpinned, zero-ref victims outside the lock to avoid blocking.
-func (s *shard) evictOrDemoteLocked() {
+func (s *shard) evictOrDemoteLocked(ctx context.Context) {
 	if s.capBytes <= 0 {
 		return
 	}
@@ -200,22 +200,22 @@ func (s *shard) evictOrDemoteLocked() {
 			toClose = append(toClose, v.h)
 		}
 		s.evicts.Add(1)
-		cacheEvicts.Add(context.Background(), 1)
+		cacheEvicts.Add(ctx, 1)
 	}
 
 	if len(toClose) > 0 {
 		s.mu.Unlock()
 		for _, h := range toClose {
-			s.closeNow(h)
+			s.closeNow(ctx, h)
 		}
 		s.mu.Lock()
 	}
 }
 
-func (s *shard) closeNow(h *Handle) {
+func (s *shard) closeNow(ctx context.Context, h *Handle) {
 	if h.closed.CompareAndSwap(false, true) {
 		_ = h.closer(h.Table)
 		s.closes.Add(1)
-		cacheCloses.Add(context.Background(), 1)
+		cacheCloses.Add(ctx, 1)
 	}
 }

--- a/tablecache_slru.go
+++ b/tablecache_slru.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"container/list"
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -78,6 +79,7 @@ func (s *shard) promoteOnHit(e *entry) {
 		e.seg = segProtected
 		s.protBytes += e.h.actualBytes
 		s.promotions.Add(1)
+		cachePromotions.Add(context.Background(), 1)
 
 		// enforce protected cap via demotion if necessary
 		for s.segmentBytes(segProtected) > s.protCapBytes {
@@ -198,6 +200,7 @@ func (s *shard) evictOrDemoteLocked() {
 			toClose = append(toClose, v.h)
 		}
 		s.evicts.Add(1)
+		cacheEvicts.Add(context.Background(), 1)
 	}
 
 	if len(toClose) > 0 {
@@ -213,5 +216,6 @@ func (s *shard) closeNow(h *Handle) {
 	if h.closed.CompareAndSwap(false, true) {
 		_ = h.closer(h.Table)
 		s.closes.Add(1)
+		cacheCloses.Add(context.Background(), 1)
 	}
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -41,6 +41,15 @@ var (
 	walRecordsCounter     metric.Int64UpDownCounter
 	walBytesCounter       metric.Int64UpDownCounter
 
+	// Table cache metrics
+	tableCacheMeter = otel.Meter("rindb/tablecache")
+	cacheHits       metric.Int64Counter
+	cacheMisses     metric.Int64Counter
+	cacheOpens      metric.Int64Counter
+	cacheCloses     metric.Int64Counter
+	cacheEvicts     metric.Int64Counter
+	cachePromotions metric.Int64Counter
+
 	// RinDB metrics
 	rindbMeter = otel.Meter("rindb")
 
@@ -79,6 +88,13 @@ func init() {
 	walAppendManyDuration = must(walMeter.Float64Histogram("rindb.wal.append_many.duration", metric.WithUnit("ms")))
 	walRecordsCounter = must(walMeter.Int64UpDownCounter("rindb.wal.records"))
 	walBytesCounter = must(walMeter.Int64UpDownCounter("rindb.wal.bytes"))
+
+	cacheHits = must(tableCacheMeter.Int64Counter("rindb.tablecache.hits"))
+	cacheMisses = must(tableCacheMeter.Int64Counter("rindb.tablecache.misses"))
+	cacheOpens = must(tableCacheMeter.Int64Counter("rindb.tablecache.opens"))
+	cacheCloses = must(tableCacheMeter.Int64Counter("rindb.tablecache.closes"))
+	cacheEvicts = must(tableCacheMeter.Int64Counter("rindb.tablecache.evicts"))
+	cachePromotions = must(tableCacheMeter.Int64Counter("rindb.tablecache.promotions"))
 
 	getCalls = must(rindbMeter.Int64Counter("rindb.get.calls"))
 	putCalls = must(rindbMeter.Int64Counter("rindb.put.calls"))

--- a/utils_test.go
+++ b/utils_test.go
@@ -194,7 +194,7 @@ func (ts *testRindbSetup) AddSSTable(level int, sstable *SStable) {
 // test if the entry remains.
 func (ts *testRindbSetup) removeFromCache(num uint64) {
 	ts.T.Helper()
-	ts.Manager.cache.Delete(tableKey{FileNum: num})
+	ts.Manager.cache.Delete(context.Background(), tableKey{FileNum: num})
 	if _, ok := ts.Manager.cache.TryGet(tableKey{FileNum: num}); ok {
 		ts.T.Fatalf("cache still has entry for %d", num)
 	}


### PR DESCRIPTION
## Summary
- allow configuring table cache size and shard count via new options and CLI flags
- export table cache statistics and wire metrics into OpenTelemetry
- document table cache usage and observability in README

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc23fe10b483258ad9ae2e55f825e2