### PR TITLE
test: add tablecache delete and close tests

### DIFF
--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -114,3 +114,112 @@ func TestTableCacheCorruptionQuarantine(t *testing.T) {
 	require.ErrorIs(t, err, ErrCorruption)
 	require.EqualValues(t, 1, opens.Load(), "should not reopen during quarantine")
 }
+
+func TestTableCacheDelete(t *testing.T) {
+	ctx := context.Background()
+	var opens atomic.Int32
+	var closes atomic.Int32
+	cache := newTestCache(t, tableCacheOptions{
+		CapBytes: 1,
+		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+			opens.Add(1)
+			return &SStable{}, nil
+		},
+		Close: func(*SStable) error {
+			closes.Add(1)
+			return nil
+		},
+	})
+
+	k := tableKey{FileNum: 1}
+	h, err := cache.Get(ctx, k)
+	require.NoError(t, err)
+	h.Unref()
+
+	// Entry should be resident prior to deletion.
+	h2, ok := cache.TryGet(k)
+	require.True(t, ok)
+	h2.Unref()
+	require.EqualValues(t, 0, closes.Load())
+
+	cache.Delete(ctx, k)
+	require.EqualValues(t, 1, closes.Load(), "delete should close handle when refs==0")
+
+	_, ok = cache.TryGet(k)
+	require.False(t, ok, "entry should be removed")
+
+	_, err = cache.Get(ctx, k)
+	require.ErrorIs(t, err, ErrObsolete, "tombstone should block re-admission")
+	require.EqualValues(t, 1, opens.Load(), "open should not be called again")
+}
+
+func TestTableCacheClose(t *testing.T) {
+	t.Run("drain", func(t *testing.T) {
+		ctx := context.Background()
+		var opens atomic.Int32
+		var closes atomic.Int32
+		cache := newTestCache(t, tableCacheOptions{
+			CapBytes: 1,
+			Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+				opens.Add(1)
+				return &SStable{}, nil
+			},
+			Close: func(*SStable) error {
+				closes.Add(1)
+				return nil
+			},
+		})
+
+		k1 := tableKey{FileNum: 1}
+		h, err := cache.Get(ctx, k1)
+		require.NoError(t, err)
+
+		done := make(chan error)
+		go func() { done <- cache.Close(ctx, 100*time.Millisecond) }()
+
+		// New admissions should be rejected.
+		// Poll until cache.Close() has started and rejects new admissions, which is more robust than a fixed sleep.
+		require.Eventually(t, func() bool {
+			if !cache.shards[0].stopAdmission.Load() {
+				return false
+			}
+			_, err := cache.Get(ctx, tableKey{FileNum: 2})
+			return err == ErrClosed
+		}, 50*time.Millisecond, 5*time.Millisecond)
+		require.EqualValues(t, 1, opens.Load())
+		require.EqualValues(t, 0, closes.Load())
+
+		// Release the outstanding handle; Close should return and close it.
+		h.Unref()
+		require.NoError(t, <-done)
+		require.EqualValues(t, 1, closes.Load())
+
+		// Further admissions are rejected after Close.
+		_, err = cache.Get(ctx, tableKey{FileNum: 3})
+		require.ErrorIs(t, err, ErrClosed)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		ctx := context.Background()
+		var closes atomic.Int32
+		cache := newTestCache(t, tableCacheOptions{
+			CapBytes: 1,
+			Close: func(*SStable) error {
+				closes.Add(1)
+				return nil
+			},
+		})
+
+		k := tableKey{FileNum: 1}
+		h, err := cache.Get(ctx, k)
+		require.NoError(t, err)
+
+		err = cache.Close(ctx, 10*time.Millisecond)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "handles still busy")
+		require.EqualValues(t, 0, closes.Load(), "handle should remain open on timeout")
+
+		h.Unref()
+		require.EqualValues(t, 1, closes.Load(), "handle should close after late Unref")
+	})
+}


### PR DESCRIPTION
## Summary
- test tablecache Delete for entry removal, immediate close, and tombstone behavior
- test tablecache Close for admission rejection, draining of handles, and timeout errors
- poll for Close admission rejection instead of using a fixed sleep

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc436e78b48325abdc5cbb8a379343