### PR TITLE
test: add table cache coverage and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ defer db.Close()
 
 The sample CLI accepts `--cache-bytes` and `--cache-shards` flags to tune the cache.
 
+### Table Cache
+
+RinDB keeps recently used SSTables open in a sharded SLRU cache. The cache size and
+number of shards are controlled via `WithCacheBytes` and `WithCacheShards`.
+You can inspect runtime metrics to observe hit/miss ratios and byte usage:
+
+```go
+stats := db.TableCacheStats()
+fmt.Printf("cache hits=%d misses=%d\n", stats.Hits, stats.Misses)
+```
+
+Files that fail verification are quarantined automatically, and the cache evicts
+least-recently-used entries while respecting internally pinned tables during
+compaction.
+
 ## Building and Testing
 
 Run tests:

--- a/integration/tablecache_compaction_test.go
+++ b/integration/tablecache_compaction_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+
+package rindb_test
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/metailurini/rindb"
+)
+
+func TestTableCacheHitAfterCompaction(t *testing.T) {
+    db, cleanup := initTestDB(t,
+        rindb.WithLevel0CompactionThreshold(2),
+        rindb.WithMaxMemtableSize(1),
+    )
+    defer cleanup()
+    ctx := context.Background()
+
+    kvs := []struct{ key, val string }{
+        {"k1", "v1"},
+        {"k2", "v2"},
+        {"k1", "v1_new"},
+        {"k3", "v3"},
+    }
+    for _, kv := range kvs {
+        require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+    }
+
+    require.Eventually(t, func() bool {
+        st := db.Stats()
+        if len(st.SSTablesPerLevel) < 2 {
+            return false
+        }
+        return st.SSTablesPerLevel[0] == 0 && st.SSTablesPerLevel[1] > 0
+    }, 5*time.Second, 100*time.Millisecond)
+
+    v, err := db.Get(ctx, rindb.Bytes("k1"))
+    require.NoError(t, err)
+    require.Equal(t, rindb.Bytes("v1_new"), v)
+    mid := db.TableCacheStats()
+
+    v, err = db.Get(ctx, rindb.Bytes("k1"))
+    require.NoError(t, err)
+    require.Equal(t, rindb.Bytes("v1_new"), v)
+
+    after := db.TableCacheStats()
+    require.Equal(t, mid.Hits+1, after.Hits)
+}
+

--- a/integration/tablecache_wal_recovery_test.go
+++ b/integration/tablecache_wal_recovery_test.go
@@ -3,57 +3,52 @@
 package rindb_test
 
 import (
-    "context"
-    "testing"
+	"context"
+	"testing"
 
-    "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 
-    "github.com/metailurini/rindb"
+	"github.com/metailurini/rindb"
 )
 
 func TestTableCacheAfterWALRecovery(t *testing.T) {
-    ctx := context.Background()
-    dir := t.TempDir()
-    opts := []rindb.Option{
-        rindb.WithDatabaseDir(dir),
-        rindb.WithMaxMemtableSize(175),
-    }
+	ctx := context.Background()
+	dir := t.TempDir()
+	opts := []rindb.Option{
+		rindb.WithDatabaseDir(dir),
+		rindb.WithMaxMemtableSize(175),
+	}
 
-    db, err := rindb.InitRinDB(ctx, opts...)
-    require.NoError(t, err)
+	db, err := rindb.InitRinDB(ctx, opts...)
+	require.NoError(t, err)
 
-    kvs := []struct{ key, val string }{
-        {"k1", "v1"},
-        {"k2", "v2"},
-        {"k3", "v3"}, // triggers flush
-    }
-    for _, kv := range kvs {
-        require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
-    }
-    require.NoError(t, db.Put(ctx, rindb.Bytes("k4"), rindb.Bytes("v4")))
-    require.NoError(t, db.Close())
+	kvs := []struct{ key, val string }{
+		{"k1", "v1"},
+		{"k2", "v2"},
+		{"k3", "v3"}, // triggers flush
+	}
+	for _, kv := range kvs {
+		require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+	}
+	require.NoError(t, db.Put(ctx, rindb.Bytes("k4"), rindb.Bytes("v4")))
+	require.NoError(t, db.Close())
 
-    db, err = rindb.InitRinDB(ctx, opts...)
-    require.NoError(t, err)
-    defer func() { require.NoError(t, db.Close()) }()
+	db, err = rindb.InitRinDB(ctx, opts...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
 
-    before := db.TableCacheStats()
+	before := db.TableCacheStats()
 
-    v, err := db.Get(ctx, rindb.Bytes("k4"))
-    require.NoError(t, err)
-    require.Equal(t, rindb.Bytes("v4"), v)
+	v, err := db.Get(ctx, rindb.Bytes("k1"))
+	require.NoError(t, err)
+	require.Equal(t, rindb.Bytes("v1"), v)
+	mid := db.TableCacheStats()
+	require.Equal(t, before.Misses+1, mid.Misses)
 
-    v, err = db.Get(ctx, rindb.Bytes("k1"))
-    require.NoError(t, err)
-    require.Equal(t, rindb.Bytes("v1"), v)
-    mid := db.TableCacheStats()
-    require.Equal(t, before.Misses+1, mid.Misses)
+	v, err = db.Get(ctx, rindb.Bytes("k1"))
+	require.NoError(t, err)
+	require.Equal(t, rindb.Bytes("v1"), v)
+	after := db.TableCacheStats()
 
-    v, err = db.Get(ctx, rindb.Bytes("k1"))
-    require.NoError(t, err)
-    require.Equal(t, rindb.Bytes("v1"), v)
-    after := db.TableCacheStats()
-
-    require.Equal(t, mid.Hits+1, after.Hits)
+	require.Equal(t, mid.Hits+1, after.Hits)
 }
-

--- a/integration/tablecache_wal_recovery_test.go
+++ b/integration/tablecache_wal_recovery_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package rindb_test
+
+import (
+    "context"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "github.com/metailurini/rindb"
+)
+
+func TestTableCacheAfterWALRecovery(t *testing.T) {
+    ctx := context.Background()
+    dir := t.TempDir()
+    opts := []rindb.Option{
+        rindb.WithDatabaseDir(dir),
+        rindb.WithMaxMemtableSize(175),
+    }
+
+    db, err := rindb.InitRinDB(ctx, opts...)
+    require.NoError(t, err)
+
+    kvs := []struct{ key, val string }{
+        {"k1", "v1"},
+        {"k2", "v2"},
+        {"k3", "v3"}, // triggers flush
+    }
+    for _, kv := range kvs {
+        require.NoError(t, db.Put(ctx, rindb.Bytes(kv.key), rindb.Bytes(kv.val)))
+    }
+    require.NoError(t, db.Put(ctx, rindb.Bytes("k4"), rindb.Bytes("v4")))
+    require.NoError(t, db.Close())
+
+    db, err = rindb.InitRinDB(ctx, opts...)
+    require.NoError(t, err)
+    defer func() { require.NoError(t, db.Close()) }()
+
+    before := db.TableCacheStats()
+
+    v, err := db.Get(ctx, rindb.Bytes("k4"))
+    require.NoError(t, err)
+    require.Equal(t, rindb.Bytes("v4"), v)
+
+    v, err = db.Get(ctx, rindb.Bytes("k1"))
+    require.NoError(t, err)
+    require.Equal(t, rindb.Bytes("v1"), v)
+    mid := db.TableCacheStats()
+    require.Equal(t, before.Misses+1, mid.Misses)
+
+    v, err = db.Get(ctx, rindb.Bytes("k1"))
+    require.NoError(t, err)
+    require.Equal(t, rindb.Bytes("v1"), v)
+    after := db.TableCacheStats()
+
+    require.Equal(t, mid.Hits+1, after.Hits)
+}
+

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1612,6 +1612,7 @@ func TestSSTableManager_findOverlappingSSTables(t *testing.T) {
 		// drop from table cache so subsequent merge attempts to reopen it
 		num, err := fileNum(overlap.FileSystem.Path())
 		require.NoError(t, err)
+		// tests use DBID 0; tableKey DBID is irrelevant until multi-DB support
 		ts.Manager.cache.Delete(ctx, tableKey{FileNum: num})
 
 		picked := append([]fileMeta(nil), ts.Manager.versionSet.Levels[0]...)

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -1609,6 +1609,11 @@ func TestSSTableManager_findOverlappingSSTables(t *testing.T) {
 		require.NoError(t, overlap.Close())
 		require.NoError(t, non.Close())
 
+		// drop from table cache so subsequent merge attempts to reopen it
+		num, err := fileNum(overlap.FileSystem.Path())
+		require.NoError(t, err)
+		ts.Manager.cache.Delete(ctx, tableKey{FileNum: num})
+
 		picked := append([]fileMeta(nil), ts.Manager.versionSet.Levels[0]...)
 		overlaps, err := ts.Manager.findOverlaps(1, picked)
 		require.NoError(t, err)

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -1,0 +1,115 @@
+package rindb
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCache(t *testing.T, opt tableCacheOptions) *tableCache {
+	t.Helper()
+	if opt.Open == nil {
+		opt.Open = func(ctx context.Context, k tableKey) (*SStable, error) { return &SStable{}, nil }
+	}
+	if opt.Close == nil {
+		opt.Close = func(*SStable) error { return nil }
+	}
+	if opt.Measure == nil {
+		opt.Measure = func(*SStable) (int64, int64) { return 0, 1 }
+	}
+	if opt.Shards == 0 {
+		opt.Shards = 1
+	}
+	return newTableCache(opt)
+}
+
+func TestTableCacheHitMiss(t *testing.T) {
+	ctx := context.Background()
+	var opens atomic.Int32
+	cache := newTestCache(t, tableCacheOptions{
+		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+			opens.Add(1)
+			return &SStable{}, nil
+		},
+	})
+
+	key := tableKey{DBID: 1, FileNum: 1}
+	h, err := cache.Get(ctx, key)
+	require.NoError(t, err)
+	h.Unref()
+
+	h, err = cache.Get(ctx, key)
+	require.NoError(t, err)
+	h.Unref()
+
+	require.EqualValues(t, 1, opens.Load())
+	st := cache.Stats()
+	require.EqualValues(t, 1, st.Misses)
+	require.EqualValues(t, 1, st.Hits)
+}
+
+func TestTableCacheEviction(t *testing.T) {
+	ctx := context.Background()
+	cache := newTestCache(t, tableCacheOptions{CapBytes: 1})
+
+	k1 := tableKey{DBID: 1, FileNum: 1}
+	h1, err := cache.Get(ctx, k1)
+	require.NoError(t, err)
+	h1.Unref()
+
+	k2 := tableKey{DBID: 1, FileNum: 2}
+	h2, err := cache.Get(ctx, k2)
+	require.NoError(t, err)
+	h2.Unref()
+
+	_, ok := cache.TryGet(k1)
+	require.False(t, ok, "k1 should be evicted")
+	_, ok = cache.TryGet(k2)
+	require.True(t, ok, "k2 should remain in cache")
+}
+
+func TestTableCachePinning(t *testing.T) {
+	ctx := context.Background()
+	cache := newTestCache(t, tableCacheOptions{CapBytes: 1})
+
+	k1 := tableKey{DBID: 1, FileNum: 1}
+	h1, err := cache.Get(ctx, k1)
+	require.NoError(t, err)
+	h1.Unref()
+	require.True(t, cache.PinKey(k1))
+
+	k2 := tableKey{DBID: 1, FileNum: 2}
+	h2, err := cache.Get(ctx, k2)
+	require.NoError(t, err)
+	h2.Unref()
+
+	_, ok := cache.TryGet(k1)
+	require.True(t, ok, "pinned k1 should stay resident")
+	_, ok = cache.TryGet(k2)
+	require.False(t, ok, "unpinned k2 should be evicted")
+}
+
+func TestTableCacheCorruptionQuarantine(t *testing.T) {
+	ctx := context.Background()
+	var opens atomic.Int32
+	cache := newTestCache(t, tableCacheOptions{
+		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+			opens.Add(1)
+			return &SStable{}, nil
+		},
+		Verify:     func(*SStable) error { return ErrCorruption },
+		CorruptTTL: time.Minute,
+	})
+
+	k := tableKey{DBID: 1, FileNum: 1}
+	_, err := cache.Get(ctx, k)
+	require.ErrorIs(t, err, ErrCorruption)
+	require.EqualValues(t, 1, opens.Load())
+
+	_, err = cache.Get(ctx, k)
+	require.ErrorIs(t, err, ErrCorruption)
+	require.EqualValues(t, 1, opens.Load(), "should not reopen during quarantine")
+}

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -36,7 +36,8 @@ func TestTableCacheHitMiss(t *testing.T) {
 		},
 	})
 
-	key := tableKey{DBID: 1, FileNum: 1}
+	// tests use default DBID 0; override when multi-DB is supported
+	key := tableKey{FileNum: 1}
 	h, err := cache.Get(ctx, key)
 	require.NoError(t, err)
 	h.Unref()
@@ -55,12 +56,12 @@ func TestTableCacheEviction(t *testing.T) {
 	ctx := context.Background()
 	cache := newTestCache(t, tableCacheOptions{CapBytes: 1})
 
-	k1 := tableKey{DBID: 1, FileNum: 1}
+	k1 := tableKey{FileNum: 1}
 	h1, err := cache.Get(ctx, k1)
 	require.NoError(t, err)
 	h1.Unref()
 
-	k2 := tableKey{DBID: 1, FileNum: 2}
+	k2 := tableKey{FileNum: 2}
 	h2, err := cache.Get(ctx, k2)
 	require.NoError(t, err)
 	h2.Unref()
@@ -75,13 +76,13 @@ func TestTableCachePinning(t *testing.T) {
 	ctx := context.Background()
 	cache := newTestCache(t, tableCacheOptions{CapBytes: 1})
 
-	k1 := tableKey{DBID: 1, FileNum: 1}
+	k1 := tableKey{FileNum: 1}
 	h1, err := cache.Get(ctx, k1)
 	require.NoError(t, err)
 	h1.Unref()
 	require.True(t, cache.PinKey(k1))
 
-	k2 := tableKey{DBID: 1, FileNum: 2}
+	k2 := tableKey{FileNum: 2}
 	h2, err := cache.Get(ctx, k2)
 	require.NoError(t, err)
 	h2.Unref()
@@ -104,7 +105,7 @@ func TestTableCacheCorruptionQuarantine(t *testing.T) {
 		CorruptTTL: time.Minute,
 	})
 
-	k := tableKey{DBID: 1, FileNum: 1}
+	k := tableKey{FileNum: 1}
 	_, err := cache.Get(ctx, k)
 	require.ErrorIs(t, err, ErrCorruption)
 	require.EqualValues(t, 1, opens.Load())


### PR DESCRIPTION
## Summary
- add unit tests for table cache hit/miss, eviction, pinning, and corruption quarantine
- cover table cache behavior in compaction and WAL recovery integration tests
- document table cache configuration and metrics in README

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc2c9092bc8325b63cf73939f445e6