### PR TITLE
refactor: mergeSSTablesV2 accepts table cache entries

### DIFF
--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -487,14 +487,12 @@ func (h *ssTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []f
 		}
 	}()
 
-	sources := make([]SStable, 0, len(inputs))
 	for _, fm := range inputs {
 		entry, err := h.openByNumber(ctx, fm.Number)
 		if err != nil {
 			return err
 		}
 		entries = append(entries, entry)
-		sources = append(sources, *entry.Table)
 	}
 
 	newFS, err := h.newSSTableFS(ctx)
@@ -512,7 +510,7 @@ func (h *ssTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []f
 		}
 	}
 
-	merged, meta, err := mergeSSTablesV2(ctx, h.config, newFS, sources, bottom, h.minSnapshotSeq)
+	merged, meta, err := mergeSSTablesV2(ctx, h.config, newFS, entries, bottom, h.minSnapshotSeq)
 	if err != nil || merged == nil {
 		_ = newFS.Close()
 		if rmErr := os.Remove(newFS.Path()); rmErr != nil && err == nil {
@@ -697,14 +695,14 @@ func (h *ssTableManager) SearchKey(ctx context.Context, key Bytes, seq ...uint64
 	return nil, ErrKeyNotFound
 }
 
-func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sources []SStable, bottommost bool, minSeq uint64) (_ *SStable, meta fileMeta, err error) {
+func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sources []*TableCacheEntry, bottommost bool, minSeq uint64) (_ *SStable, meta fileMeta, err error) {
 	if len(sources) == 0 {
 		return nil, fileMeta{}, nil
 	}
 
 	iterators := make([]Iterator[Record], 0, len(sources))
-	for _, sstable := range sources {
-		iter, err := sstable.Iterator()
+	for _, entry := range sources {
+		iter, err := entry.Table.Iterator()
 		if err != nil {
 			return nil, fileMeta{}, err
 		}
@@ -722,8 +720,8 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 	}()
 
 	expected := 0
-	for _, sstable := range sources {
-		expected += len(sstable.SparseIndex)
+	for _, entry := range sources {
+		expected += len(entry.Table.SparseIndex)
 	}
 
 	builder, err := NewSSTableBuilder(ctx, config, target, expected)

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -927,7 +927,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		ts.AddSSTable(0, &sst2)
 
 		target := ts.newSSTableFS()
-		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2}, false, math.MaxUint64)
+		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []*TableCacheEntry{{Table: &sst1}, {Table: &sst2}}, false, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.NotNil(t, merged)
 
@@ -966,7 +966,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS()
-		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2}, true, math.MaxUint64)
+		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []*TableCacheEntry{{Table: &sst1}, {Table: &sst2}}, true, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.NotNil(t, merged)
 
@@ -1008,7 +1008,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS()
-		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2, sst3}, true, 2)
+		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []*TableCacheEntry{{Table: &sst1}, {Table: &sst2}, {Table: &sst3}}, true, 2)
 		assert.NoError(t, err)
 		assert.NotNil(t, merged)
 
@@ -1052,7 +1052,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS()
-		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst1, sst2, sst3}, false, math.MaxUint64)
+		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []*TableCacheEntry{{Table: &sst1}, {Table: &sst2}, {Table: &sst3}}, false, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.NotNil(t, merged)
 
@@ -1061,7 +1061,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.Nil(t, v)
 
 		target2 := ts.newSSTableFS()
-		merged2, _, err := mergeSSTablesV2(ctx, *ts.Config, target2, []SStable{sst1, sst2, sst3}, true, math.MaxUint64)
+		merged2, _, err := mergeSSTablesV2(ctx, *ts.Config, target2, []*TableCacheEntry{{Table: &sst1}, {Table: &sst2}, {Table: &sst3}}, true, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.Nil(t, merged2)
 	})
@@ -1072,7 +1072,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		defer ts.Cleanup()
 
 		target := ts.newSSTableFS()
-		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{}, false, math.MaxUint64)
+		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []*TableCacheEntry{}, false, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.Nil(t, merged)
 	})
@@ -1088,7 +1088,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		assert.NoError(t, err)
 
 		target := ts.newSSTableFS()
-		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []SStable{sst}, true, math.MaxUint64)
+		merged, _, err := mergeSSTablesV2(ctx, *ts.Config, target, []*TableCacheEntry{{Table: &sst}}, true, math.MaxUint64)
 		assert.NoError(t, err)
 		assert.Nil(t, merged)
 	})
@@ -1106,7 +1106,7 @@ func Test_mergeSSTablesV2(t *testing.T) {
 		target := ts.newSSTableFS()
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		cancel()
-		merged, _, err := mergeSSTablesV2(cancelCtx, *ts.Config, target, []SStable{sst}, false, math.MaxUint64)
+		merged, _, err := mergeSSTablesV2(cancelCtx, *ts.Config, target, []*TableCacheEntry{{Table: &sst}}, false, math.MaxUint64)
 		assert.ErrorIs(t, err, context.Canceled)
 		assert.Nil(t, merged)
 	})


### PR DESCRIPTION
## Summary
- refactor mergeSSTablesV2 to take table cache entries instead of raw SSTables
- update compaction to pass cache entries directly
- adjust tests for new mergeSSTablesV2 signature

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bcdc171190832581f687df2ee6b137