### PR TITLE
fix: keep SSTable handles cached during search

### DIFF
--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -681,7 +681,7 @@ func (h *ssTableManager) SearchKey(ctx context.Context, key Bytes, seq ...uint64
 		}
 		for _, hnd := range ssts {
 			val, err := hnd.Table.GetValue(ctx, key, maxSeq)
-			hnd.Release()
+			hnd.Unref()
 			if err == nil {
 				return val, nil
 			}


### PR DESCRIPTION
## Summary
- keep SSTable handles cached in `SearchKey` by unrefing instead of releasing

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`
- `go test -tags=integration -v ./integration -run TestTableCacheMissAfterGetFollowingCompaction`
- `go test -tags=integration -v ./integration -run TestTableCacheAfterWALRecovery`


------
https://chatgpt.com/codex/tasks/task_e_68bc5fe89fe08325ab85e5a41669b399