### PR TITLE
feat: add semaphore-based FD limiter

### DIFF
--- a/fd_limiter.go
+++ b/fd_limiter.go
@@ -1,0 +1,37 @@
+package rindb
+
+import "context"
+
+// SemaphoreFDLimiter limits concurrent file descriptor usage using a semaphore.
+// It implements the FDLimiter interface for table cache operations.
+type SemaphoreFDLimiter struct {
+	sem chan struct{}
+}
+
+// NewSemaphoreFDLimiter creates a limiter that permits up to n concurrent
+// acquisitions. n must be >0.
+func NewSemaphoreFDLimiter(n int) *SemaphoreFDLimiter {
+	if n <= 0 {
+		panic("rindb: FD limit must be positive")
+	}
+	return &SemaphoreFDLimiter{sem: make(chan struct{}, n)}
+}
+
+// Acquire blocks until a slot is available or the context is done.
+func (l *SemaphoreFDLimiter) Acquire(ctx context.Context) error {
+	select {
+	case l.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Release frees a slot previously acquired.
+func (l *SemaphoreFDLimiter) Release() {
+	select {
+	case <-l.sem:
+	default:
+		panic("rindb: extra call to FDLimiter.Release")
+	}
+}

--- a/fd_limiter_test.go
+++ b/fd_limiter_test.go
@@ -1,0 +1,63 @@
+package rindb
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemaphoreFDLimiterConcurrentGet(t *testing.T) {
+	ctx := context.Background()
+	limiter := NewSemaphoreFDLimiter(1)
+
+	var current atomic.Int32
+	var max atomic.Int32
+
+	cache := newTestCache(t, tableCacheOptions{
+		FDLimiter: limiter,
+		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+			c := current.Add(1)
+			for {
+				old := max.Load()
+				if c <= old || max.CompareAndSwap(old, c) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			current.Add(-1)
+			return &SStable{}, nil
+		},
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			h, err := cache.Get(ctx, tableKey{FileNum: uint64(i)})
+			require.NoError(t, err)
+			h.Unref()
+		}(i)
+	}
+	wg.Wait()
+
+	require.EqualValues(t, 1, max.Load(), "concurrent opens should be limited to 1")
+}
+
+func TestSemaphoreFDLimiterAcquireCancelled(t *testing.T) {
+	limiter := NewSemaphoreFDLimiter(1)
+
+	require.NoError(t, limiter.Acquire(context.Background()))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := limiter.Acquire(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+
+	limiter.Release()
+}


### PR DESCRIPTION
## Summary
- add `SemaphoreFDLimiter` to control concurrent file opens via a buffered channel
- panic on non-positive limits and on extra release calls
- test limiter concurrency and cancellation behavior

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc4385f2388325b06e581cf9a70e03