### PR TITLE
fix: clear corrupt quarantine on delete

### DIFF
--- a/tablecache.go
+++ b/tablecache.go
@@ -377,6 +377,7 @@ func (c *tableCache) Delete(ctx context.Context, k tableKey) {
 		ttl = defaultCacheQuarantineTTL
 	}
 	s.tombstone[k] = time.Now().Add(ttl)
+	delete(s.corrupt, k)
 	if e, ok := s.items[k]; ok {
 		e.entry.evictWhenZero.Store(true)
 		s.unlink(e) // remove from SLRU

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -330,6 +330,46 @@ func TestTableCacheTombstoneExpiry(t *testing.T) {
 	require.EqualValues(t, 2, opens.Load())
 }
 
+func TestTableCacheDeleteClearsCorruptQuarantine(t *testing.T) {
+	ctx := context.Background()
+	var opens atomic.Int32
+	var verifies atomic.Int32
+	ttl := 100 * time.Millisecond
+	cache := newTestCache(t, tableCacheOptions{
+		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+			opens.Add(1)
+			return &SStable{}, nil
+		},
+		Verify: func(*SStable) error {
+			if verifies.Add(1) == 1 {
+				return ErrCorruption
+			}
+			return nil
+		},
+		CorruptTTL:   time.Hour,
+		TombstoneTTL: ttl,
+	})
+
+	k := tableKey{FileNum: 1}
+	_, err := cache.Get(ctx, k)
+	require.ErrorIs(t, err, ErrCorruption)
+	require.EqualValues(t, 1, opens.Load())
+
+	cache.Delete(ctx, k)
+
+	// Admission is blocked by tombstone.
+	_, err = cache.Get(ctx, k)
+	require.ErrorIs(t, err, ErrObsolete)
+	require.EqualValues(t, 1, opens.Load())
+
+	time.Sleep(ttl + time.Millisecond)
+
+	h, err := cache.Get(ctx, k)
+	require.NoError(t, err)
+	h.Unref()
+	require.EqualValues(t, 2, opens.Load())
+}
+
 func TestTableCacheMeasureAndByteAccounting(t *testing.T) {
 	ctx := context.Background()
 	actuals := []int64{0, 5, -7}


### PR DESCRIPTION
## Summary
- ensure table cache deletion removes corruption quarantine entries
- test that corrupted tables can be re-admitted after delete and tombstone expiry

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bcfdea36d88325b8f790ff06268137