### PR TITLE
fix: track TryGet misses in table cache stats

### DIFF
--- a/tablecache.go
+++ b/tablecache.go
@@ -171,6 +171,8 @@ func (c *tableCache) TryGet(ctx context.Context, k tableKey) (entry *TableCacheE
 		cacheHits.Add(ctx, 1)
 		return e.entry, true
 	}
+	s.misses.Add(1)
+	cacheMisses.Add(ctx, 1)
 	return nil, false
 }
 

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -59,6 +59,35 @@ func TestTableCacheHitMiss(t *testing.T) {
 	require.EqualValues(t, 1, st.Hits)
 }
 
+func TestTableCacheTryGetStats(t *testing.T) {
+	ctx := context.Background()
+	cache := newTestCache(t, tableCacheOptions{})
+
+	k1 := tableKey{FileNum: 1}
+	h, err := cache.Get(ctx, k1)
+	require.NoError(t, err)
+	h.Unref()
+
+	st := cache.Stats()
+	require.EqualValues(t, 1, st.Misses)
+	require.EqualValues(t, 0, st.Hits)
+
+	h, ok := cache.TryGet(ctx, k1)
+	require.True(t, ok)
+	h.Unref()
+
+	st = cache.Stats()
+	require.EqualValues(t, 1, st.Misses)
+	require.EqualValues(t, 1, st.Hits)
+
+	_, ok = cache.TryGet(ctx, tableKey{FileNum: 2})
+	require.False(t, ok)
+
+	st = cache.Stats()
+	require.EqualValues(t, 2, st.Misses)
+	require.EqualValues(t, 1, st.Hits)
+}
+
 func TestTableCacheEviction(t *testing.T) {
 	ctx := context.Background()
 	cache := newTestCache(t, tableCacheOptions{CapBytes: 1})
@@ -244,7 +273,7 @@ func TestTableCachePinnedOverCapacity(t *testing.T) {
 
 	st := cache.Stats()
 	require.EqualValues(t, 2, st.Hits)
-	require.EqualValues(t, 3, st.Misses)
+	require.EqualValues(t, 4, st.Misses)
 	require.EqualValues(t, 1, st.Evicts)
 	require.EqualValues(t, 1, st.Closes)
 }


### PR DESCRIPTION
## Summary
- count TryGet misses in table cache stats
- test stats accounting for TryGet hits and misses

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bd3fd07f648325b10910def5d34283