### PR TITLE
fix: replace footer buffers and verify padding

### DIFF
--- a/sstable.go
+++ b/sstable.go
@@ -92,8 +92,8 @@ func readFooter(fs *FileSystem, off int64) (footer, error) {
 
 	f.indexOffset = byteOrder.Uint64(buf[0:8])
 	f.indexSize = byteOrder.Uint64(buf[8:16])
-	for _, b := range buf[16:40] {
-		if b != 0 {
+	for i := 16; i < 40; i += 8 {
+		if byteOrder.Uint64(buf[i:i+8]) != 0 {
 			return f, ErrMalFormedSSTable
 		}
 	}

--- a/sstable.go
+++ b/sstable.go
@@ -73,11 +73,11 @@ type footer struct {
 }
 
 func writeFooter(tx *transaction, f footer) error {
-	buf := make([]byte, footerSize)
+	var buf [footerSize]byte
 	byteOrder.PutUint64(buf[0:8], f.indexOffset)
 	byteOrder.PutUint64(buf[8:16], f.indexSize)
 	byteOrder.PutUint64(buf[40:48], f.magic)
-	if _, err := tx.write(buf); err != nil {
+	if _, err := tx.write(buf[:]); err != nil {
 		return fmt.Errorf("failed to write footer: %w", err)
 	}
 	return nil
@@ -85,12 +85,18 @@ func writeFooter(tx *transaction, f footer) error {
 
 func readFooter(fs *FileSystem, off int64) (footer, error) {
 	var f footer
-	buf := make([]byte, footerSize)
-	if _, err := fs.ReadAt(buf, off); err != nil {
+	var buf [footerSize]byte
+	if _, err := fs.ReadAt(buf[:], off); err != nil {
 		return f, err
 	}
+
 	f.indexOffset = byteOrder.Uint64(buf[0:8])
 	f.indexSize = byteOrder.Uint64(buf[8:16])
+	for _, b := range buf[16:40] {
+		if b != 0 {
+			return f, ErrMalFormedSSTable
+		}
+	}
 	f.magic = byteOrder.Uint64(buf[40:48])
 	if f.magic != magicNumber {
 		return f, ErrMalFormedSSTable

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -630,6 +630,17 @@ func TestReadFooterErrors(t *testing.T) {
 		assert.ErrorIs(t, err, ErrMalFormedSSTable)
 	})
 
+	t.Run("InvalidPadding", func(t *testing.T) {
+		tx, cleanup := newFileTx(t)
+		defer cleanup()
+		err := writeFooter(tx, footer{indexOffset: 1, indexSize: 2, magic: magicNumber})
+		require.NoError(t, err)
+		_, err = tx.log.WriteAt([]byte{1}, 16)
+		require.NoError(t, err)
+		_, err = readFooter(tx.log, 0)
+		assert.ErrorIs(t, err, ErrMalFormedSSTable)
+	})
+
 	t.Run("ShortRead", func(t *testing.T) {
 		tx, cleanup := newFileTx(t)
 		defer cleanup()


### PR DESCRIPTION
## Summary
- avoid slice allocation for footer read/write by using fixed-size buffers
- ensure footer padding bytes are zero when reading
- add test coverage for padding validation

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0bbe474a883259b62333ad2b458a7