### PR TITLE
fix: unref table cache entries instead of releasing

### DIFF
--- a/range_test.go
+++ b/range_test.go
@@ -105,8 +105,11 @@ func TestIRangeCloseReleasesSSTables(t *testing.T) {
 	assert.Equal(t, int32(1), h.refs.Load())
 	assert.NoError(t, iter.Close())
 	assert.Equal(t, int32(0), h.refs.Load())
-	_, ok = ts.Manager.cache.TryGet(ctx, tableKey{FileNum: num})
-	require.False(t, ok)
+	h, ok = ts.Manager.cache.TryGet(ctx, tableKey{FileNum: num})
+	require.True(t, ok)
+	assert.Equal(t, int32(1), h.refs.Load())
+	h.Unref()
+	assert.Equal(t, int32(0), h.refs.Load())
 }
 
 func TestRangeIteratorPrepare(t *testing.T) {

--- a/rindb.go
+++ b/rindb.go
@@ -272,7 +272,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 
 	cleanupOpened := func() {
 		for _, o := range opened {
-			o.Release()
+			o.Unref()
 		}
 	}
 

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -113,7 +113,7 @@ func TestTombstoneRemovedAfterSnapshotRelease(t *testing.T) {
 			return false
 		}
 		for _, h := range ssts {
-			h.Release()
+			h.Unref()
 		}
 		return len(ssts) == 0
 	}, 5*time.Second, 100*time.Millisecond)

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -584,10 +584,12 @@ func (h *ssTableManager) cacheAndPinSSTable(ctx context.Context, fileNum uint64)
 }
 
 // GetRelevantSSTables gathers SSTables whose ranges overlap [startKey, endKey].
-// Level 0 files are returned in newest-first order while higher levels retain
-// their existing ordering. If an SSTable referenced in the current version is
-// missing on disk, the function returns the error so callers can retry with a
-// fresh view.
+// Each returned TableCacheEntry is pinned in the cache; callers MUST invoke
+// Unref on every entry when finished. Use Release only when the SSTable is
+// obsolete and should be evicted once all references drain. Level 0 files are
+// returned in newest-first order while higher levels retain their existing
+// ordering. If an SSTable referenced in the current version is missing on disk,
+// the function returns the error so callers can retry with a fresh view.
 func (h *ssTableManager) GetRelevantSSTables(ctx context.Context, startKey, endKey Bytes) ([]*TableCacheEntry, error) {
 	ctx, span := sstableMgmtTracer.Start(ctx, "ssTableManager.GetRelevantSSTables")
 	start := time.Now()
@@ -647,7 +649,7 @@ func (h *ssTableManager) GetRelevantSSTables(ctx context.Context, startKey, endK
 		entry, err := h.openByNumber(ctx, num)
 		if err != nil {
 			for _, o := range entries {
-				o.Release()
+				o.Unref()
 			}
 			if errors.Is(err, os.ErrNotExist) || errors.Is(err, ErrObsolete) || errors.Is(err, ErrCorruption) {
 				return nil, err

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -601,7 +601,7 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		for i, h := range ssts {
 			nums[i], err = fileNum(h.Table.Path())
 			require.NoError(t, err)
-			h.Release()
+			h.Unref()
 		}
 		assert.Equal(t, []uint64{nNewer, nOlder}, nums)
 	})
@@ -627,7 +627,7 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		for i, h := range ssts {
 			nums[i], err = fileNum(h.Table.Path())
 			require.NoError(t, err)
-			h.Release()
+			h.Unref()
 		}
 		assert.Equal(t, []uint64{nOlder, nNewer}, nums)
 	})
@@ -689,7 +689,7 @@ func TestSSTableManager_GetRelevantSSTables(t *testing.T) {
 		for i, h := range ssts {
 			nums[i], err = fileNum(h.Table.Path())
 			require.NoError(t, err)
-			h.Release()
+			h.Unref()
 		}
 		assert.Equal(t, []uint64{nL0b, nL0a, nL1}, nums)
 	})


### PR DESCRIPTION
## Summary
- keep cached SSTables alive by unrefing instead of releasing
- document GetRelevantSSTables unref requirement and update tests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bcdf249f708325ab958be3ccc936ce