### PR TITLE
test: broaden diffharness coverage

### DIFF
--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -131,41 +131,40 @@ func (h *Harness) pickKnownKey(r *rand.Rand) []byte {
 	return []byte(h.keys[r.Intn(len(h.keys))])
 }
 
+func (h *Harness) genKey(r *rand.Rand, n int) []byte {
+	k := randKey(r, n)
+	if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
+		k = ex
+	}
+	return k
+}
+
 func (h *Harness) genOp(r *rand.Rand, cfg Cfg) Op {
 	sum := 0
 	for _, w := range cfg.Weights {
 		sum += w
 	}
 	x := r.Intn(sum)
-	var k OpKind
-	for kind, w := range cfg.Weights {
+	var kind OpKind
+	for op, w := range cfg.Weights {
 		if x < w {
-			k = kind
+			kind = op
 			break
 		}
 		x -= w
 	}
-	switch k {
+	switch kind {
 	case OpPut:
 		vlen := cfg.ValLenMin + r.Intn(cfg.ValLenMax-cfg.ValLenMin+1)
-		k := randKey(r, cfg.KeyLen)
-		if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
-			k = ex
-		}
-		return Op{Kind: OpPut, K: k, V: randBytes(r, vlen)}
+		key := h.genKey(r, cfg.KeyLen)
+		return Op{Kind: OpPut, K: key, V: randBytes(r, vlen)}
 	case OpDel:
-		k := randKey(r, cfg.KeyLen)
-		if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
-			k = ex
-		}
-		return Op{Kind: OpDel, K: k}
+		key := h.genKey(r, cfg.KeyLen)
+		return Op{Kind: OpDel, K: key}
 	case OpGet:
-		k := randKey(r, cfg.KeyLen)
-		if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
-			k = ex
-		}
+		key := h.genKey(r, cfg.KeyLen)
 		s := h.pickSnapshot(r)
-		return Op{Kind: OpGet, K: k, SnapSeq: s}
+		return Op{Kind: OpGet, K: key, SnapSeq: s}
 	case OpRange:
 		lo := randKey(r, cfg.KeyLen)
 		hi := randKey(r, cfg.KeyLen)
@@ -431,11 +430,11 @@ func Replay(ctx context.Context, my Engine, ref *SQLiteOracle, logPath string) (
 	defer devnull.Close()
 	h := &Harness{My: my, Ref: ref, log: devnull, enc: json.NewEncoder(devnull)}
 	h.Snapshots = append(h.Snapshots, h.Seq)
+	var entry struct {
+		Seq uint64 `json:"seq"`
+		Op  Op     `json:"op"`
+	}
 	for {
-		var entry struct {
-			Seq uint64 `json:"seq"`
-			Op  Op     `json:"op"`
-		}
 		if err := dec.Decode(&entry); err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 )
@@ -42,6 +44,9 @@ type Harness struct {
 
 	Seq       uint64
 	Snapshots []uint64
+
+	keys   []string
+	keySet map[string]struct{}
 
 	log *os.File
 	enc *json.Encoder
@@ -83,6 +88,49 @@ func randBytes(r *rand.Rand, n int) []byte {
 
 func randKey(r *rand.Rand, n int) []byte { return randBytes(r, n) }
 
+const maxKnownKeys = 100
+
+func (h *Harness) addKey(k []byte) {
+	if h.keySet == nil {
+		h.keySet = make(map[string]struct{})
+	}
+	s := string(k)
+	if _, ok := h.keySet[s]; ok {
+		return
+	}
+	if len(h.keys) >= maxKnownKeys {
+		oldest := h.keys[0]
+		h.keys = h.keys[1:]
+		delete(h.keySet, oldest)
+	}
+	h.keys = append(h.keys, s)
+	h.keySet[s] = struct{}{}
+}
+
+func (h *Harness) delKey(k []byte) {
+	if h.keySet == nil {
+		return
+	}
+	s := string(k)
+	if _, ok := h.keySet[s]; !ok {
+		return
+	}
+	delete(h.keySet, s)
+	for i, v := range h.keys {
+		if v == s {
+			h.keys = append(h.keys[:i], h.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+func (h *Harness) pickKnownKey(r *rand.Rand) []byte {
+	if len(h.keys) == 0 {
+		return nil
+	}
+	return []byte(h.keys[r.Intn(len(h.keys))])
+}
+
 func (h *Harness) genOp(r *rand.Rand, cfg Cfg) Op {
 	sum := 0
 	for _, w := range cfg.Weights {
@@ -100,12 +148,24 @@ func (h *Harness) genOp(r *rand.Rand, cfg Cfg) Op {
 	switch k {
 	case OpPut:
 		vlen := cfg.ValLenMin + r.Intn(cfg.ValLenMax-cfg.ValLenMin+1)
-		return Op{Kind: OpPut, K: randKey(r, cfg.KeyLen), V: randBytes(r, vlen)}
+		k := randKey(r, cfg.KeyLen)
+		if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
+			k = ex
+		}
+		return Op{Kind: OpPut, K: k, V: randBytes(r, vlen)}
 	case OpDel:
-		return Op{Kind: OpDel, K: randKey(r, cfg.KeyLen)}
+		k := randKey(r, cfg.KeyLen)
+		if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
+			k = ex
+		}
+		return Op{Kind: OpDel, K: k}
 	case OpGet:
+		k := randKey(r, cfg.KeyLen)
+		if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
+			k = ex
+		}
 		s := h.pickSnapshot(r)
-		return Op{Kind: OpGet, K: randKey(r, cfg.KeyLen), SnapSeq: s}
+		return Op{Kind: OpGet, K: k, SnapSeq: s}
 	case OpRange:
 		lo := randKey(r, cfg.KeyLen)
 		hi := randKey(r, cfg.KeyLen)
@@ -154,6 +214,7 @@ func (h *Harness) Step(ctx context.Context, op Op) error {
 		if err := h.My.Put(ctx, op.K, op.V); err != nil {
 			return h.fail(i, op, err)
 		}
+		h.addKey(op.K)
 		if h.Ref != nil {
 			if err := h.Ref.PutWithSeq(op.K, op.V, h.Seq); err != nil {
 				return h.fail(i, op, err)
@@ -164,6 +225,7 @@ func (h *Harness) Step(ctx context.Context, op Op) error {
 		if err := h.My.Delete(ctx, op.K); err != nil {
 			return h.fail(i, op, err)
 		}
+		h.delKey(op.K)
 		if h.Ref != nil {
 			if err := h.Ref.DelWithSeq(op.K, h.Seq); err != nil {
 				return h.fail(i, op, err)
@@ -351,4 +413,39 @@ func (h *Harness) checkInvariants(ctx context.Context, r *rand.Rand, cfg Cfg) er
 		}
 	}
 	return nil
+}
+
+// Replay replays operations from logPath against the provided engines.
+// It returns the final sequence after applying all operations.
+func Replay(ctx context.Context, my Engine, ref *SQLiteOracle, logPath string) (uint64, error) {
+	log, err := os.Open(logPath)
+	if err != nil {
+		return 0, err
+	}
+	defer log.Close()
+	dec := json.NewDecoder(log)
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer devnull.Close()
+	h := &Harness{My: my, Ref: ref, log: devnull, enc: json.NewEncoder(devnull)}
+	h.Snapshots = append(h.Snapshots, h.Seq)
+	for {
+		var entry struct {
+			Seq uint64 `json:"seq"`
+			Op  Op     `json:"op"`
+		}
+		if err := dec.Decode(&entry); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return 0, err
+		}
+		h.Seq = entry.Seq
+		if err := h.Step(ctx, entry.Op); err != nil {
+			return 0, err
+		}
+	}
+	return h.Seq, nil
 }

--- a/diffharness/harness_test.go
+++ b/diffharness/harness_test.go
@@ -72,6 +72,73 @@ func (e *sqliteEngine) Range(ctx context.Context, lo, hi []byte, snapshot uint64
 
 func (e *sqliteEngine) Close() error { return e.o.Close() }
 
+func TestHistoricalReads(t *testing.T) {
+	dir := t.TempDir()
+	ref, err := OpenSQLiteOracle(filepath.Join(dir, "ref.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ref.Close() })
+
+	dbDir := filepath.Join(dir, "db")
+	db, err := rindb.InitRinDB(context.Background(), rindb.WithDatabaseDir(dbDir))
+	require.NoError(t, err)
+	eng := NewRinDBEngine(db)
+
+	logPath := filepath.Join(dir, "log.jsonl")
+	h, err := NewHarness(eng, ref, 1, logPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close(); _ = eng.Close() })
+
+	ctx := context.Background()
+	h.Snapshots = append(h.Snapshots, h.Seq)
+	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v1")}))
+	snap := h.Seq
+	require.NoError(t, h.Step(ctx, Op{Kind: OpSnap}))
+	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v2")}))
+
+	v, ok, err := h.My.Get(ctx, []byte("k"), snap)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []byte("v1"), v)
+
+	v, ok, err = h.My.Get(ctx, []byte("k"), h.Seq)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []byte("v2"), v)
+}
+
+func TestRangeHistoricalSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	ref, err := OpenSQLiteOracle(filepath.Join(dir, "ref.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ref.Close() })
+
+	myOracle, err := OpenSQLiteOracle(filepath.Join(dir, "my.db"))
+	require.NoError(t, err)
+	eng := &sqliteEngine{o: myOracle}
+
+	logPath := filepath.Join(dir, "log.jsonl")
+	h, err := NewHarness(eng, ref, 1, logPath)
+	require.NoError(t, err)
+	eng.seq = &h.Seq
+	t.Cleanup(func() { _ = h.Close(); _ = eng.Close() })
+
+	ctx := context.Background()
+	h.Snapshots = append(h.Snapshots, h.Seq)
+	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("a"), V: []byte("1")}))
+	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("b"), V: []byte("2")}))
+	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("c"), V: []byte("3")}))
+	snap := h.Seq
+	require.NoError(t, h.Step(ctx, Op{Kind: OpSnap}))
+
+	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("b"), V: []byte("2'")}))
+	require.NoError(t, h.Step(ctx, Op{Kind: OpDel, K: []byte("c")}))
+
+	res, err := h.My.Range(ctx, []byte("a"), []byte("z"), snap, 10)
+	require.NoError(t, err)
+	exp := []KV{{K: []byte("a"), V: []byte("1")}, {K: []byte("b"), V: []byte("2")}, {K: []byte("c"), V: []byte("3")}}
+	require.Equal(t, exp, res)
+}
+
 func TestHarnessRunChecksInvariants(t *testing.T) {
 	dir := t.TempDir()
 	ref, err := OpenSQLiteOracle(filepath.Join(dir, "ref.db"))
@@ -111,7 +178,8 @@ func TestHarnessCrashAndTelemetryHooks(t *testing.T) {
 	require.NoError(t, err)
 	defer ref.Close()
 
-	myOracle, err := OpenSQLiteOracle(filepath.Join(dir, "my.db"))
+	myPath := filepath.Join(dir, "my.db")
+	myOracle, err := OpenSQLiteOracle(myPath)
 	require.NoError(t, err)
 	eng := &sqliteEngine{o: myOracle}
 
@@ -124,8 +192,34 @@ func TestHarnessCrashAndTelemetryHooks(t *testing.T) {
 
 	crashes := 0
 	telem := 0
-	h.SetCrashHook(func() error { crashes++; return nil })
+	h.SetCrashHook(func() error {
+		crashes++
+		if err := eng.Close(); err != nil {
+			return err
+		}
+		myOracle, err = OpenSQLiteOracle(myPath)
+		if err != nil {
+			return err
+		}
+		eng.o = myOracle
+		return nil
+	})
 	h.SetTelemetryHook(func(seq uint64, ops int) { telem++ })
+
+	ctx := context.Background()
+	h.Snapshots = append(h.Snapshots, h.Seq)
+	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v")}))
+	snap := h.Seq
+	require.NoError(t, h.Step(ctx, Op{Kind: OpSnap}))
+	require.NoError(t, h.crash())
+	v, ok, err := h.My.Get(ctx, []byte("k"), h.Seq)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []byte("v"), v)
+	v, ok, err = h.My.Get(ctx, []byte("k"), snap)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []byte("v"), v)
 
 	cfg := Cfg{
 		KeyLen:    4,
@@ -142,8 +236,60 @@ func TestHarnessCrashAndTelemetryHooks(t *testing.T) {
 		CrashEvery:     10,
 		TelemetryEvery: 5,
 	}
-	ctx := context.Background()
 	require.NoError(t, h.Run(ctx, cfg, 50))
-	require.Greater(t, crashes, 0)
+	require.Greater(t, crashes, 1)
 	require.Greater(t, telem, 0)
+}
+
+func TestReplayReproducesState(t *testing.T) {
+	dir := t.TempDir()
+	ref, err := OpenSQLiteOracle(filepath.Join(dir, "ref.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ref.Close() })
+
+	myOracle, err := OpenSQLiteOracle(filepath.Join(dir, "my.db"))
+	require.NoError(t, err)
+	eng := &sqliteEngine{o: myOracle}
+
+	logPath := filepath.Join(dir, "log.jsonl")
+	h, err := NewHarness(eng, ref, 1, logPath)
+	require.NoError(t, err)
+	eng.seq = &h.Seq
+	t.Cleanup(func() { _ = h.Close(); _ = eng.Close() })
+
+	cfg := Cfg{
+		KeyLen:    2,
+		ValLenMin: 1,
+		ValLenMax: 4,
+		RangeMax:  100,
+		Weights: map[OpKind]int{
+			OpPut:   1,
+			OpDel:   1,
+			OpGet:   1,
+			OpRange: 1,
+			OpSnap:  1,
+		},
+	}
+	ctx := context.Background()
+	require.NoError(t, h.Run(ctx, cfg, 30))
+	finalSeq := h.Seq
+	lo := []byte{0x00, 0x00}
+	hi := []byte{0xff, 0xff}
+	exp, err := ref.RangeWithSeq(lo, hi, finalSeq, 1000)
+	require.NoError(t, err)
+
+	// Replay
+	ref2, err := OpenSQLiteOracle(filepath.Join(dir, "ref2.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ref2.Close() })
+	dbDir2 := filepath.Join(dir, "db2")
+	db2, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dbDir2))
+	require.NoError(t, err)
+	eng2 := NewRinDBEngine(db2)
+	t.Cleanup(func() { _ = eng2.Close() })
+	seq2, err := Replay(ctx, eng2, ref2, logPath)
+	require.NoError(t, err)
+	got, err := ref2.RangeWithSeq(lo, hi, seq2, 1000)
+	require.NoError(t, err)
+	require.Equal(t, exp, got)
 }


### PR DESCRIPTION
## Summary
- reuse previously written keys in diffharness operations
- add historical read, range, crash persistence and replay tests
- implement log replay helper

## Testing
- `make check`
- `make test`
- `cd diffharness && go test -v ./...`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bec1ff40ac8325ba80680fed340cdf