### PR TITLE
chore: add context to transaction begin

### DIFF
--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -39,7 +39,7 @@ func NewSSTableBuilder(ctx context.Context, cfg Config, fs *FileSystem, expected
 		return nil, fmt.Errorf("failed to clean file system: %w", err)
 	}
 	tm := newTransactionManager()
-	tx, err := tm.begin(fs)
+	tx, err := tm.begin(ctx, fs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to begin transaction: %w", err)
 	}

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -31,7 +31,7 @@ func newTransactionManager() *transactionManager {
 }
 
 // begin starts a new transaction for the provided FileSystem.
-func (tm *transactionManager) begin(fs *FileSystem) (*transaction, error) {
+func (tm *transactionManager) begin(ctx context.Context, fs *FileSystem) (*transaction, error) {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
@@ -45,7 +45,7 @@ func (tm *transactionManager) begin(fs *FileSystem) (*transaction, error) {
 	dir := filepath.Dir(path)
 	shadowPath := filepath.Join(dir, fmt.Sprintf("txn-%d.log", id))
 
-	shadowFS, err := OpenFS(context.Background(), shadowPath)
+	shadowFS, err := OpenFS(ctx, shadowPath)
 	if err != nil {
 		return nil, err
 	}

--- a/transaction_manager_test.go
+++ b/transaction_manager_test.go
@@ -29,7 +29,7 @@ func TestBeginCopiesExistingData(t *testing.T) {
 	require.NoError(t, fs.Sync())
 
 	tm := newTransactionManager()
-	txn, err := tm.begin(fs)
+	txn, err := tm.begin(context.Background(), fs)
 	require.NoError(t, err)
 	require.NotNil(t, txn)
 
@@ -56,7 +56,7 @@ func TestBeginCopyOpenError(t *testing.T) {
 	osOpen = func(string) (*os.File, error) { return nil, wantErr }
 	defer func() { osOpen = origOpen }()
 
-	txn, err := tm.begin(fs)
+	txn, err := tm.begin(context.Background(), fs)
 	require.ErrorIs(t, err, wantErr)
 	require.Nil(t, txn)
 
@@ -74,7 +74,7 @@ func TestBeginCopyCopyError(t *testing.T) {
 	ioCopy = func(io.Writer, io.Reader) (int64, error) { return 0, wantErr }
 	defer func() { ioCopy = origCopy }()
 
-	txn, err := tm.begin(fs)
+	txn, err := tm.begin(context.Background(), fs)
 	require.ErrorIs(t, err, wantErr)
 	require.Nil(t, txn)
 
@@ -86,7 +86,7 @@ func TestBeginCopyCopyError(t *testing.T) {
 func TestWriteAndCommit(t *testing.T) {
 	fs := newTempFS(t)
 	tm := newTransactionManager()
-	txn, err := tm.begin(fs)
+	txn, err := tm.begin(context.Background(), fs)
 	require.NoError(t, err)
 
 	_, err = txn.write([]byte("hello"))
@@ -105,7 +105,7 @@ func TestRollback(t *testing.T) {
 	require.NoError(t, fs.Sync())
 
 	tm := newTransactionManager()
-	txn, err := tm.begin(fs)
+	txn, err := tm.begin(context.Background(), fs)
 	require.NoError(t, err)
 
 	_, err = txn.write([]byte("new"))
@@ -120,7 +120,7 @@ func TestRollback(t *testing.T) {
 func TestWriteAfterCommit(t *testing.T) {
 	fs := newTempFS(t)
 	tm := newTransactionManager()
-	txn, err := tm.begin(fs)
+	txn, err := tm.begin(context.Background(), fs)
 	require.NoError(t, err)
 
 	_, err = txn.write([]byte("data"))
@@ -142,7 +142,7 @@ func TestConcurrentBegin(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			fs := newTempFS(t)
-			tx, err := tm.begin(fs)
+			tx, err := tm.begin(context.Background(), fs)
 			require.NoError(t, err)
 			txns[i] = tx
 		}(i)
@@ -158,7 +158,7 @@ func TestConcurrentBegin(t *testing.T) {
 func TestConcurrentWrite(t *testing.T) {
 	tm := newTransactionManager()
 	fs := newTempFS(t)
-	tx, err := tm.begin(fs)
+	tx, err := tm.begin(context.Background(), fs)
 	require.NoError(t, err)
 
 	const numWrites = 100
@@ -185,9 +185,9 @@ func TestTransactionCommitRollbackConcurrency(t *testing.T) {
 
 	tm := newTransactionManager()
 
-	txCommit, err := tm.begin(w.FileSystem)
+	txCommit, err := tm.begin(ctx, w.FileSystem)
 	require.NoError(t, err)
-	txRollback, err := tm.begin(w.FileSystem)
+	txRollback, err := tm.begin(ctx, w.FileSystem)
 	require.NoError(t, err)
 
 	seq := uint64(1)

--- a/wal.go
+++ b/wal.go
@@ -111,7 +111,7 @@ func (w *wal) Append(ctx context.Context, record Record) error {
 		span.End()
 	}()
 
-	tx, err := w.tm.begin(w.FileSystem)
+	tx, err := w.tm.begin(ctx, w.FileSystem)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,7 @@ func (w *wal) AppendMany(ctx context.Context, records []Record) error {
 		span.End()
 	}()
 
-	tx, err := w.tm.begin(w.FileSystem)
+	tx, err := w.tm.begin(ctx, w.FileSystem)
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func (w *wal) Clean(ctx context.Context, minSeq uint64) error {
 		if rec.GetSequenceNumber() < minSeq {
 			continue
 		}
-		tx, err := w.tm.begin(tmpFS)
+		tx, err := w.tm.begin(ctx, tmpFS)
 		if err != nil {
 			cleanupTemp(tmpFS, tmpPath)
 			return fmt.Errorf("failed to begin transaction: %w", err)

--- a/wal_test.go
+++ b/wal_test.go
@@ -280,7 +280,7 @@ func TestWALCrashRecovery_PartialWrite(t *testing.T) {
 
 	// Simulate a crash during the write of a third record
 	record3 := newRecord(Bytes("key3"), Bytes("value3"), 3)
-	tx, err := w.tm.begin(w.FileSystem)
+	tx, err := w.tm.begin(context.Background(), w.FileSystem)
 	require.NoError(t, err)
 	defer tx.rollback(context.Background())
 


### PR DESCRIPTION
## Summary
- add context parameter to transactionManager.begin
- pass context through WAL and SSTable builder

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bd728368d883258682320a220a1695