### PR TITLE
test: cover transaction manager and search errors

### DIFF
--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path"
@@ -422,6 +423,31 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		result, err := ts.Manager.SearchKey(ctx, Bytes("absent-key"))
 		assert.ErrorIs(t, err, ErrKeyNotFound)
 		assert.Nil(t, result)
+	})
+
+	t.Run("Propagates underlying error", func(t *testing.T) {
+		ctx := context.Background()
+		ts := newTestRindbSetup(t, ctx, &cfg)
+		defer ts.Cleanup()
+
+		key := Bytes("err-key")
+		value := Bytes("val")
+		sst := ts.createSSTable(map[string]string{string(key): string(value)})
+		ts.AddSSTable(0, sst)
+
+		rec := newRecord(key, value, 1)
+		offset := int64(CalOnDiskSize(rec)) - checksumSize
+		f, err := os.OpenFile(sst.Path(), os.O_WRONLY, 0)
+		require.NoError(t, err)
+		_, err = f.Seek(offset, io.SeekStart)
+		require.NoError(t, err)
+		_, err = f.Write([]byte{0, 0, 0, 0})
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		res, err := ts.Manager.SearchKey(ctx, key)
+		assert.Nil(t, res)
+		assert.True(t, errors.Is(err, ErrChecksumMismatch))
 	})
 
 	t.Run("Missing SSTable is not recreated", func(t *testing.T) {

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -12,9 +12,14 @@ import (
 )
 
 var (
-	globalTxnID atomic.Uint64
-	osOpen      = os.Open
-	ioCopy      = io.Copy
+	globalTxnID    atomic.Uint64
+	osOpen         = os.Open
+	ioCopy         = io.Copy
+	osRename       = os.Rename
+	osRemove       = os.Remove
+	fsSync         = (*FileSystem).Sync
+	fsClose        = (*FileSystem).Close
+	fsOpenExisting = (*FileSystem).OpenExisting
 )
 
 // transactionManager manages transactions with a mutex for safe creation.
@@ -119,19 +124,19 @@ func (t *transaction) commit(ctx context.Context) error {
 		return errors.New("transaction is not active")
 	}
 
-	if err := t.log.Sync(); err != nil {
+	if err := fsSync(t.log); err != nil {
 		return err
 	}
-	if err := t.log.Close(); err != nil {
+	if err := fsClose(t.log); err != nil {
 		return err
 	}
-	if err := os.Rename(t.log.Path(), t.target.Path()); err != nil {
+	if err := osRename(t.log.Path(), t.target.Path()); err != nil {
 		return err
 	}
-	if err := t.target.Close(); err != nil && !errors.Is(err, ErrFileNotOpened) {
+	if err := fsClose(t.target); err != nil && !errors.Is(err, ErrFileNotOpened) {
 		return err
 	}
-	if err := t.target.OpenExisting(ctx); err != nil {
+	if err := fsOpenExisting(t.target, ctx); err != nil {
 		return err
 	}
 
@@ -153,10 +158,10 @@ func (t *transaction) rollback(ctx context.Context) error {
 	}
 
 	shadowPath := t.log.Path()
-	if err := t.log.Close(); err != nil {
+	if err := fsClose(t.log); err != nil {
 		return err
 	}
-	if err := os.Remove(shadowPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := osRemove(shadowPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to remove shadow log %q during rollback: %w", shadowPath, err)
 	}
 

--- a/transaction_manager_test.go
+++ b/transaction_manager_test.go
@@ -83,6 +83,49 @@ func TestBeginCopyCopyError(t *testing.T) {
 	require.Len(t, entries, 1)
 }
 
+func TestBeginCloseError(t *testing.T) {
+	fs := newTempFS(t)
+	// Close underlying file without updating fs to simulate close error
+	require.NoError(t, fs.file.Close())
+
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.Error(t, err)
+	require.Nil(t, txn)
+}
+
+func TestBeginShadowFSOpenError(t *testing.T) {
+	fs := newTempFS(t)
+	dir := filepath.Dir(fs.Path())
+	require.NoError(t, fs.Close())
+	require.NoError(t, os.RemoveAll(dir))
+
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.Error(t, err)
+	require.Nil(t, txn)
+}
+
+func TestBeginSrcCloseError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+
+	tmp, err := os.CreateTemp("", "src")
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+	defer os.Remove(tmp.Name())
+
+	origOpen := osOpen
+	origCopy := ioCopy
+	osOpen = func(string) (*os.File, error) { return tmp, nil }
+	ioCopy = func(io.Writer, io.Reader) (int64, error) { return 0, nil }
+	defer func() { osOpen = origOpen; ioCopy = origCopy }()
+
+	txn, err := tm.begin(context.Background(), fs)
+	require.Error(t, err)
+	require.Nil(t, txn)
+}
+
 func TestWriteAndCommit(t *testing.T) {
 	fs := newTempFS(t)
 	tm := newTransactionManager()
@@ -219,4 +262,126 @@ func TestTransactionCommitRollbackConcurrency(t *testing.T) {
 	val, err := mem.Get(Bytes("key"))
 	require.NoError(t, err)
 	require.Equal(t, Bytes("commit"), val)
+}
+
+func TestCommitSyncError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.NoError(t, err)
+
+	wantErr := errors.New("sync fail")
+	origSync := fsSync
+	fsSync = func(*FileSystem) error { return wantErr }
+	defer func() { fsSync = origSync }()
+
+	err = txn.commit(context.Background())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestCommitLogCloseError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.NoError(t, err)
+
+	wantErr := errors.New("log close fail")
+	origSync := fsSync
+	origClose := fsClose
+	fsSync = func(*FileSystem) error { return nil }
+	fsClose = func(f *FileSystem) error {
+		if f == txn.log {
+			return wantErr
+		}
+		return origClose(f)
+	}
+	defer func() { fsSync = origSync; fsClose = origClose }()
+
+	err = txn.commit(context.Background())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestCommitRenameError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.NoError(t, err)
+
+	wantErr := errors.New("rename fail")
+	origRename := osRename
+	osRename = func(_, _ string) error { return wantErr }
+	defer func() { osRename = origRename }()
+
+	err = txn.commit(context.Background())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestCommitTargetCloseError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.NoError(t, err)
+
+	wantErr := errors.New("target close fail")
+	origClose := fsClose
+	fsClose = func(f *FileSystem) error {
+		if f == txn.target {
+			return wantErr
+		}
+		return origClose(f)
+	}
+	defer func() { fsClose = origClose }()
+
+	err = txn.commit(context.Background())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestCommitOpenExistingError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.NoError(t, err)
+
+	wantErr := errors.New("open existing fail")
+	origOpenExisting := fsOpenExisting
+	fsOpenExisting = func(*FileSystem, context.Context) error { return wantErr }
+	defer func() { fsOpenExisting = origOpenExisting }()
+
+	err = txn.commit(context.Background())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestRollbackCloseError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.NoError(t, err)
+
+	wantErr := errors.New("log close fail")
+	origClose := fsClose
+	fsClose = func(f *FileSystem) error {
+		if f == txn.log {
+			return wantErr
+		}
+		return origClose(f)
+	}
+	defer func() { fsClose = origClose }()
+
+	err = txn.rollback(context.Background())
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestRollbackRemoveError(t *testing.T) {
+	fs := newTempFS(t)
+	tm := newTransactionManager()
+	txn, err := tm.begin(context.Background(), fs)
+	require.NoError(t, err)
+
+	wantErr := errors.New("remove fail")
+	origRemove := osRemove
+	osRemove = func(string) error { return wantErr }
+	defer func() { osRemove = origRemove }()
+
+	err = txn.rollback(context.Background())
+	require.ErrorIs(t, err, wantErr)
 }


### PR DESCRIPTION
## Summary
- add function hooks for file and OS ops in transaction manager
- cover begin, commit, and rollback error paths with new tests
- verify SearchKey propagates non-NotFound errors

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bdad4c79108325bf400fca7ccf5fc6