### PR TITLE
test: cover tombstone branch in SearchKey

### DIFF
--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -377,6 +377,21 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		assert.Equal(t, value, result)
 	})
 
+	t.Run("Tombstone returns ErrKeyNotFound", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		key := Bytes("dead-key")
+		fs0 := ts.newSSTableFS()
+		sst := createSSTable(t, cfg, fs0, [2]Bytes{key, nil})
+		ts.AddSSTable(0, &sst)
+
+		result, err := ts.Manager.SearchKey(ctx, key)
+		assert.ErrorIs(t, err, ErrKeyNotFound)
+		assert.Nil(t, result)
+	})
+
 	t.Run("Tombstone in level 0 overrides level 1", func(t *testing.T) {
 		ctx := context.Background()
 		ts := newTestRindbSetup(t, ctx, &cfg)


### PR DESCRIPTION
## Summary
- add unit test ensuring SearchKey maps tombstone errors to ErrKeyNotFound

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bd88fb6270832589ada6b0cd23d169