### PR TITLE
fix: handle pinned cache overflow

### DIFF
--- a/tablecache.go
+++ b/tablecache.go
@@ -343,7 +343,10 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 	cacheMisses.Add(ctx, 1)
 
 	// Evict/demote to budget (may close victims outside the lock).
-	s.evictOrDemoteLocked(ctx)
+	if !s.evictOrDemoteLocked(ctx, e) {
+		// Entry was dropped due to full pinned cache; the handle remains valid
+		// but won't be reachable through the cache and will close on Unref().
+	}
 	s.mu.Unlock()
 	return h, nil
 }

--- a/tablecache_slru.go
+++ b/tablecache_slru.go
@@ -148,6 +148,21 @@ func (s *shard) segmentBytes(seg segment) int64 {
 	}
 }
 
+func (s *shard) evictEntryLocked(ctx context.Context, e *entry, toClose *[]*Handle) {
+	s.unlink(e)
+	delete(s.items, e.key)
+	s.usedBytes -= e.h.actualBytes
+	s.parent.totalBytes.Add(-e.h.actualBytes)
+
+	if e.h.refs.Load() > 0 {
+		e.h.evictWhenZero.Store(true)
+	} else {
+		*toClose = append(*toClose, e.h)
+	}
+	s.evicts.Add(1)
+	cacheEvicts.Add(ctx, 1)
+}
+
 // evictOrDemoteLocked ensures segment splits and capBytes.
 // It closes unpinned, zero-ref victims outside the lock to avoid blocking.
 func (s *shard) evictOrDemoteLocked(ctx context.Context, recent *entry) bool {
@@ -177,35 +192,12 @@ func (s *shard) evictOrDemoteLocked(ctx context.Context, recent *entry) bool {
 		if v == nil {
 			// No evictable entries remain (all pinned); drop the recently added entry.
 			if recent != nil && recent.seg != segNone {
-				s.unlink(recent)
-				delete(s.items, recent.key)
-				s.usedBytes -= recent.h.actualBytes
-				s.parent.totalBytes.Add(-recent.h.actualBytes)
-				if recent.h.refs.Load() > 0 {
-					recent.h.evictWhenZero.Store(true)
-				} else {
-					toClose = append(toClose, recent.h)
-				}
-				s.evicts.Add(1)
-				cacheEvicts.Add(ctx, 1)
+				s.evictEntryLocked(ctx, recent, &toClose)
 			}
 			break
 		}
 		// Remove from SLRU + map; stop future pins; free budget immediately (cache residency accounting).
-		s.unlink(v)
-		delete(s.items, v.key)
-		s.usedBytes -= v.h.actualBytes
-		s.parent.totalBytes.Add(-v.h.actualBytes)
-
-		if v.h.refs.Load() > 0 {
-			// Busy: mark for close later when refs drain.
-			v.h.evictWhenZero.Store(true)
-		} else {
-			// Cold: close now (outside lock).
-			toClose = append(toClose, v.h)
-		}
-		s.evicts.Add(1)
-		cacheEvicts.Add(ctx, 1)
+		s.evictEntryLocked(ctx, v, &toClose)
 	}
 
 	if len(toClose) > 0 {

--- a/tablecache_slru.go
+++ b/tablecache_slru.go
@@ -150,9 +150,9 @@ func (s *shard) segmentBytes(seg segment) int64 {
 
 // evictOrDemoteLocked ensures segment splits and capBytes.
 // It closes unpinned, zero-ref victims outside the lock to avoid blocking.
-func (s *shard) evictOrDemoteLocked(ctx context.Context) {
+func (s *shard) evictOrDemoteLocked(ctx context.Context, recent *entry) bool {
 	if s.capBytes <= 0 {
-		return
+		return true
 	}
 	// First, if protected exceeds its cap, demote from protected tail into probation head.
 	for s.segmentBytes(segProtected) > s.protCapBytes {
@@ -175,8 +175,20 @@ func (s *shard) evictOrDemoteLocked(ctx context.Context) {
 	for s.usedBytes > s.capBytes {
 		v := s.chooseVictim()
 		if v == nil {
-			// No evictable entries remain (all pinned); stop admission and exit.
-			s.stopAdmission.Store(true)
+			// No evictable entries remain (all pinned); drop the recently added entry.
+			if recent != nil && recent.seg != segNone {
+				s.unlink(recent)
+				delete(s.items, recent.key)
+				s.usedBytes -= recent.h.actualBytes
+				s.parent.totalBytes.Add(-recent.h.actualBytes)
+				if recent.h.refs.Load() > 0 {
+					recent.h.evictWhenZero.Store(true)
+				} else {
+					toClose = append(toClose, recent.h)
+				}
+				s.evicts.Add(1)
+				cacheEvicts.Add(ctx, 1)
+			}
 			break
 		}
 		// Remove from SLRU + map; stop future pins; free budget immediately (cache residency accounting).
@@ -203,6 +215,11 @@ func (s *shard) evictOrDemoteLocked(ctx context.Context) {
 		}
 		s.mu.Lock()
 	}
+
+	if recent != nil && recent.seg == segNone {
+		return false
+	}
+	return true
 }
 
 func (s *shard) closeNow(ctx context.Context, h *Handle) {

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -93,6 +93,29 @@ func TestTableCachePinning(t *testing.T) {
 	require.False(t, ok, "unpinned k2 should be evicted")
 }
 
+func TestTableCachePinnedOverCapacity(t *testing.T) {
+	ctx := context.Background()
+	cache := newTestCache(t, tableCacheOptions{CapBytes: 1})
+
+	k1 := tableKey{FileNum: 1}
+	h1, err := cache.Get(ctx, k1)
+	require.NoError(t, err)
+	h1.Unref()
+	require.True(t, cache.PinKey(k1))
+
+	k2 := tableKey{FileNum: 2}
+	h2, err := cache.Get(ctx, k2)
+	require.NoError(t, err)
+	h2.Unref()
+
+	_, ok := cache.TryGet(k2)
+	require.False(t, ok, "k2 should not be cached when capacity is pinned")
+
+	h2, err = cache.Get(ctx, k2)
+	require.NoError(t, err)
+	h2.Unref()
+}
+
 func TestTableCacheCorruptionQuarantine(t *testing.T) {
 	ctx := context.Background()
 	var opens atomic.Int32


### PR DESCRIPTION
## Summary
- avoid stopping shard admission when capacity is exceeded by pinned tables
- handle Get for no-cache outcomes and keep table handles usable
- add regression test for lookups beyond pinned cache capacity

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc43cd38a48325b8cc1361935726d3