### PR TITLE
fix: reuse offset reader in sparse index loading

### DIFF
--- a/sstable.go
+++ b/sstable.go
@@ -256,9 +256,9 @@ func loadSparseIndex(fs *FileSystem, offset, size int64) (SparseIndex, error) {
 	}
 
 	limit := offset + size
+	reader := newOffsetReader(fs, offset)
 	sparseIndex := SparseIndex{}
-	for offset < limit {
-		reader := newOffsetReader(fs, offset)
+	for reader.Offset() < limit {
 		ko, err := readKeyOffset(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -267,12 +267,11 @@ func loadSparseIndex(fs *FileSystem, offset, size int64) (SparseIndex, error) {
 			return SparseIndex{}, fmt.Errorf("failed to read sparse index entry in %s: %w", fs.Path(), err)
 		}
 		sparseIndex = append(sparseIndex, ko)
-		offset = reader.Offset()
 	}
 
-	if offset != limit {
+	if reader.Offset() != limit {
 		return SparseIndex{}, fmt.Errorf("mismatched sparse index size in %s: expected end at %d, but read until %d: %w",
-			fs.Path(), limit, offset, ErrMalFormedSSTable)
+			fs.Path(), limit, reader.Offset(), ErrMalFormedSSTable)
 	}
 
 	return sparseIndex, nil

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"os"
 	"testing"
@@ -661,4 +662,25 @@ func TestNewSSTableInvalidFooter(t *testing.T) {
 		_, err = NewSSTable(ctx, cfg, tx.log)
 		assert.ErrorIs(t, err, ErrMalFormedSSTable)
 	})
+}
+
+func TestLoadSparseIndexSizeMismatch(t *testing.T) {
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	key := Bytes("a")
+	off := int64(123)
+	buf := make([]byte, 8+len(key)+8)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(len(key)))
+	copy(buf[8:], key)
+	binary.BigEndian.PutUint64(buf[8+len(key):], uint64(off))
+
+	_, err := fs.Write(buf)
+	require.NoError(t, err)
+
+	_, err = loadSparseIndex(fs, 0, int64(len(buf)-1))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMalFormedSSTable)
+	assert.Contains(t, err.Error(), "mismatched sparse index size")
 }


### PR DESCRIPTION
## Summary
- reuse a single `offsetReader` when loading the sparse index
- iterate until the reader's offset reaches the size limit

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0bb7b27748325ac3197cbc119e78d