### PR TITLE
refactor: rename table cache handle

### DIFF
--- a/docs/dev/168/overall_plan.md
+++ b/docs/dev/168/overall_plan.md
@@ -5,7 +5,7 @@ The complete reference implementation used to inform this plan is available in [
 ## Plan
 1. Add a sharded SLRU table cache in this package (no new subpackage).
    - define typed errors, `tableKey`, `Options`, `FDLimiter`, and core structs
-   - implement `Handle`, `shard`, singleflight-backed `Get`, and eviction helpers
+   - implement `TableCacheEntry`, `shard`, singleflight-backed `Get`, and eviction helpers
    - expose `Stats`, `Delete`, and graceful `Close`
 
 2. Wire the cache into `ssTableManager`.

--- a/docs/dev/168/tablecache_sample.go
+++ b/docs/dev/168/tablecache_sample.go
@@ -68,8 +68,8 @@ type FDLimiter interface {
 	Release()
 }
 
-// Handle wraps a live SStable + refcount + size accounting.
-type Handle struct {
+// TableCacheEntry wraps a live SStable + refcount + size accounting.
+type TableCacheEntry struct {
 	Table *SStable
 
 	refs          atomic.Int32 // pin/unpin (must be >0 when returned by Get/TryGet)
@@ -84,11 +84,11 @@ type Handle struct {
 }
 
 // Pin increments the refcount.
-func (h *Handle) Pin() { h.refs.Add(1) }
+func (h *TableCacheEntry) Pin() { h.refs.Add(1) }
 
 // Unref drops a refcount; if it hits zero AND eviction/obsolete was requested,
 // the underlying table is finally closed.
-func (h *Handle) Unref() {
+func (h *TableCacheEntry) Unref() {
 	if h.refs.Add(-1) == 0 && h.evictWhenZero.Load() {
 		if h.closed.CompareAndSwap(false, true) {
 			_ = h.closer(h.Table)
@@ -111,7 +111,7 @@ const (
 
 type entry struct {
 	key    tableKey
-	h      *Handle
+	h      *TableCacheEntry
 	seg    segment
 	elem   *list.Element // element in prob/prot list
 	pinned bool          // pin top-N / critical tables
@@ -202,7 +202,7 @@ func (c *TableCache) shardFor(k tableKey) *shard {
 
 // TryGet returns a pinned handle if present without doing any I/O.
 // ok=false if not resident or tombstoned/quarantined.
-func (c *TableCache) TryGet(ctx context.Context, k tableKey) (h *Handle, ok bool) {
+func (c *TableCache) TryGet(ctx context.Context, k tableKey) (h *TableCacheEntry, ok bool) {
 	s := c.shardFor(k)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -239,7 +239,7 @@ func (c *TableCache) TryRef(ctx context.Context, k tableKey) bool {
 // Get returns a pinned handle; caller MUST Unref() when done.
 // On miss it opens exactly once per key (singleflight), then installs into SLRU.
 // ctx is used for Open() and for optional FDLimiter acquisition.
-func (c *TableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
+func (c *TableCache) Get(ctx context.Context, k tableKey) (*TableCacheEntry, error) {
 	s := c.shardFor(k)
 
 	// admission stopped?
@@ -302,7 +302,7 @@ func (c *TableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 				actual = 1
 			}
 		}
-		h := &Handle{
+		h := &TableCacheEntry{
 			Table:        t,
 			logicalBytes: logical,
 			actualBytes:  actual,
@@ -324,7 +324,7 @@ func (c *TableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 		}
 		return nil, err
 	}
-	h := v.(*Handle)
+	h := v.(*TableCacheEntry)
 
 	// Install (idempotent in case someone else won the race).
 	s.mu.Lock()
@@ -379,7 +379,7 @@ func (c *TableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 // Actual close happens immediately only if refcount hits zero.
 func (c *TableCache) Delete(k tableKey) {
 	s := c.shardFor(k)
-	var toClose *Handle
+	var toClose *TableCacheEntry
 
 	s.mu.Lock()
 	// Set tombstone first to block racing admissions
@@ -434,7 +434,7 @@ func (c *TableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 	// fast unlink all entries (non-blocking I/O outside locks)
 	type hpair struct {
 		s *shard
-		h *Handle
+		h *TableCacheEntry
 	}
 	var toClose []hpair
 
@@ -585,7 +585,7 @@ func (s *shard) evictOrDemoteLocked() {
 	}
 
 	// Then evict until within total cap.
-	var toClose []*Handle
+	var toClose []*TableCacheEntry
 	for s.usedBytes > s.capBytes {
 		v := s.chooseVictim()
 		if v == nil {
@@ -627,7 +627,7 @@ func (s *shard) evictOrDemoteLocked() {
 	}
 }
 
-func (s *shard) closeNow(h *Handle) {
+func (s *shard) closeNow(h *TableCacheEntry) {
 	if h.closed.CompareAndSwap(false, true) {
 		_ = h.closer(h.Table)
 		s.closes.Add(1)

--- a/rindb.go
+++ b/rindb.go
@@ -264,11 +264,11 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 
 	iterators := []Iterator[Record]{r.Memtable.IRange(start, end, maxSeq)}
 
-	ssts, err := r.SSTableManager.GetRelevantSSTables(ctx, start, end)
+	entries, err := r.SSTableManager.GetRelevantSSTables(ctx, start, end)
 	if err != nil {
 		return nil, err
 	}
-	opened := ssts
+	opened := entries
 
 	cleanupOpened := func() {
 		for _, o := range opened {
@@ -276,8 +276,8 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 		}
 	}
 
-	for _, hnd := range ssts {
-		rangeIter, err := hnd.Table.IRange(start, end, maxSeq)
+	for _, entry := range entries {
+		rangeIter, err := entry.Table.IRange(start, end, maxSeq)
 		if err != nil {
 			cleanupOpened()
 			return nil, err

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -479,22 +479,22 @@ func (h *ssTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []f
 		return nil
 	}
 
-	handles := make([]*Handle, 0, len(inputs))
+	entries := make([]*TableCacheEntry, 0, len(inputs))
 	defer func() {
-		// release handles to input SSTables
-		for _, hnd := range handles {
-			hnd.Release()
+		// release entries to input SSTables
+		for _, entry := range entries {
+			entry.Release()
 		}
 	}()
 
 	sources := make([]SStable, 0, len(inputs))
 	for _, fm := range inputs {
-		hnd, err := h.openByNumber(ctx, fm.Number)
+		entry, err := h.openByNumber(ctx, fm.Number)
 		if err != nil {
 			return err
 		}
-		handles = append(handles, hnd)
-		sources = append(sources, *hnd.Table)
+		entries = append(entries, entry)
+		sources = append(sources, *entry.Table)
 	}
 
 	newFS, err := h.newSSTableFS(ctx)
@@ -564,9 +564,9 @@ func (h *ssTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []f
 	return nil
 }
 
-// openByNumber returns a pinned handle for the given SSTable number using the
-// table cache. Callers must invoke `Unref` on the returned handle when done.
-func (h *ssTableManager) openByNumber(ctx context.Context, num uint64) (*Handle, error) {
+// openByNumber returns a pinned TableCacheEntry for the given SSTable number using the
+// table cache. Callers must invoke `Unref` on the returned entry when done.
+func (h *ssTableManager) openByNumber(ctx context.Context, num uint64) (*TableCacheEntry, error) {
 	return h.cache.Get(ctx, tableKey{FileNum: num})
 }
 
@@ -575,9 +575,9 @@ func (h *ssTableManager) openByNumber(ctx context.Context, num uint64) (*Handle,
 // returned so registration can proceed.
 func (h *ssTableManager) cacheAndPinSSTable(ctx context.Context, fileNum uint64) {
 	k := tableKey{FileNum: fileNum}
-	if hnd, err := h.cache.Get(ctx, k); err == nil {
+	if entry, err := h.cache.Get(ctx, k); err == nil {
 		h.cache.PinKey(k)
-		hnd.Unref()
+		entry.Unref()
 	} else {
 		warn(ctx, "Failed to cache new SSTable %d: %v", fileNum, err)
 	}
@@ -588,7 +588,7 @@ func (h *ssTableManager) cacheAndPinSSTable(ctx context.Context, fileNum uint64)
 // their existing ordering. If an SSTable referenced in the current version is
 // missing on disk, the function returns the error so callers can retry with a
 // fresh view.
-func (h *ssTableManager) GetRelevantSSTables(ctx context.Context, startKey, endKey Bytes) ([]*Handle, error) {
+func (h *ssTableManager) GetRelevantSSTables(ctx context.Context, startKey, endKey Bytes) ([]*TableCacheEntry, error) {
 	ctx, span := sstableMgmtTracer.Start(ctx, "ssTableManager.GetRelevantSSTables")
 	start := time.Now()
 	defer func() {
@@ -642,11 +642,11 @@ func (h *ssTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 	}
 	h.mu.RUnlock()
 
-	out := make([]*Handle, 0, len(nums))
+	entries := make([]*TableCacheEntry, 0, len(nums))
 	for _, num := range nums {
-		hnd, err := h.openByNumber(ctx, num)
+		entry, err := h.openByNumber(ctx, num)
 		if err != nil {
-			for _, o := range out {
+			for _, o := range entries {
 				o.Release()
 			}
 			if errors.Is(err, os.ErrNotExist) || errors.Is(err, ErrObsolete) || errors.Is(err, ErrCorruption) {
@@ -655,10 +655,10 @@ func (h *ssTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 			warn(ctx, "Failed to open SSTable %d: %v", num, err)
 			return nil, fmt.Errorf("failed to open SSTable %d: %w", num, err)
 		}
-		out = append(out, hnd)
+		entries = append(entries, entry)
 	}
-	getRelevantSSTables.Add(ctx, int64(len(out)))
-	return out, nil
+	getRelevantSSTables.Add(ctx, int64(len(entries)))
+	return entries, nil
 }
 
 func (h *ssTableManager) SearchKey(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
@@ -679,9 +679,9 @@ func (h *ssTableManager) SearchKey(ctx context.Context, key Bytes, seq ...uint64
 			}
 			return nil, err
 		}
-		for _, hnd := range ssts {
-			val, err := hnd.Table.GetValue(ctx, key, maxSeq)
-			hnd.Unref()
+		for _, entry := range ssts {
+			val, err := entry.Table.GetValue(ctx, key, maxSeq)
+			entry.Unref()
 			if err == nil {
 				return val, nil
 			}

--- a/tablecache.go
+++ b/tablecache.go
@@ -69,8 +69,8 @@ type noopFDLimiter struct{}
 func (noopFDLimiter) Acquire(context.Context) error { return nil }
 func (noopFDLimiter) Release()                      {}
 
-// Handle wraps a live SStable + refcount + size accounting.
-type Handle struct {
+// TableCacheEntry wraps a live SStable along with refcount and size accounting.
+type TableCacheEntry struct {
 	Table *SStable
 
 	refs          atomic.Int32 // pin/unpin (must be >0 when returned by Get/TryGet)
@@ -85,26 +85,26 @@ type Handle struct {
 }
 
 // Pin increments the refcount.
-func (h *Handle) Pin() { h.refs.Add(1) }
+func (e *TableCacheEntry) Pin() { e.refs.Add(1) }
 
 // Unref drops a refcount; if it hits zero AND eviction/obsolete was requested,
 // the underlying table is finally closed.
-func (h *Handle) Unref() {
-	if h.refs.Add(-1) == 0 && h.evictWhenZero.Load() {
-		if h.closed.CompareAndSwap(false, true) {
-			_ = h.closer(h.Table)
-			if h.onClose != nil {
-				h.onClose()
+func (e *TableCacheEntry) Unref() {
+	if e.refs.Add(-1) == 0 && e.evictWhenZero.Load() {
+		if e.closed.CompareAndSwap(false, true) {
+			_ = e.closer(e.Table)
+			if e.onClose != nil {
+				e.onClose()
 			}
 		}
 	}
 }
 
-// Release marks the handle for closure and drops a refcount. The underlying
+// Release marks the entry for closure and drops a refcount. The underlying
 // resources are released when the reference count reaches zero.
-func (h *Handle) Release() {
-	h.evictWhenZero.Store(true)
-	h.Unref()
+func (e *TableCacheEntry) Release() {
+	e.evictWhenZero.Store(true)
+	e.Unref()
 }
 
 // --- SLRU internals ---
@@ -157,9 +157,9 @@ func (c *tableCache) shardFor(k tableKey) *shard {
 	return c.shards[h&c.shardMask]
 }
 
-// TryGet returns a pinned handle if present without doing any I/O.
+// TryGet returns a pinned TableCacheEntry if present without doing any I/O.
 // ok=false if not resident or tombstoned/quarantined.
-func (c *tableCache) TryGet(ctx context.Context, k tableKey) (h *Handle, ok bool) {
+func (c *tableCache) TryGet(ctx context.Context, k tableKey) (entry *TableCacheEntry, ok bool) {
 	s := c.shardFor(k)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -174,17 +174,17 @@ func (c *tableCache) TryGet(ctx context.Context, k tableKey) (h *Handle, ok bool
 		delete(s.corrupt, k)
 	}
 	if e, ok := s.items[k]; ok {
-		if e.h.closed.Load() {
+		if e.entry.closed.Load() {
 			s.unlink(e)
 			delete(s.items, k)
-			s.usedBytes -= e.h.actualBytes
-			c.totalBytes.Add(-e.h.actualBytes)
+			s.usedBytes -= e.entry.actualBytes
+			c.totalBytes.Add(-e.entry.actualBytes)
 		} else {
-			e.h.Pin()
+			e.entry.Pin()
 			s.promoteOnHit(ctx, e)
 			s.hits.Add(1)
 			cacheHits.Add(ctx, 1)
-			return e.h, true
+			return e.entry, true
 		}
 	}
 	return nil, false
@@ -194,17 +194,17 @@ func (c *tableCache) TryGet(ctx context.Context, k tableKey) (h *Handle, ok bool
 // It briefly pins the handle to promote the entry and immediately unrefs it,
 // so no reference is retained on success.
 func (c *tableCache) TryRef(ctx context.Context, k tableKey) bool {
-	h, ok := c.TryGet(ctx, k)
+	entry, ok := c.TryGet(ctx, k)
 	if ok {
-		h.Unref()
+		entry.Unref()
 	}
 	return ok
 }
 
-// Get returns a pinned handle; caller MUST Unref() when done.
+// Get returns a pinned TableCacheEntry; caller MUST Unref() when done.
 // On miss it opens exactly once per key (singleflight), then installs into SLRU.
 // ctx is used for Open() and for optional FDLimiter acquisition.
-func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
+func (c *tableCache) Get(ctx context.Context, k tableKey) (*TableCacheEntry, error) {
 	s := c.shardFor(k)
 
 	// admission stopped?
@@ -229,18 +229,18 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 		delete(s.corrupt, k)
 	}
 	if e, ok := s.items[k]; ok {
-		if e.h.closed.Load() {
+		if e.entry.closed.Load() {
 			s.unlink(e)
 			delete(s.items, k)
-			s.usedBytes -= e.h.actualBytes
-			c.totalBytes.Add(-e.h.actualBytes)
+			s.usedBytes -= e.entry.actualBytes
+			c.totalBytes.Add(-e.entry.actualBytes)
 		} else {
-			e.h.Pin()
+			e.entry.Pin()
 			s.promoteOnHit(ctx, e)
 			s.hits.Add(1)
 			cacheHits.Add(ctx, 1)
 			s.mu.Unlock()
-			return e.h, nil
+			return e.entry, nil
 		}
 	}
 	s.mu.Unlock()
@@ -278,14 +278,14 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 				actual = 1
 			}
 		}
-		h := &Handle{
+		entry := &TableCacheEntry{
 			Table:        t,
 			logicalBytes: logical,
 			actualBytes:  actual,
 			closer:       c.opt.Close,
 		}
-		h.refs.Store(1) // caller's ref
-		return h, nil
+		entry.refs.Store(1) // caller's ref
+		return entry, nil
 	})
 	if err != nil {
 		// quarantine on corruption
@@ -300,15 +300,15 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 		}
 		return nil, err
 	}
-	h := v.(*Handle)
+	ce := v.(*TableCacheEntry)
 
 	// Install (idempotent in case someone else won the race).
 	s.mu.Lock()
 	// Recheck admission stop or tombstone (race with Delete/Close):
 	if s.stopAdmission.Load() {
 		s.mu.Unlock()
-		if h.closed.CompareAndSwap(false, true) {
-			_ = c.opt.Close(h.Table)
+		if ce.closed.CompareAndSwap(false, true) {
+			_ = c.opt.Close(ce.Table)
 			s.closes.Add(1)
 			cacheCloses.Add(ctx, 1)
 		}
@@ -316,8 +316,8 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 	}
 	if s.isTombstoned(k) {
 		s.mu.Unlock()
-		if h.closed.CompareAndSwap(false, true) {
-			_ = c.opt.Close(h.Table)
+		if ce.closed.CompareAndSwap(false, true) {
+			_ = c.opt.Close(ce.Table)
 			s.closes.Add(1)
 			cacheCloses.Add(ctx, 1)
 		}
@@ -325,42 +325,42 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 	}
 	if existing, ok := s.items[k]; ok {
 		// Another goroutine installed first. Use it.
-		existing.h.Pin()
+		existing.entry.Pin()
 		s.promoteOnHit(ctx, existing)
 		s.hits.Add(1)
 		cacheHits.Add(ctx, 1)
 		s.mu.Unlock()
 		// Close duplicate we just opened.
-		if h != existing.h && h.closed.CompareAndSwap(false, true) {
-			_ = c.opt.Close(h.Table)
+		if ce != existing.entry && ce.closed.CompareAndSwap(false, true) {
+			_ = c.opt.Close(ce.Table)
 			s.closes.Add(1)
 			cacheCloses.Add(ctx, 1)
 		}
-		return existing.h, nil
+		return existing.entry, nil
 	}
 
-	e := &entry{key: k, h: h, seg: segProbation}
-	// hook: when handle closes via Unref path, count closes
-	h.onClose = func() {
+	e := &entry{key: k, entry: ce, seg: segProbation}
+	// hook: when entry closes via Unref path, count closes
+	ce.onClose = func() {
 		s.closes.Add(1)
 		cacheCloses.Add(ctx, 1)
 	}
 
 	e.elem = s.prob.PushFront(e)
 	s.items[k] = e
-	s.usedBytes += h.actualBytes
-	s.probBytes += h.actualBytes
-	c.totalBytes.Add(h.actualBytes)
+	s.usedBytes += ce.actualBytes
+	s.probBytes += ce.actualBytes
+	c.totalBytes.Add(ce.actualBytes)
 	s.misses.Add(1)
 	cacheMisses.Add(ctx, 1)
 
 	// Evict/demote to budget (may close victims outside the lock).
 	if !s.evictOrDemoteLocked(ctx, e) {
-		// Entry was dropped due to full pinned cache; the handle remains valid
+		// Entry was dropped due to full pinned cache; the table remains valid
 		// but won't be reachable through the cache and will close on Unref().
 	}
 	s.mu.Unlock()
-	return h, nil
+	return ce, nil
 }
 
 // Delete marks a key obsolete and unlinks it from the cache immediately.
@@ -368,7 +368,7 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*Handle, error) {
 // only if the refcount hits zero.
 func (c *tableCache) Delete(ctx context.Context, k tableKey) {
 	s := c.shardFor(k)
-	var toClose *Handle
+	var toClose *TableCacheEntry
 
 	s.mu.Lock()
 	// Set tombstone first to block racing admissions
@@ -378,13 +378,13 @@ func (c *tableCache) Delete(ctx context.Context, k tableKey) {
 	}
 	s.tombstone[k] = time.Now().Add(ttl)
 	if e, ok := s.items[k]; ok {
-		e.h.evictWhenZero.Store(true)
+		e.entry.evictWhenZero.Store(true)
 		s.unlink(e) // remove from SLRU
 		delete(s.items, k)
-		s.usedBytes -= e.h.actualBytes
-		c.totalBytes.Add(-e.h.actualBytes)
-		if e.h.refs.Load() == 0 {
-			toClose = e.h
+		s.usedBytes -= e.entry.actualBytes
+		c.totalBytes.Add(-e.entry.actualBytes)
+		if e.entry.refs.Load() == 0 {
+			toClose = e.entry
 		}
 	}
 	s.mu.Unlock()
@@ -425,26 +425,26 @@ func (c *tableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 	}
 
 	// fast unlink all entries (non-blocking I/O outside locks)
-	type hpair struct {
-		s *shard
-		h *Handle
+	type entryPair struct {
+		s     *shard
+		entry *TableCacheEntry
 	}
-	var toClose []hpair
-	var busy []*Handle
+	var toClose []entryPair
+	var busy []*TableCacheEntry
 
 	for _, s := range c.shards {
 		s.mu.Lock()
 		for k, e := range s.items {
 			_ = k // keep for clarity; we drop the map entry
-			e.h.evictWhenZero.Store(true)
+			e.entry.evictWhenZero.Store(true)
 			s.unlink(e)
 			delete(s.items, k)
-			s.usedBytes -= e.h.actualBytes
-			c.totalBytes.Add(-e.h.actualBytes)
-			if e.h.refs.Load() == 0 {
-				toClose = append(toClose, hpair{s: s, h: e.h})
+			s.usedBytes -= e.entry.actualBytes
+			c.totalBytes.Add(-e.entry.actualBytes)
+			if e.entry.refs.Load() == 0 {
+				toClose = append(toClose, entryPair{s: s, entry: e.entry})
 			} else {
-				busy = append(busy, e.h)
+				busy = append(busy, e.entry)
 			}
 		}
 		s.mu.Unlock()
@@ -452,7 +452,7 @@ func (c *tableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 
 	// close the cold ones immediately
 	for _, p := range toClose {
-		p.s.closeNow(ctx, p.h)
+		p.s.closeNow(ctx, p.entry)
 	}
 
 	// bounded wait for busy ones to drain
@@ -462,9 +462,9 @@ func (c *tableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 
 	var wg sync.WaitGroup
 	wg.Add(len(busy))
-	for _, h := range busy {
-		orig := h.onClose
-		h.onClose = func() {
+	for _, entry := range busy {
+		orig := entry.onClose
+		entry.onClose = func() {
 			if orig != nil {
 				orig()
 			}
@@ -485,13 +485,13 @@ func (c *tableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 		return ctx.Err()
 	case <-time.After(drainTimeout):
 		remaining := 0
-		for _, h := range busy {
-			if h.refs.Load() > 0 {
+		for _, entry := range busy {
+			if entry.refs.Load() > 0 {
 				remaining++
 			}
 		}
 		if remaining > 0 {
-			return fmt.Errorf("%d handles still busy after timeout", remaining)
+			return fmt.Errorf("%d entries still busy after timeout", remaining)
 		}
 		return nil
 	}

--- a/tablecache_slru.go
+++ b/tablecache_slru.go
@@ -20,7 +20,7 @@ const (
 
 type entry struct {
 	key    tableKey
-	h      *Handle
+	entry  *TableCacheEntry
 	seg    segment
 	elem   *list.Element // element in prob/prot list
 	pinned bool          // pin top-N / critical tables
@@ -86,10 +86,10 @@ func (s *shard) promoteOnHit(ctx context.Context, e *entry) {
 		if e.elem != nil {
 			s.prob.Remove(e.elem)
 		}
-		s.probBytes -= e.h.actualBytes
+		s.probBytes -= e.entry.actualBytes
 		e.elem = s.prot.PushFront(e)
 		e.seg = segProtected
-		s.protBytes += e.h.actualBytes
+		s.protBytes += e.entry.actualBytes
 		s.promotions.Add(1)
 		cachePromotions.Add(ctx, 1)
 
@@ -100,10 +100,10 @@ func (s *shard) promoteOnHit(ctx context.Context, e *entry) {
 				if dem.elem != nil {
 					s.prot.Remove(dem.elem)
 				}
-				s.protBytes -= dem.h.actualBytes
+				s.protBytes -= dem.entry.actualBytes
 				dem.elem = s.prob.PushFront(dem)
 				dem.seg = segProbation
-				s.probBytes += dem.h.actualBytes
+				s.probBytes += dem.entry.actualBytes
 			} else {
 				break
 			}
@@ -122,12 +122,12 @@ func (s *shard) unlink(e *entry) {
 		if e.elem != nil {
 			s.prob.Remove(e.elem)
 		}
-		s.probBytes -= e.h.actualBytes
+		s.probBytes -= e.entry.actualBytes
 	case segProtected:
 		if e.elem != nil {
 			s.prot.Remove(e.elem)
 		}
-		s.protBytes -= e.h.actualBytes
+		s.protBytes -= e.entry.actualBytes
 	}
 	e.elem = nil
 	e.seg = segNone
@@ -160,16 +160,16 @@ func (s *shard) segmentBytes(seg segment) int64 {
 	}
 }
 
-func (s *shard) evictEntryLocked(ctx context.Context, e *entry, toClose *[]*Handle) {
+func (s *shard) evictEntryLocked(ctx context.Context, e *entry, toClose *[]*TableCacheEntry) {
 	s.unlink(e)
 	delete(s.items, e.key)
-	s.usedBytes -= e.h.actualBytes
-	s.parent.totalBytes.Add(-e.h.actualBytes)
+	s.usedBytes -= e.entry.actualBytes
+	s.parent.totalBytes.Add(-e.entry.actualBytes)
 
-	if e.h.refs.Load() > 0 {
-		e.h.evictWhenZero.Store(true)
+	if e.entry.refs.Load() > 0 {
+		e.entry.evictWhenZero.Store(true)
 	} else {
-		*toClose = append(*toClose, e.h)
+		*toClose = append(*toClose, e.entry)
 	}
 	s.evicts.Add(1)
 	cacheEvicts.Add(ctx, 1)
@@ -188,17 +188,17 @@ func (s *shard) evictOrDemoteLocked(ctx context.Context, recent *entry) bool {
 			if dem.elem != nil {
 				s.prot.Remove(dem.elem)
 			}
-			s.protBytes -= dem.h.actualBytes
+			s.protBytes -= dem.entry.actualBytes
 			dem.elem = s.prob.PushFront(dem)
 			dem.seg = segProbation
-			s.probBytes += dem.h.actualBytes
+			s.probBytes += dem.entry.actualBytes
 		} else {
 			break
 		}
 	}
 
 	// Then evict until within total cap.
-	var toClose []*Handle
+	var toClose []*TableCacheEntry
 	for s.usedBytes > s.capBytes {
 		v := s.chooseVictim()
 		if v == nil {
@@ -214,8 +214,8 @@ func (s *shard) evictOrDemoteLocked(ctx context.Context, recent *entry) bool {
 
 	if len(toClose) > 0 {
 		s.mu.Unlock()
-		for _, h := range toClose {
-			s.closeNow(ctx, h)
+		for _, entry := range toClose {
+			s.closeNow(ctx, entry)
 		}
 		s.mu.Lock()
 	}
@@ -226,9 +226,9 @@ func (s *shard) evictOrDemoteLocked(ctx context.Context, recent *entry) bool {
 	return true
 }
 
-func (s *shard) closeNow(ctx context.Context, h *Handle) {
-	if h.closed.CompareAndSwap(false, true) {
-		_ = h.closer(h.Table)
+func (s *shard) closeNow(ctx context.Context, entry *TableCacheEntry) {
+	if entry.closed.CompareAndSwap(false, true) {
+		_ = entry.closer(entry.Table)
 		s.closes.Add(1)
 		cacheCloses.Add(ctx, 1)
 	}

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -115,7 +115,7 @@ func TestTableCacheCorruptionQuarantine(t *testing.T) {
 	require.EqualValues(t, 1, opens.Load(), "should not reopen during quarantine")
 }
 
-func TestTableCacheCloseDrainsBusyHandles(t *testing.T) {
+func TestTableCacheCloseDrainsBusyEntries(t *testing.T) {
 	ctx := context.Background()
 	cache := newTestCache(t, tableCacheOptions{CapBytes: 2})
 
@@ -291,11 +291,11 @@ func TestTableCacheClose(t *testing.T) {
 
 		err = cache.Close(ctx, 10*time.Millisecond)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "handles still busy")
-		require.EqualValues(t, 0, closes.Load(), "handle should remain open on timeout")
+		require.Contains(t, err.Error(), "entries still busy")
+		require.EqualValues(t, 0, closes.Load(), "entry should remain open on timeout")
 
 		h.Unref()
-		require.EqualValues(t, 1, closes.Load(), "handle should close after late Unref")
+		require.EqualValues(t, 1, closes.Load(), "entry should close after late Unref")
 	})
 }
 


### PR DESCRIPTION
## Summary
- rename Handle to TableCacheEntry across the codebase
- update sstable manager, caching logic, and documentation to use new name
- adjust tests and messages for entry terminology

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bcc9a9a6588325bd2bebd592d7dd8c