### PR TITLE
fix: validate index alignment in NewSSTable

### DIFF
--- a/sstable.go
+++ b/sstable.go
@@ -227,6 +227,10 @@ func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, er
 		errorf(ctx, "index block out of bounds in %s: offset=%d size=%d tail=%d", fs.Path(), f.indexOffset, f.indexSize, tailOffset)
 		return SStable{}, ErrMalFormedSSTable
 	}
+	if f.indexOffset+f.indexSize != uint64(tailOffset) {
+		errorf(ctx, "index block does not align with footer in %s: offset=%d size=%d tail=%d", fs.Path(), f.indexOffset, f.indexSize, tailOffset)
+		return SStable{}, ErrMalFormedSSTable
+	}
 	if f.indexOffset > uint64(math.MaxInt64) || f.indexSize > uint64(math.MaxInt64) {
 		errorf(ctx, "index offset or size too large in %s: offset=%d size=%d", fs.Path(), f.indexOffset, f.indexSize)
 		return SStable{}, ErrMalFormedSSTable

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -661,4 +661,28 @@ func TestNewSSTableInvalidFooter(t *testing.T) {
 		_, err = NewSSTable(ctx, cfg, tx.log)
 		assert.ErrorIs(t, err, ErrMalFormedSSTable)
 	})
+
+	t.Run("ExtraBytesBetweenIndexAndFooter", func(t *testing.T) {
+		tx, cleanup := newFileTx(t)
+		defer cleanup()
+
+		// write one record at offset 0
+		err := writeRecord(tx, newRecord(Bytes("a"), Bytes("v"), 1))
+		require.NoError(t, err)
+
+		indexOffset := tx.size()
+		err = writeKeyOffset(tx, KeyOffset{key: Bytes("a"), offset: 0})
+		require.NoError(t, err)
+		indexSize := tx.size() - indexOffset
+
+		// insert extra bytes between index and footer
+		_, err = tx.write([]byte{0})
+		require.NoError(t, err)
+
+		err = writeFooter(tx, footer{indexOffset: uint64(indexOffset), indexSize: uint64(indexSize), magic: magicNumber})
+		require.NoError(t, err)
+
+		_, err = NewSSTable(ctx, cfg, tx.log)
+		assert.ErrorIs(t, err, ErrMalFormedSSTable)
+	})
 }


### PR DESCRIPTION
## Summary
- ensure index block ends at footer in NewSSTable
- test misaligned index block handling

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0bbafc490832584d402001523de83