### PR TITLE
fix: evict over-budget entries on unpin

### DIFF
--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -551,7 +551,7 @@ func (h *ssTableManager) mergeIntoLevel(ctx context.Context, dst int, inputs []f
 	h.cacheAndPinSSTable(ctx, meta.Number)
 	for _, fm := range inputs {
 		k := tableKey{FileNum: fm.Number}
-		h.cache.UnpinKey(k)
+		h.cache.UnpinKey(ctx, k)
 		h.cache.Delete(ctx, k)
 	}
 

--- a/tablecache.go
+++ b/tablecache.go
@@ -391,12 +391,13 @@ func (c *tableCache) PinKey(k tableKey) bool {
 	return false
 }
 
-// UnpinKey removes the pin flag.
-func (c *tableCache) UnpinKey(k tableKey) {
+// UnpinKey removes the pin flag and enforces the cache's capacity.
+func (c *tableCache) UnpinKey(ctx context.Context, k tableKey) {
 	s := c.shardFor(k)
 	s.mu.Lock()
 	if e, ok := s.items[k]; ok {
 		e.pinned = false
+		s.evictOrDemoteLocked(ctx, nil)
 	}
 	s.mu.Unlock()
 }

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -587,7 +587,7 @@ func TestTableCachePinnedByteAccounting(t *testing.T) {
 	_, ok := cache.TryGet(ctx, k2)
 	require.False(t, ok)
 
-	cache.UnpinKey(k1)
+	cache.UnpinKey(ctx, k1)
 	h, err = cache.Get(ctx, k2)
 	require.NoError(t, err)
 	h.Unref()
@@ -598,4 +598,38 @@ func TestTableCachePinnedByteAccounting(t *testing.T) {
 	require.False(t, ok)
 	_, ok = cache.TryGet(ctx, k2)
 	require.True(t, ok)
+}
+
+func TestTableCacheUnpinTriggersEviction(t *testing.T) {
+	ctx := context.Background()
+	cache := newTestCache(t, tableCacheOptions{CapBytes: 2})
+
+	k1 := tableKey{FileNum: 1}
+	h, err := cache.Get(ctx, k1)
+	require.NoError(t, err)
+	h.Unref()
+	require.True(t, cache.PinKey(k1))
+
+	k2 := tableKey{FileNum: 2}
+	h, err = cache.Get(ctx, k2)
+	require.NoError(t, err)
+	h.Unref()
+	require.True(t, cache.PinKey(k2))
+
+	// Drop the capacity so the shard exceeds its budget while entries are pinned.
+	cache.shards[0].capBytes = 1
+
+	st := cache.Stats()
+	require.EqualValues(t, 2, st.UsedBytes)
+
+	cache.UnpinKey(ctx, k1)
+
+	st = cache.Stats()
+	require.EqualValues(t, 1, st.UsedBytes)
+
+	_, ok := cache.TryGet(ctx, k1)
+	require.False(t, ok, "unpinned key should be evicted")
+
+	_, ok = cache.TryGet(ctx, k2)
+	require.True(t, ok, "still pinned key stays")
 }


### PR DESCRIPTION
## Summary
- enforce table cache capacity immediately when unpinning a key
- update compaction to use new UnpinKey signature
- test unpin-triggered eviction

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bd2c68f4cc83259b87eedb62bc0621