### PR TITLE
fix: improve range invariant check and offset reader semantics

### DIFF
--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -448,7 +448,8 @@ func (h *Harness) checkInvariants(ctx context.Context, r *rand.Rand, cfg Cfg) er
 		}
 
 		if len(left) < cfg.RangeMax && len(right) < cfg.RangeMax {
-			full, err := h.My.Range(ctx, lo, hi, snap, cfg.RangeMax*2)
+			limit := len(left) + len(right) + 1
+			full, err := h.My.Range(ctx, lo, hi, snap, limit)
 			if err != nil {
 				return err
 			}
@@ -457,7 +458,7 @@ func (h *Harness) checkInvariants(ctx context.Context, r *rand.Rand, cfg Cfg) er
 				return fmt.Errorf("range concat: %w", err)
 			}
 			// Compare full range with reference only when not truncated
-			f2, err := h.Ref.RangeWithSeq(lo, hi, snap, cfg.RangeMax*2)
+			f2, err := h.Ref.RangeWithSeq(lo, hi, snap, limit)
 			if err != nil {
 				return err
 			}

--- a/offset_reader.go
+++ b/offset_reader.go
@@ -10,16 +10,11 @@ func newOffsetReader(fs *FileSystem, off int64) *offsetReader {
 }
 
 func (r *offsetReader) Read(p []byte) (int, error) {
-	orig := r.offset
-	n, err := r.fs.ReadAt(p, orig)
-	if err != nil {
-		r.offset = orig
-		return n, err
-	}
+	n, err := r.fs.ReadAt(p, r.offset)
 	if n > 0 {
-		r.offset = orig + int64(n)
+		r.offset += int64(n)
 	}
-	return n, nil
+	return n, err
 }
 
 func (r *offsetReader) Offset() int64 {

--- a/offset_reader_test.go
+++ b/offset_reader_test.go
@@ -21,7 +21,7 @@ func TestOffsetReader_Read(t *testing.T) {
 		assert.Equal(t, int64(5), r.Offset())
 	})
 
-	t.Run("partial read leaves offset unchanged", func(t *testing.T) {
+	t.Run("partial read advances offset", func(t *testing.T) {
 		fss, closer := initTempFileSystems(t, 1, [][]byte{[]byte("hello")})
 		defer closer()
 
@@ -30,7 +30,7 @@ func TestOffsetReader_Read(t *testing.T) {
 		n, err := r.Read(buf)
 		assert.ErrorIs(t, err, io.EOF)
 		assert.Equal(t, 5, n)
-		assert.Equal(t, int64(0), r.Offset())
+		assert.Equal(t, int64(5), r.Offset())
 	})
 
 	t.Run("read error leaves offset unchanged", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- prevent truncated range invariant comparisons by sizing the full-range limit
- advance offset after partial reads and update tests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4047d9d108325b9d3f1c1db7ac818