### PR TITLE
fix: prevent table cache Close/Unref race

### DIFF
--- a/tablecache.go
+++ b/tablecache.go
@@ -464,22 +464,19 @@ func (c *tableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 	var wg sync.WaitGroup
 	for _, entry := range busy {
 		wg.Add(1)
-		prev := entry.onClose.Load()
 		var once sync.Once
-		wrapper := func() {
-			if prev != nil {
-				(*prev)()
-			}
-			once.Do(func() { wg.Done() })
-		}
-		for !entry.onClose.CompareAndSwap(prev, &wrapper) {
-			prev = entry.onClose.Load()
-			wrapper = func() {
+		prev := entry.onClose.Load()
+		for {
+			wrapper := func() {
 				if prev != nil {
 					(*prev)()
 				}
 				once.Do(func() { wg.Done() })
 			}
+			if entry.onClose.CompareAndSwap(prev, &wrapper) {
+				break
+			}
+			prev = entry.onClose.Load()
 		}
 		if entry.closed.Load() {
 			once.Do(func() { wg.Done() })

--- a/tablecache.go
+++ b/tablecache.go
@@ -80,8 +80,8 @@ type TableCacheEntry struct {
 	logicalBytes int64
 	actualBytes  int64
 
-	closer  func(*SStable) error // injected from tableCacheOptions.Close
-	onClose func()               // shard hook (metrics)
+	closer  func(*SStable) error   // injected from tableCacheOptions.Close
+	onClose atomic.Pointer[func()] // shard hook (metrics)
 }
 
 // Pin increments the refcount.
@@ -93,8 +93,8 @@ func (e *TableCacheEntry) Unref() {
 	if e.refs.Add(-1) == 0 && e.evictWhenZero.Load() {
 		if e.closed.CompareAndSwap(false, true) {
 			_ = e.closer(e.Table)
-			if e.onClose != nil {
-				e.onClose()
+			if f := e.onClose.Load(); f != nil {
+				(*f)()
 			}
 		}
 	}
@@ -341,10 +341,11 @@ func (c *tableCache) Get(ctx context.Context, k tableKey) (*TableCacheEntry, err
 
 	e := &entry{key: k, entry: ce, seg: segProbation}
 	// hook: when entry closes via Unref path, count closes
-	ce.onClose = func() {
+	fn := func() {
 		s.closes.Add(1)
 		cacheCloses.Add(ctx, 1)
 	}
+	ce.onClose.Store(&fn)
 
 	e.elem = s.prob.PushFront(e)
 	s.items[k] = e
@@ -461,14 +462,27 @@ func (c *tableCache) Close(ctx context.Context, drainTimeout time.Duration) erro
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(len(busy))
 	for _, entry := range busy {
-		orig := entry.onClose
-		entry.onClose = func() {
-			if orig != nil {
-				orig()
+		wg.Add(1)
+		prev := entry.onClose.Load()
+		var once sync.Once
+		wrapper := func() {
+			if prev != nil {
+				(*prev)()
 			}
-			wg.Done()
+			once.Do(func() { wg.Done() })
+		}
+		for !entry.onClose.CompareAndSwap(prev, &wrapper) {
+			prev = entry.onClose.Load()
+			wrapper = func() {
+				if prev != nil {
+					(*prev)()
+				}
+				once.Do(func() { wg.Done() })
+			}
+		}
+		if entry.closed.Load() {
+			once.Do(func() { wg.Done() })
 		}
 	}
 

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -2,6 +2,8 @@ package rindb
 
 import (
 	"context"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -297,6 +299,36 @@ func TestTableCacheClose(t *testing.T) {
 		h.Unref()
 		require.EqualValues(t, 1, closes.Load(), "entry should close after late Unref")
 	})
+}
+
+func TestTableCacheCloseUnrefRace(t *testing.T) {
+	ctx := context.Background()
+	cache := newTestCache(t, tableCacheOptions{CapBytes: 1})
+
+	k := tableKey{FileNum: 1}
+	h, err := cache.Get(ctx, k)
+	require.NoError(t, err)
+
+	startG := runtime.NumGoroutine()
+	var unrefWG sync.WaitGroup
+	unrefWG.Add(1)
+	go func() {
+		defer unrefWG.Done()
+		time.Sleep(10 * time.Millisecond)
+		h.Unref()
+	}()
+
+	start := time.Now()
+	err = cache.Close(ctx, time.Second)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	require.Less(t, elapsed, time.Second)
+
+	unrefWG.Wait()
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= startG+1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestTableCacheTombstoneExpiry(t *testing.T) {


### PR DESCRIPTION
## Summary
- guard table cache close with atomic onClose swaps and per-entry checks
- add regression test covering Close vs Unref race

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bcfd7a9a288325a9b272c2db5da21f