### PR TITLE
fix: prevent sstable reads past data section

### DIFF
--- a/sstable.go
+++ b/sstable.go
@@ -36,6 +36,7 @@ type SStable struct {
 	*FileSystem
 	SparseIndex SparseIndex
 	Bloom       *BloomFilter
+	dataEnd     int64
 }
 
 func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, error) {
@@ -83,7 +84,7 @@ func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, er
 	}
 
 	info(ctx, "Successfully created SSTable at %s with %d sparse index entries", fs.Path(), len(sparseIndex))
-	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom}, nil
+	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom, dataEnd: int64(f.indexOffset)}, nil
 }
 
 func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
@@ -127,6 +128,9 @@ func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes,
 
 	reader := newOffsetReader(s.FileSystem, offset)
 	for {
+		if reader.Offset() >= s.dataEnd {
+			return nil, ErrKeyNotFound
+		}
 		record, err := ReadRecord(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -168,7 +168,7 @@ func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, meta fileMeta,
 	}
 
 	b.built = true
-	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom}
+	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom, dataEnd: indexOffset}
 	num, nerr := fileNum(b.fs.Path())
 	if nerr != nil {
 		err = fmt.Errorf("invalid sstable path %s: %w", b.fs.Path(), nerr)


### PR DESCRIPTION
## Summary
- track the start of the index block in every SSTable and expose it as `dataEnd`
- stop `SStable.GetValue` from reading beyond the data section when the searched key is greater than any table key

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`
- `timeout 70s make diffharness-local`

------
https://chatgpt.com/codex/tasks/task_e_68c2370d9b2c8325ba0d86d96f85ccda