### PR TITLE
fix: validate empty sstable index

### DIFF
--- a/sstable.go
+++ b/sstable.go
@@ -219,6 +219,10 @@ func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, er
 	if err != nil {
 		return SStable{}, fmt.Errorf("failed to read footer from %s: %w", fs.Path(), err)
 	}
+	if f.indexSize == 0 {
+		errorf(ctx, "index size is zero in %s", fs.Path())
+		return SStable{}, ErrMalFormedSSTable
+	}
 	if f.indexOffset > uint64(tailOffset) || f.indexSize > uint64(tailOffset) {
 		errorf(ctx, "invalid footer values in %s: offset=%d size=%d tail=%d", fs.Path(), f.indexOffset, f.indexSize, tailOffset)
 		return SStable{}, ErrMalFormedSSTable

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -668,41 +668,33 @@ func TestNewSSTableEmptyIndex(t *testing.T) {
 	cfg := testConfig()
 
 	tests := []struct {
-		name        string
-		data        []byte
-		indexOffset uint64
+		name string
+		data []byte
 	}{
 		{
-			name:        "OnlyFooter",
-			data:        nil,
-			indexOffset: 0,
+			name: "OnlyFooter",
+			data: nil,
 		},
 		{
-			name:        "DataWithoutIndex",
-			data:        []byte("data"),
-			indexOffset: uint64(len("data")),
+			name: "DataWithoutIndex",
+			data: []byte("data"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fss, closer := initTempFileSystems(t, 1, nil)
-			defer closer()
-			fs := fss[0]
+			tx, cleanup := newFileTx(t)
+			defer cleanup()
 
 			if tt.data != nil {
-				_, err := fs.Write(tt.data)
+				_, err := tx.write(tt.data)
 				require.NoError(t, err)
 			}
 
-			buf := make([]byte, footerSize)
-			byteOrder.PutUint64(buf[0:8], tt.indexOffset)
-			byteOrder.PutUint64(buf[8:16], 0)
-			byteOrder.PutUint64(buf[40:48], magicNumber)
-			_, err := fs.Write(buf)
+			err := writeFooter(tx, footer{indexOffset: uint64(len(tt.data)), indexSize: 0, magic: magicNumber})
 			require.NoError(t, err)
 
-			_, err = NewSSTable(ctx, cfg, fs)
+			_, err = NewSSTable(ctx, cfg, tx.log)
 			assert.ErrorIs(t, err, ErrMalFormedSSTable)
 		})
 	}

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -662,3 +662,48 @@ func TestNewSSTableInvalidFooter(t *testing.T) {
 		assert.ErrorIs(t, err, ErrMalFormedSSTable)
 	})
 }
+
+func TestNewSSTableEmptyIndex(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+
+	tests := []struct {
+		name        string
+		data        []byte
+		indexOffset uint64
+	}{
+		{
+			name:        "OnlyFooter",
+			data:        nil,
+			indexOffset: 0,
+		},
+		{
+			name:        "DataWithoutIndex",
+			data:        []byte("data"),
+			indexOffset: uint64(len("data")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fss, closer := initTempFileSystems(t, 1, nil)
+			defer closer()
+			fs := fss[0]
+
+			if tt.data != nil {
+				_, err := fs.Write(tt.data)
+				require.NoError(t, err)
+			}
+
+			buf := make([]byte, footerSize)
+			byteOrder.PutUint64(buf[0:8], tt.indexOffset)
+			byteOrder.PutUint64(buf[8:16], 0)
+			byteOrder.PutUint64(buf[40:48], magicNumber)
+			_, err := fs.Write(buf)
+			require.NoError(t, err)
+
+			_, err = NewSSTable(ctx, cfg, fs)
+			assert.ErrorIs(t, err, ErrMalFormedSSTable)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- ensure `NewSSTable` rejects footers with zero index size
- test that SSTable files missing an index return `ErrMalFormedSSTable`

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0bc0618848325a28bbecf4288692e