### PR TITLE
fix: make table cache respect context cancellation

### DIFF
--- a/tablecache.go
+++ b/tablecache.go
@@ -245,9 +245,14 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*TableCacheEntry, err
 	}
 	s.mu.Unlock()
 
+	// quick ctx check before starting the flight
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Miss: singleflight open (no locks while doing I/O).
 	keyStr := fmt.Sprintf("%d/%d", k.DBID, k.FileNum)
-	v, err, _ := s.flight.Do(keyStr, func() (any, error) {
+	ch := s.flight.DoChan(keyStr, func() (any, error) {
 		// FD limiter (optional)
 		if c.opt.FDLimiter != nil {
 			if err := c.opt.FDLimiter.Acquire(ctx); err != nil {
@@ -287,6 +292,17 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*TableCacheEntry, err
 		entry.refs.Store(1) // caller's ref
 		return entry, nil
 	})
+
+	var (
+		v   any
+		err error
+	)
+	select {
+	case res := <-ch:
+		v, err = res.Val, res.Err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	if err != nil {
 		// quarantine on corruption
 		if errors.Is(err, ErrCorruption) {

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -115,6 +115,58 @@ func TestTableCacheCorruptionQuarantine(t *testing.T) {
 	require.EqualValues(t, 1, opens.Load(), "should not reopen during quarantine")
 }
 
+func TestTableCacheGetCanceledWhileSingleflight(t *testing.T) {
+	ctx := context.Background()
+	openStart := make(chan struct{})
+	release := make(chan struct{})
+	var opens atomic.Int32
+	cache := newTestCache(t, tableCacheOptions{
+		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+			opens.Add(1)
+			close(openStart)
+			<-release
+			return &SStable{}, nil
+		},
+	})
+
+	key := tableKey{FileNum: 1}
+
+	// Hold the singleflight with the first call.
+	done := make(chan struct{})
+	go func() {
+		h, err := cache.Get(ctx, key)
+		if err == nil {
+			h.Unref()
+		}
+		close(done)
+	}()
+
+	<-openStart // ensure first open started and is blocking
+
+	ctx2, cancel := context.WithCancel(ctx)
+	errCh := make(chan error)
+	go func() {
+		_, err := cache.Get(ctx2, key)
+		errCh <- err
+	}()
+
+	time.Sleep(10 * time.Millisecond) // let second call join the flight
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Get did not return after context cancellation")
+	}
+
+	// Release first call and wait for it to finish.
+	close(release)
+	<-done
+
+	require.EqualValues(t, 1, opens.Load())
+}
+
 func TestTableCacheCloseDrainsBusyEntries(t *testing.T) {
 	ctx := context.Background()
 	cache := newTestCache(t, tableCacheOptions{CapBytes: 2})


### PR DESCRIPTION
## Summary
- avoid blocking cache open on canceled context
- add test for Get cancellation while singleflight is busy

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bcfdd1e32483259f3f1642699cd7f1