### PR TITLE
feat: prefix keys and values in diff harness

### DIFF
--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -89,7 +89,29 @@ func randBytes(r *rand.Rand, n int) []byte {
 	return b
 }
 
-func randKey(r *rand.Rand, n int) []byte { return randBytes(r, n) }
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randString(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func randKey(r *rand.Rand, n int) []byte {
+	if n < 4 {
+		n = 4
+	}
+	return []byte("sk" + randString(r, n-4) + "ek")
+}
+
+func randValue(r *rand.Rand, n int) []byte {
+	if n < 4 {
+		n = 4
+	}
+	return []byte("sv" + randString(r, n-4) + "ev")
+}
 
 const maxKnownKeys = 100
 
@@ -160,7 +182,7 @@ func (h *Harness) genOp(r *rand.Rand, cfg Cfg) Op {
 	case OpPut:
 		vlen := cfg.ValLenMin + r.Intn(cfg.ValLenMax-cfg.ValLenMin+1)
 		key := h.genKey(r, cfg.KeyLen)
-		return Op{Kind: OpPut, K: key, V: randBytes(r, vlen)}
+		return Op{Kind: OpPut, K: key, V: randValue(r, vlen)}
 	case OpDel:
 		key := h.genKey(r, cfg.KeyLen)
 		return Op{Kind: OpDel, K: key}

--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -83,34 +83,28 @@ func (h *Harness) Close() error {
 	return h.log.Close()
 }
 
-func randBytes(r *rand.Rand, n int) []byte {
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randPrefixedBytes(r *rand.Rand, n int, prefix, suffix string) []byte {
+	minLen := len(prefix) + len(suffix)
+	if n < minLen {
+		n = minLen
+	}
 	b := make([]byte, n)
-	_, _ = r.Read(b)
+	copy(b, prefix)
+	for i := len(prefix); i < n-len(suffix); i++ {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	copy(b[n-len(suffix):], suffix)
 	return b
 }
 
-const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-func randString(r *rand.Rand, n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letters[r.Intn(len(letters))]
-	}
-	return string(b)
-}
-
 func randKey(r *rand.Rand, n int) []byte {
-	if n < 4 {
-		n = 4
-	}
-	return []byte("sk" + randString(r, n-4) + "ek")
+	return randPrefixedBytes(r, n, "sk", "ek")
 }
 
 func randValue(r *rand.Rand, n int) []byte {
-	if n < 4 {
-		n = 4
-	}
-	return []byte("sv" + randString(r, n-4) + "ev")
+	return randPrefixedBytes(r, n, "sv", "ev")
 }
 
 const maxKnownKeys = 100


### PR DESCRIPTION
## Summary
- prefix generated keys with "sk" and values with "sv" to ensure structured data in diff harness

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf6d741a84832599a5f96d52184bd3