### PR TITLE
refactor: optimize io handling

### DIFF
--- a/internal_key.go
+++ b/internal_key.go
@@ -3,6 +3,7 @@ package rindb
 import (
 	"bytes"
 	"cmp"
+	"encoding/binary"
 	"fmt"
 )
 
@@ -32,7 +33,7 @@ func EncodeInternalKey(key Bytes, seq uint64, typ RecordType) []byte {
 	internalKey := make([]byte, len(key)+internalKeySuffixLen)
 	copy(internalKey, key)
 	var seqBuf [seqNumBytes]byte
-	byteOrder.PutUint64(seqBuf[:], ^seq)
+	binary.BigEndian.PutUint64(seqBuf[:], ^seq)
 	copy(internalKey[len(key):], seqBuf[:])
 	internalKey[len(key)+seqNumBytes] = byte(typ)
 	return internalKey
@@ -49,7 +50,7 @@ func DecodeInternalKey(ikey Bytes) (Bytes, uint64, RecordType, error) {
 		userKey = nil
 	}
 
-	seq := ^byteOrder.Uint64(ikey[userKeyEnd : userKeyEnd+seqNumBytes])
+	seq := ^binary.BigEndian.Uint64(ikey[userKeyEnd : userKeyEnd+seqNumBytes])
 	typ := RecordType(ikey[len(ikey)-1])
 	return userKey, seq, typ, nil
 }

--- a/io.go
+++ b/io.go
@@ -5,10 +5,24 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 )
 
-// Use BigEndian for consistent cross-platform encoding/decoding
-var byteOrder = binary.BigEndian
+var bufPool = sync.Pool{New: func() any {
+	b := make([]byte, 1<<16)
+	return &b
+}}
+
+func getBuf(n int) []byte {
+	p := bufPool.Get().(*[]byte)
+	if cap(*p) < n {
+		b := make([]byte, n)
+		*p = b
+	}
+	return (*p)[:n]
+}
+
+func putBuf(b []byte) { bufPool.Put(&b) }
 
 const (
 	mdByteSize   = 8
@@ -22,7 +36,7 @@ func readNumber(storage io.Reader) (uint64, error) {
 	if _, err := io.ReadFull(storage, numBytes[:]); err != nil {
 		return 0, err
 	}
-	return byteOrder.Uint64(numBytes[:]), nil
+	return binary.BigEndian.Uint64(numBytes[:]), nil
 }
 
 func readRecord(storage io.Reader) (Record, error) {
@@ -38,10 +52,13 @@ func readRecord(storage io.Reader) (Record, error) {
 
 	var internalKeyBytes Bytes
 	if internalKeyLen > 0 {
-		internalKeyBytes = make(Bytes, internalKeyLen)
-		if _, err := io.ReadFull(storage, internalKeyBytes); err != nil {
+		ikey := getBuf(int(internalKeyLen))
+		defer putBuf(ikey)
+		if _, err := io.ReadFull(storage, ikey[:internalKeyLen]); err != nil {
 			return nil, fmt.Errorf("failed to read internal key bytes: %w", err)
 		}
+		internalKeyBytes = make(Bytes, internalKeyLen)
+		copy(internalKeyBytes, ikey[:internalKeyLen])
 	}
 
 	userKey, seq, typ, err := DecodeInternalKey(internalKeyBytes)
@@ -51,17 +68,20 @@ func readRecord(storage io.Reader) (Record, error) {
 
 	var valueBytes Bytes
 	if valueLen > 0 {
-		valueBytes = make(Bytes, valueLen)
-		if _, err := io.ReadFull(storage, valueBytes); err != nil {
+		val := getBuf(int(valueLen))
+		defer putBuf(val)
+		if _, err := io.ReadFull(storage, val[:valueLen]); err != nil {
 			return nil, fmt.Errorf("failed to read value bytes: %w", err)
 		}
+		valueBytes = make(Bytes, valueLen)
+		copy(valueBytes, val[:valueLen])
 	}
 
 	var checksumBytes [checksumSize]byte
 	if _, err := io.ReadFull(storage, checksumBytes[:]); err != nil {
 		return nil, fmt.Errorf("failed to read checksum: %w", err)
 	}
-	expected := byteOrder.Uint32(checksumBytes[:])
+	expected := binary.BigEndian.Uint32(checksumBytes[:])
 	if actual := checksum(internalKeyBytes, valueBytes); actual != expected {
 		return nil, ErrChecksumMismatch
 	}
@@ -76,7 +96,7 @@ func readRecord(storage io.Reader) (Record, error) {
 
 func writeNumber(tx *transaction, number uint64) error {
 	numBytes := [mdByteSize]byte{}
-	byteOrder.PutUint64(numBytes[:], number)
+	binary.BigEndian.PutUint64(numBytes[:], number)
 	if _, err := tx.write(numBytes[:]); err != nil {
 		return fmt.Errorf("failed to write number bytes: %w", err)
 	}
@@ -106,7 +126,7 @@ func writeRecord(tx *transaction, record Record) error {
 	}
 
 	var checksumBytes [checksumSize]byte
-	byteOrder.PutUint32(checksumBytes[:], checksum)
+	binary.BigEndian.PutUint32(checksumBytes[:], checksum)
 	if _, err := tx.write(checksumBytes[:]); err != nil {
 		return fmt.Errorf("failed to write checksum: %w", err)
 	}

--- a/io_test.go
+++ b/io_test.go
@@ -3,6 +3,7 @@ package rindb
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -38,7 +39,7 @@ func newFileTx(t *testing.T) (*transaction, func()) {
 
 func writeNumberBuf(buf *bytes.Buffer, n uint64) {
 	var b [mdByteSize]byte
-	byteOrder.PutUint64(b[:], n)
+	binary.BigEndian.PutUint64(b[:], n)
 	buf.Write(b[:])
 }
 
@@ -211,7 +212,7 @@ func BenchmarkReadRecord(b *testing.B) {
 	// Write checksum
 	var checksumBytes [checksumSize]byte
 	chk := checksum(ikey, val)
-	byteOrder.PutUint32(checksumBytes[:], chk)
+	binary.BigEndian.PutUint32(checksumBytes[:], chk)
 	buf.Write(checksumBytes[:])
 
 	recordBytes := buf.Bytes()

--- a/manifest.go
+++ b/manifest.go
@@ -3,6 +3,7 @@ package rindb
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/gob"
 	"errors"
 	"fmt"
@@ -65,9 +66,9 @@ func (w *fileManifestWriter) Append(edit versionEdit) error {
 	}
 	data := w.buf.Bytes()
 	var header [manifestRecordHeaderSize]byte
-	byteOrder.PutUint64(header[0:manifestRecordLengthSize], uint64(len(data)))
+	binary.BigEndian.PutUint64(header[0:manifestRecordLengthSize], uint64(len(data)))
 	crc := checksum(data)
-	byteOrder.PutUint32(header[manifestRecordLengthSize:], crc)
+	binary.BigEndian.PutUint32(header[manifestRecordLengthSize:], crc)
 	if _, err := w.fs.Write(header[:]); err != nil {
 		return err
 	}
@@ -95,11 +96,11 @@ func (r *fileManifestReader) Next() (versionEdit, error) {
 	if _, err := io.ReadFull(r.fs, header[:]); err != nil {
 		return versionEdit{}, err
 	}
-	n := byteOrder.Uint64(header[0:manifestRecordLengthSize])
+	n := binary.BigEndian.Uint64(header[0:manifestRecordLengthSize])
 	if n > uint64(math.MaxInt) {
 		return versionEdit{}, fmt.Errorf("manifest record size %d exceeds max slice size on this architecture", n)
 	}
-	crc := byteOrder.Uint32(header[manifestRecordLengthSize:])
+	crc := binary.BigEndian.Uint32(header[manifestRecordLengthSize:])
 	data := make([]byte, int(n))
 	if _, err := io.ReadFull(r.fs, data); err != nil {
 		return versionEdit{}, err

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"math"
 	"os"
@@ -92,8 +93,8 @@ func TestManifest(t *testing.T) {
 		f, err := os.Create(mf)
 		require.NoError(t, err)
 		var header [manifestRecordHeaderSize]byte
-		byteOrder.PutUint64(header[0:manifestRecordLengthSize], uint64(math.MaxInt)+1)
-		byteOrder.PutUint32(header[manifestRecordLengthSize:], 0)
+		binary.BigEndian.PutUint64(header[0:manifestRecordLengthSize], uint64(math.MaxInt)+1)
+		binary.BigEndian.PutUint32(header[manifestRecordLengthSize:], 0)
 		_, err = f.Write(header[:])
 		require.NoError(t, err)
 		require.NoError(t, f.Close())

--- a/sstable_footer.go
+++ b/sstable_footer.go
@@ -1,6 +1,9 @@
 package rindb
 
-import "fmt"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 // footer layout: |8 index offset|8 index size|24 padding|8 magic|
 type footer struct {
@@ -12,9 +15,9 @@ type footer struct {
 
 func writeFooter(tx *transaction, f footer) error {
 	var buf [footerSize]byte
-	byteOrder.PutUint64(buf[0:8], f.indexOffset)
-	byteOrder.PutUint64(buf[8:16], f.indexSize)
-	byteOrder.PutUint64(buf[40:48], f.magic)
+	binary.BigEndian.PutUint64(buf[0:8], f.indexOffset)
+	binary.BigEndian.PutUint64(buf[8:16], f.indexSize)
+	binary.BigEndian.PutUint64(buf[40:48], f.magic)
 	if _, err := tx.write(buf[:]); err != nil {
 		return fmt.Errorf("failed to write footer: %w", err)
 	}
@@ -28,14 +31,14 @@ func readFooter(fs *FileSystem, off int64) (footer, error) {
 		return f, err
 	}
 
-	f.indexOffset = byteOrder.Uint64(buf[0:8])
-	f.indexSize = byteOrder.Uint64(buf[8:16])
+	f.indexOffset = binary.BigEndian.Uint64(buf[0:8])
+	f.indexSize = binary.BigEndian.Uint64(buf[8:16])
 	for i := 16; i < 40; i += 8 {
-		if byteOrder.Uint64(buf[i:i+8]) != 0 {
+		if binary.BigEndian.Uint64(buf[i:i+8]) != 0 {
 			return f, ErrMalFormedSSTable
 		}
 	}
-	f.magic = byteOrder.Uint64(buf[40:48])
+	f.magic = binary.BigEndian.Uint64(buf[40:48])
 	if f.magic != magicNumber {
 		return f, ErrMalFormedSSTable
 	}

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"io"
 	"sort"
@@ -51,7 +52,7 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	if _, err := s.FileSystem.ReadAt(buf, tailOffset); err != nil {
 		return nil, err
 	}
-	dataEnd := int64(byteOrder.Uint64(buf))
+	dataEnd := int64(binary.BigEndian.Uint64(buf))
 
 	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd}, nil
 }

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -991,9 +991,9 @@ func TestNewSSTable_IndexBlockOutOfBounds(t *testing.T) {
 	defer file.Close()
 
 	var buf [footerSize]byte
-	byteOrder.PutUint64(buf[0:8], f.indexOffset)
-	byteOrder.PutUint64(buf[8:16], f.indexSize+1)
-	byteOrder.PutUint64(buf[40:48], magicNumber)
+	binary.BigEndian.PutUint64(buf[0:8], f.indexOffset)
+	binary.BigEndian.PutUint64(buf[8:16], f.indexSize+1)
+	binary.BigEndian.PutUint64(buf[40:48], magicNumber)
 	_, err = file.WriteAt(buf[:], tail)
 	require.NoError(t, err)
 
@@ -1027,7 +1027,7 @@ func TestNewSSTable_LoadSparseIndexFailure(t *testing.T) {
 
 	const oversizedKeyLen = 1 << 20 // 1 MiB
 	var keyLen [8]byte
-	byteOrder.PutUint64(keyLen[:], oversizedKeyLen)
+	binary.BigEndian.PutUint64(keyLen[:], oversizedKeyLen)
 	_, err = file.WriteAt(keyLen[:], int64(f.indexOffset))
 	require.NoError(t, err)
 

--- a/wal_test.go
+++ b/wal_test.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -37,8 +38,8 @@ func validateWALFormat(t *testing.T, file io.ReadSeeker) {
 		_, err = io.ReadFull(file, valueLenBytes[:])
 		assert.NoError(t, err)
 
-		keyLen := byteOrder.Uint64(keyLenBytes[:])
-		valueLen := byteOrder.Uint64(valueLenBytes[:])
+		keyLen := binary.BigEndian.Uint64(keyLenBytes[:])
+		valueLen := binary.BigEndian.Uint64(valueLenBytes[:])
 
 		// The internal key must at least contain the sequence number
 		// and type information.
@@ -71,7 +72,7 @@ func validateWALFormat(t *testing.T, file io.ReadSeeker) {
 		checksumBytes := [checksumSize]byte{}
 		_, err = io.ReadFull(file, checksumBytes[:])
 		assert.NoError(t, err)
-		expected := byteOrder.Uint32(checksumBytes[:])
+		expected := binary.BigEndian.Uint32(checksumBytes[:])
 		actual := checksum(keyBytes, valueBytes)
 		assert.Equal(t, expected, actual)
 


### PR DESCRIPTION
## Summary
- reuse scratch buffers for record reads via `sync.Pool`
- inline big-endian operations by removing `byteOrder` interface dispatch

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c383f647ac8325aff173820ad9d2ac