### PR TITLE
feat: remove obsolete manifest files

### DIFF
--- a/manifest_rotation.go
+++ b/manifest_rotation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const manifestsToKeepAfterRotation = 1
+
 // snapshotEdit returns a versionEdit that captures the full state of the
 // versionSet. The edit can be written as a manifest snapshot.
 func (vs *versionSet) snapshotEdit() versionEdit {
@@ -95,7 +97,7 @@ func (r *Rindb) maybeRotateManifest(ctx context.Context) error {
 	if old != nil {
 		_ = old.Close()
 	}
-	return cleanupManifests(r.config.databaseDir, 1)
+	return cleanupManifests(r.config.databaseDir, manifestsToKeepAfterRotation)
 }
 
 // cleanupManifests removes old MANIFEST files, keeping the one referenced by
@@ -134,7 +136,9 @@ func cleanupManifests(dir string, keepRecent int) error {
 		if i < keepRecent {
 			continue
 		}
-		_ = os.Remove(filepath.Join(dir, m.name))
+		if err := os.Remove(filepath.Join(dir, m.name)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/manifest_rotation_test.go
+++ b/manifest_rotation_test.go
@@ -75,7 +75,7 @@ func TestCleanupManifests(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
 	}
 	require.NoError(t, writeCurrent(ctx, dir, manifestPath(5)))
-	require.NoError(t, cleanupManifests(dir, 1))
+	require.NoError(t, cleanupManifests(dir, manifestsToKeepAfterRotation))
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -85,7 +85,11 @@ func TestCleanupManifests(t *testing.T) {
 			names = append(names, e.Name())
 		}
 	}
-	require.ElementsMatch(t, []string{manifestPath(5), manifestPath(4)}, names)
+	expected := []string{manifestPath(5)}
+	for i := 1; i <= manifestsToKeepAfterRotation; i++ {
+		expected = append(expected, manifestPath(5-i))
+	}
+	require.ElementsMatch(t, expected, names)
 }
 
 func TestManifestRotationCleanup(t *testing.T) {
@@ -119,7 +123,7 @@ func TestManifestRotationCleanup(t *testing.T) {
 			manifests = append(manifests, e.Name())
 		}
 	}
-	require.Equal(t, 2, len(manifests))
+	require.Equal(t, manifestsToKeepAfterRotation+1, len(manifests))
 }
 
 func TestManifestRotationRecovery(t *testing.T) {


### PR DESCRIPTION
## Summary
- clean up older MANIFEST files after rotation
- test manifest cleanup helper and rotation pruning

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68be3b2c42fc8325ac21e359d6b15f93