### PR TITLE
chore: exclude cmd from coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GOTOOLCHAIN ?= go1.25.0
 GO = go
 UNAME_S := $(shell uname -s)
-PKGS := $(shell $(GO) list ./... | grep -v '/cmd$$')
+PKGS := $(shell $(GO) list ./... | grep -v -e '/cmd$$' -e '/cmd/')
 
 check:
 	@$(MAKE) check-spanname

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export GOTOOLCHAIN ?= go1.25.0
 GO = go
 UNAME_S := $(shell uname -s)
+PKGS := $(shell $(GO) list ./... | grep -v '/cmd$$')
 
 check:
 	@$(MAKE) check-spanname
@@ -34,7 +35,7 @@ test-integration: test-integration-full
 
 test-coverage: clean-testdata
 	@echo "Running tests with coverage..."
-	@$(GO) test -v -coverprofile=coverage.txt ./...
+	@$(GO) test -v -coverprofile=coverage.txt $(PKGS)
 
 test-pprof:
 	@./scripts/run-pprof-tests.sh


### PR DESCRIPTION
## Summary
- exclude the `cmd` package from coverage measurements

## Testing
- `make check | tail -n 20`
- `make test | tail -n 20`
- `make test-integration-smoke | tail -n 20`
- `make test-coverage | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bcf0cb1b0c8325b47efd4b746a5321