### PR TITLE
feat: add Jaeger tracing support to diff harness

### DIFF
--- a/diffharness/README.md
+++ b/diffharness/README.md
@@ -1,0 +1,20 @@
+# Diff Harness
+
+The diff harness runs RinDB operations against a SQLite oracle to surface logic discrepancies. It now supports exporting traces to a local Jaeger instance.
+
+## Local Jaeger Setup
+
+Start Jaeger using the provided compose file:
+
+```bash
+docker compose -f diffharness/docker-compose.yaml up -d
+```
+
+The Jaeger UI is available at http://localhost:16686 and accepts OTLP gRPC on `localhost:4317`.
+
+Run the harness and send traces to Jaeger:
+
+```bash
+go run ./diffharness/cmd -jaeger=localhost:4317
+```
+

--- a/diffharness/cmd/main.go
+++ b/diffharness/cmd/main.go
@@ -18,6 +18,7 @@ func main() {
 	logPath := flag.String("log", "repro.jsonl", "log file path")
 	crashEvery := flag.Int("crash-every", 0, "crash/recover every N ops")
 	telemetryEvery := flag.Int("telemetry-every", 0, "emit telemetry every N ops")
+	jaeger := flag.String("jaeger", "", "Jaeger OTLP gRPC endpoint (e.g., localhost:4317)")
 	metamorphic := flag.Bool("metamorphic", false, "run metamorphic config variants")
 	flag.Parse()
 
@@ -38,13 +39,13 @@ func main() {
 	}
 
 	for _, c := range configs {
-		if err := runOne(*seed, *n, *logPath+"-"+c.label, *crashEvery, *telemetryEvery, c.opts); err != nil {
+		if err := runOne(*seed, *n, *logPath+"-"+c.label, *crashEvery, *telemetryEvery, *jaeger, c.opts); err != nil {
 			log.Fatalf("%s run failed: %v", c.label, err)
 		}
 	}
 }
 
-func runOne(seed int64, n int, logPath string, crashEvery, telemetryEvery int, opts []rindb.Option) error {
+func runOne(seed int64, n int, logPath string, crashEvery, telemetryEvery int, jaeger string, opts []rindb.Option) error {
 	dir, err := os.MkdirTemp("", "diffharness")
 	if err != nil {
 		return err
@@ -52,7 +53,15 @@ func runOne(seed int64, n int, logPath string, crashEvery, telemetryEvery int, o
 	defer os.RemoveAll(dir)
 	dbDir := filepath.Join(dir, "db")
 	refPath := filepath.Join(dir, "ref.db")
-	db, err := rindb.InitRinDB(context.Background(), append([]rindb.Option{rindb.WithDatabaseDir(dbDir)}, opts...)...)
+	baseOpts := []rindb.Option{rindb.WithDatabaseDir(dbDir)}
+	if jaeger != "" {
+		baseOpts = append(baseOpts,
+			rindb.WithEnableTelemetry(true),
+			rindb.WithExporterEndpoint(jaeger),
+			rindb.WithExporterInsecure(true),
+		)
+	}
+	db, err := rindb.InitRinDB(context.Background(), append(baseOpts, opts...)...)
 	if err != nil {
 		return err
 	}
@@ -95,7 +104,7 @@ func runOne(seed int64, n int, logPath string, crashEvery, telemetryEvery int, o
 			if err := ref.Close(); err != nil {
 				return err
 			}
-			db, err := rindb.InitRinDB(context.Background(), append([]rindb.Option{rindb.WithDatabaseDir(dbDir)}, opts...)...)
+			db, err := rindb.InitRinDB(context.Background(), append(baseOpts, opts...)...)
 			if err != nil {
 				return err
 			}

--- a/diffharness/docker-compose.yaml
+++ b/diffharness/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    ports:
+      - '16686:16686'
+      - '4317:4317'
+      - '4318:4318'


### PR DESCRIPTION
## Summary
- add docker compose for local Jaeger
- allow diff harness to export traces via -jaeger flag
- document running diff harness with Jaeger

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68be2f4e92b88325ad6898937cab2b64