### PR TITLE
feat: support reverse range scanning

### DIFF
--- a/docs/dev/54/overall_plan.md
+++ b/docs/dev/54/overall_plan.md
@@ -18,7 +18,6 @@ func NewMergingIterator(iterators []BiIterator[Record], reverse bool, cleanup fu
     less := func(a, b pqItem) bool {
         cmp := a.rec.GetKey().Compare(b.rec.GetKey())
         if cmp == CmpEqual {
-            if reverse { return a.rec.GetSequenceNumber() < b.rec.GetSequenceNumber() }
             return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
         }
         if reverse { return cmp == CmpGreater }

--- a/docs/dev/54/overall_plan.md
+++ b/docs/dev/54/overall_plan.md
@@ -1,0 +1,87 @@
+# Support Reverse Range Scanning
+
+1. **Introduce bi-directional iterator contracts**
+   - Extend the minimal `Iterator` to optionally move backwards.
+```go
+// Iterator now supports symmetric traversal.
+type BiIterator[T any] interface {
+    HasNext() bool
+    Next() (T, error)
+    HasPrev() bool
+    Prev() (T, error)
+}
+```
+2. **Allow `MergingIterator` to order items descending**
+   - Add a `reverse bool` flag and adjust the priority queue comparator.
+```go
+func NewMergingIterator(iterators []BiIterator[Record], reverse bool, cleanup func()) (*MergingIterator, error) {
+    less := func(a, b pqItem) bool {
+        cmp := a.rec.GetKey().Compare(b.rec.GetKey())
+        if cmp == CmpEqual {
+            if reverse { return a.rec.GetSequenceNumber() < b.rec.GetSequenceNumber() }
+            return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
+        }
+        if reverse { return cmp == CmpGreater }
+        return cmp == CmpLess
+    }
+    pq := NewPriorityQueue(less)
+    // prime heap with first/last record depending on direction
+    for _, it := range iterators {
+        if reverse && it.HasPrev() {
+            rec, _ := it.Prev()
+            pq.PushItem(pqItem{rec: rec, iter: it})
+        } else if it.HasNext() {
+            rec, _ := it.Next()
+            pq.PushItem(pqItem{rec: rec, iter: it})
+        }
+    }
+    return &MergingIterator{pq: pq, reverse: reverse, cleanup: cleanup}, nil
+}
+```
+3. **Implement reverse-range readers for Memtable and SSTable**
+   - Provide `IRangeReverse` which positions iterators at the end key and walks backwards.
+```go
+// Memtable
+func (m *memtable) IRangeReverse(start, end Bytes, seq uint64) Iterator[Record] {
+    startKey := InternalKey{UserKey: start, Seq: 0, Type: TypeMerge}
+    endKey   := InternalKey{UserKey: end,   Seq: math.MaxUint64, Type: TypeValue}
+    it := m.data.IRangeReverse(endKey, startKey)
+    return &memtableIRange{it: it, seq: seq}
+}
+
+// SSTable
+func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (Iterator[Record], error) {
+    // locate initial block using sparse index then seek backwards
+    idx := sort.Search(len(s.SparseIndex), func(i int) bool { return s.SparseIndex[i].key.Compare(end) > 0 })
+    offset := s.SparseIndex[idx-1].offset
+    return &sstableIRangeRev{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: offset}, nil
+}
+```
+4. **Expose descending scans in public APIs**
+   - Add `IRangeReverse` to `Rindb` and `Snapshot`; `RangeIterator` becomes direction-aware.
+```go
+func (r *Rindb) IRangeReverse(ctx context.Context, start, end Bytes, seq ...uint64) (*RangeIterator, error) {
+    iterators := []BiIterator[Record]{r.Memtable.IRangeReverse(start, end, maxSeq)}
+    // gather SSTables...
+    mi, err := NewMergingIterator(iterators, true, cleanup)
+    if err != nil { return nil, err }
+    return NewRangeIterator(mi, true), nil
+}
+```
+5. **Add comprehensive tests**
+   - Validate backward traversal across memtable, SSTable, and high-level API.
+```go
+func TestIRangeReverse(t *testing.T) {
+    db := openTestDB(t)
+    // write keys a..e, then scan [e,a]
+    iter, err := db.IRangeReverse(ctx, Bytes("a"), Bytes("e"))
+    require.NoError(t, err)
+    expect := []string{"e","d","c","b","a"}
+    for _, k := range expect {
+        r, _ := iter.Next()
+        assert.Equal(t, k, string(r.GetKey()))
+    }
+    _, err = iter.Next()
+    assert.ErrorIs(t, err, EOI)
+}
+```

--- a/docs/dev/54/overall_plan.md
+++ b/docs/dev/54/overall_plan.md
@@ -42,7 +42,7 @@ func NewMergingIterator(iterators []BiIterator[Record], reverse bool, cleanup fu
    - Provide `IRangeReverse` which positions iterators at the end key and walks backwards.
 ```go
 // Memtable
-func (m *memtable) IRangeReverse(start, end Bytes, seq uint64) Iterator[Record] {
+func (m *memtable) IRangeReverse(start, end Bytes, seq uint64) BiIterator[Record] {
     startKey := InternalKey{UserKey: start, Seq: 0, Type: TypeMerge}
     endKey   := InternalKey{UserKey: end,   Seq: math.MaxUint64, Type: TypeValue}
     it := m.data.IRangeReverse(endKey, startKey)
@@ -50,7 +50,7 @@ func (m *memtable) IRangeReverse(start, end Bytes, seq uint64) Iterator[Record] 
 }
 
 // SSTable
-func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (Iterator[Record], error) {
+func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (BiIterator[Record], error) {
     // locate initial block using sparse index then seek backwards
     idx := sort.Search(len(s.SparseIndex), func(i int) bool { return s.SparseIndex[i].key.Compare(end) > 0 })
     offset := s.SparseIndex[idx-1].offset
@@ -58,14 +58,14 @@ func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (Iterator[Record
 }
 ```
 4. **Expose descending scans in public APIs**
-   - Add `IRangeReverse` to `Rindb` and `Snapshot`; `RangeIterator` becomes direction-aware.
+   - Add `IRangeReverse` to `Rindb` and `Snapshot`; reuse `RangeIterator` for both directions.
 ```go
 func (r *Rindb) IRangeReverse(ctx context.Context, start, end Bytes, seq ...uint64) (*RangeIterator, error) {
     iterators := []BiIterator[Record]{r.Memtable.IRangeReverse(start, end, maxSeq)}
     // gather SSTables...
     mi, err := NewMergingIterator(iterators, true, cleanup)
     if err != nil { return nil, err }
-    return NewRangeIterator(mi, true), nil
+    return NewRangeIterator(mi), nil
 }
 ```
 5. **Add comprehensive tests**

--- a/docs/dev/54/overall_plan.md
+++ b/docs/dev/54/overall_plan.md
@@ -3,7 +3,6 @@
 1. **Introduce bi-directional iterator contracts**
    - Extend the minimal `Iterator` to optionally move backwards.
 ```go
-// Iterator now supports symmetric traversal.
 type BiIterator[T any] interface {
     HasNext() bool
     Next() (T, error)
@@ -11,6 +10,11 @@ type BiIterator[T any] interface {
     Prev() (T, error)
 }
 ```
+   - **Cursor semantics:** `Next` and `Prev` maintain independent cursors.
+     Calling `Prev` after `Next` does **not** return the element preceding the
+     last `Next` result; instead `Prev` iterates from the end of the range.  A
+     `BiIterator` is therefore expected to be consumed in a single direction per
+     use.
 2. **Allow `MergingIterator` to order items descending**
    - Add a `reverse bool` flag and adjust the priority queue comparator.
 ```go

--- a/io.go
+++ b/io.go
@@ -74,37 +74,37 @@ func readRecord(storage io.Reader) (Record, error) {
 	}, nil
 }
 
-// readRecordMeta reads only the internal key and skips the value and checksum.
-// The reader must be an *offsetReader so its offset can be advanced without
-// reading the skipped bytes.
-func readRecordMeta(r *offsetReader) (Bytes, uint64, error) {
+// readRecordMeta reads the internal key and returns metadata needed to later
+// reconstruct the record without re-reading the key. The reader must be an
+// *offsetReader so its offset can be advanced without reading the skipped
+// value and checksum bytes.
+func readRecordMeta(r *offsetReader) (key Bytes, seq uint64, typ RecordType, valueOff int64, valueLen uint64, err error) {
 	internalKeyLen, err := readNumber(r)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to read internal key length: %w", err)
+		return nil, 0, 0, 0, 0, fmt.Errorf("failed to read internal key length: %w", err)
 	}
 
-	valueLen, err := readNumber(r)
+	valueLen, err = readNumber(r)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to read value length: %w", err)
+		return nil, 0, 0, 0, 0, fmt.Errorf("failed to read value length: %w", err)
 	}
 
 	var internalKeyBytes Bytes
 	if internalKeyLen > 0 {
 		internalKeyBytes = make(Bytes, internalKeyLen)
 		if _, err := io.ReadFull(r, internalKeyBytes); err != nil {
-			return nil, 0, fmt.Errorf("failed to read internal key bytes: %w", err)
+			return nil, 0, 0, 0, 0, fmt.Errorf("failed to read internal key bytes: %w", err)
 		}
 	}
 
-	userKey, seq, _, err := DecodeInternalKey(internalKeyBytes)
+	key, seq, typ, err = DecodeInternalKey(internalKeyBytes)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, 0, 0, err
 	}
 
-	// Skip value and checksum bytes since they're not needed for range checks.
+	valueOff = r.Offset()
 	r.offset += int64(valueLen) + checksumSize
-
-	return userKey, seq, nil
+	return key, seq, typ, valueOff, valueLen, nil
 }
 
 func writeNumber(tx *transaction, number uint64) error {

--- a/io.go
+++ b/io.go
@@ -74,6 +74,39 @@ func readRecord(storage io.Reader) (Record, error) {
 	}, nil
 }
 
+// readRecordMeta reads only the internal key and skips the value and checksum.
+// The reader must be an *offsetReader so its offset can be advanced without
+// reading the skipped bytes.
+func readRecordMeta(r *offsetReader) (Bytes, uint64, error) {
+	internalKeyLen, err := readNumber(r)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read internal key length: %w", err)
+	}
+
+	valueLen, err := readNumber(r)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read value length: %w", err)
+	}
+
+	var internalKeyBytes Bytes
+	if internalKeyLen > 0 {
+		internalKeyBytes = make(Bytes, internalKeyLen)
+		if _, err := io.ReadFull(r, internalKeyBytes); err != nil {
+			return nil, 0, fmt.Errorf("failed to read internal key bytes: %w", err)
+		}
+	}
+
+	userKey, seq, _, err := DecodeInternalKey(internalKeyBytes)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Skip value and checksum bytes since they're not needed for range checks.
+	r.offset += int64(valueLen) + checksumSize
+
+	return userKey, seq, nil
+}
+
 func writeNumber(tx *transaction, number uint64) error {
 	numBytes := [mdByteSize]byte{}
 	byteOrder.PutUint64(numBytes[:], number)

--- a/io.go
+++ b/io.go
@@ -103,7 +103,9 @@ func readRecordMeta(r *offsetReader) (key Bytes, seq uint64, typ RecordType, val
 	}
 
 	valueOff = r.Offset()
-	r.offset += int64(valueLen) + checksumSize
+	if _, err := io.CopyN(io.Discard, r, int64(valueLen)+checksumSize); err != nil {
+		return nil, 0, 0, 0, 0, fmt.Errorf("failed to skip value and checksum: %w", err)
+	}
 	return key, seq, typ, valueOff, valueLen, nil
 }
 

--- a/io_test.go
+++ b/io_test.go
@@ -225,3 +225,18 @@ func BenchmarkReadRecord(b *testing.B) {
 		}
 	}
 }
+
+func TestReadRecordMetaSkipError(t *testing.T) {
+	ikey := EncodeInternalKey(Bytes("k"), 1, TypeValue)
+	var buf bytes.Buffer
+	writeNumberBuf(&buf, uint64(len(ikey)))
+	writeNumberBuf(&buf, 1)
+	buf.Write(ikey)
+
+	fss, closer := initTempFileSystems(t, 1, [][]byte{buf.Bytes()})
+	defer closer()
+	reader := newOffsetReader(fss[0], 0)
+	_, _, _, _, _, err := readRecordMeta(reader)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to skip value and checksum")
+}

--- a/iterator.go
+++ b/iterator.go
@@ -14,3 +14,78 @@ type Iterator[T any] interface {
 	HasNext() bool
 	Next() (T, error)
 }
+
+// BiIterator extends Iterator with optional backward traversal support.
+// Implementations that are forward-only can embed Iterator and have HasPrev
+// return false while Prev returns EOI.
+type BiIterator[T any] interface {
+	Iterator[T]
+	HasPrev() bool
+	Prev() (T, error)
+}
+
+// forwardIterator adapts a forward-only Iterator into a BiIterator.
+type forwardIterator[T any] struct {
+	Iterator[T]
+}
+
+// HasPrev implements BiIterator for forwardIterator.
+func (f *forwardIterator[T]) HasPrev() bool { return false }
+
+// Prev implements BiIterator for forwardIterator.
+func (f *forwardIterator[T]) Prev() (T, error) {
+	var zero T
+	return zero, EOI
+}
+
+// asBiIterator ensures the provided iterator satisfies BiIterator by
+// wrapping forward-only implementations.
+func asBiIterator[T any](it Iterator[T]) BiIterator[T] {
+	if bi, ok := any(it).(BiIterator[T]); ok {
+		return bi
+	}
+	return &forwardIterator[T]{Iterator: it}
+}
+
+// sliceBiIterator iterates over a fixed slice in both directions.
+type sliceBiIterator[T any] struct {
+	items   []T
+	nextIdx int
+	prevIdx int
+}
+
+// newSliceBiIterator constructs a bidirectional iterator over the provided slice.
+func newSliceBiIterator[T any](items []T) *sliceBiIterator[T] {
+	return &sliceBiIterator[T]{items: items, nextIdx: 0, prevIdx: len(items)}
+}
+
+// HasNext implements Iterator.
+func (s *sliceBiIterator[T]) HasNext() bool {
+	return s.nextIdx < len(s.items)
+}
+
+// Next implements Iterator.
+func (s *sliceBiIterator[T]) Next() (T, error) {
+	if !s.HasNext() {
+		var zero T
+		return zero, EOI
+	}
+	item := s.items[s.nextIdx]
+	s.nextIdx++
+	return item, nil
+}
+
+// HasPrev implements BiIterator.
+func (s *sliceBiIterator[T]) HasPrev() bool {
+	return s.prevIdx > 0
+}
+
+// Prev implements BiIterator.
+func (s *sliceBiIterator[T]) Prev() (T, error) {
+	if !s.HasPrev() {
+		var zero T
+		return zero, EOI
+	}
+	s.prevIdx--
+	return s.items[s.prevIdx], nil
+}

--- a/memtable.go
+++ b/memtable.go
@@ -96,52 +96,100 @@ func (m *memtable) Iterator() Iterator[Record] {
 func (m *memtable) IRange(start, end Bytes, seq uint64) Iterator[Record] {
 	startKey := InternalKey{UserKey: start, Seq: math.MaxUint64, Type: TypeValue}
 	endKey := InternalKey{UserKey: end, Seq: 0, Type: TypeMerge}
-	it := m.data.IRange(startKey, endKey)
+	it := asBiIterator(m.data.IRange(startKey, endKey))
+	return &memtableIRange{it: it, seq: seq}
+}
+
+// IRangeReverse returns an iterator over records within [start, end] walking
+// backwards by key.
+func (m *memtable) IRangeReverse(start, end Bytes, seq uint64) BiIterator[Record] {
+	startKey := InternalKey{UserKey: start, Seq: math.MaxUint64, Type: TypeValue}
+	endKey := InternalKey{UserKey: end, Seq: 0, Type: TypeMerge}
+	it := asBiIterator(m.data.IRange(startKey, endKey))
 	return &memtableIRange{it: it, seq: seq}
 }
 
 type memtableIRange struct {
-	it       Iterator[Record]
-	seq      uint64
-	next     Record
-	prepared bool
-	err      error
+	it           BiIterator[Record]
+	seq          uint64
+	next         Record
+	nextPrepared bool
+	nextErr      error
+	prev         Record
+	prevPrepared bool
+	prevErr      error
 }
 
-func (mi *memtableIRange) prepare() {
-	for !mi.prepared && mi.err == nil {
+func (mi *memtableIRange) prepareNext() {
+	for !mi.nextPrepared && mi.nextErr == nil {
 		if !mi.it.HasNext() {
-			mi.err = EOI
+			mi.nextErr = EOI
 			return
 		}
 		rec, err := mi.it.Next()
 		if err != nil {
-			mi.err = err
+			mi.nextErr = err
 			return
 		}
 		if rec.GetSequenceNumber() > mi.seq {
 			continue
 		}
 		mi.next = rec
-		mi.prepared = true
+		mi.nextPrepared = true
 	}
 }
 
 func (mi *memtableIRange) HasNext() bool {
-	mi.prepare()
-	return mi.prepared
+	mi.prepareNext()
+	return mi.nextPrepared
 }
 
 func (mi *memtableIRange) Next() (Record, error) {
 	if !mi.HasNext() {
 		var empty Record
-		if mi.err != nil {
-			return empty, mi.err
+		if mi.nextErr != nil {
+			return empty, mi.nextErr
 		}
 		return empty, EOI
 	}
-	mi.prepared = false
+	mi.nextPrepared = false
 	return mi.next, nil
+}
+
+func (mi *memtableIRange) preparePrev() {
+	for !mi.prevPrepared && mi.prevErr == nil {
+		if !mi.it.HasPrev() {
+			mi.prevErr = EOI
+			return
+		}
+		rec, err := mi.it.Prev()
+		if err != nil {
+			mi.prevErr = err
+			return
+		}
+		if rec.GetSequenceNumber() > mi.seq {
+			continue
+		}
+		mi.prev = rec
+		mi.prevPrepared = true
+	}
+}
+
+func (mi *memtableIRange) HasPrev() bool {
+	mi.preparePrev()
+	return mi.prevPrepared
+}
+
+func (mi *memtableIRange) Prev() (Record, error) {
+	if !mi.HasPrev() {
+		var empty Record
+		if mi.prevErr != nil {
+			return empty, mi.prevErr
+		}
+		return empty, EOI
+	}
+	mi.prevPrepared = false
+	return mi.prev, nil
 }
 
 // Cleanup removes records with sequence numbers less than minSeq.

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -347,21 +347,19 @@ func TestMemtableIRange_Prepare(t *testing.T) {
 
 	t.Run("skip higher seq", func(t *testing.T) {
 		it := mem.IRange(Bytes("k"), Bytes("k"), 6)
-		mi, ok := it.(*memtableIRange)
-		assert.True(t, ok)
-
-		assert.True(t, mi.HasNext())
-		assert.Equal(t, uint64(5), mi.next.GetSequenceNumber())
-		assert.NoError(t, mi.nextErr)
+		require.True(t, it.HasNext())
+		rec, err := it.Next()
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), rec.GetSequenceNumber())
+		_, err = it.Next()
+		assert.ErrorIs(t, err, EOI)
 	})
 
 	t.Run("no matching seq", func(t *testing.T) {
 		it := mem.IRange(Bytes("k"), Bytes("k"), 4)
-		mi, ok := it.(*memtableIRange)
-		assert.True(t, ok)
-
-		assert.False(t, mi.HasNext())
-		assert.ErrorIs(t, mi.nextErr, EOI)
+		assert.False(t, it.HasNext())
+		_, err := it.Next()
+		assert.ErrorIs(t, err, EOI)
 	})
 }
 
@@ -417,4 +415,28 @@ func TestMemtableIRangeReverse(t *testing.T) {
 	assert.Equal(t, []string{"c", "b", "a"}, keys)
 	_, err := it.Prev()
 	assert.ErrorIs(t, err, EOI)
+}
+
+func TestMemtableIRangeReverse_PreparePrev(t *testing.T) {
+	cfg := testConfig()
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("k"), Bytes("v7"), 7))
+	mem.Put(newRecord(Bytes("k"), Bytes("v5"), 5))
+
+	t.Run("skip higher seq", func(t *testing.T) {
+		it := mem.IRangeReverse(Bytes("k"), Bytes("k"), 6)
+		require.True(t, it.HasPrev())
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		assert.Equal(t, uint64(5), rec.GetSequenceNumber())
+		_, err = it.Prev()
+		assert.ErrorIs(t, err, EOI)
+	})
+
+	t.Run("no matching seq", func(t *testing.T) {
+		it := mem.IRangeReverse(Bytes("k"), Bytes("k"), 4)
+		assert.False(t, it.HasPrev())
+		_, err := it.Prev()
+		assert.ErrorIs(t, err, EOI)
+	})
 }

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemtable_Basic(t *testing.T) {
@@ -349,10 +350,9 @@ func TestMemtableIRange_Prepare(t *testing.T) {
 		mi, ok := it.(*memtableIRange)
 		assert.True(t, ok)
 
-		mi.prepare()
-		assert.True(t, mi.prepared)
+		assert.True(t, mi.HasNext())
 		assert.Equal(t, uint64(5), mi.next.GetSequenceNumber())
-		assert.NoError(t, mi.err)
+		assert.NoError(t, mi.nextErr)
 	})
 
 	t.Run("no matching seq", func(t *testing.T) {
@@ -360,9 +360,8 @@ func TestMemtableIRange_Prepare(t *testing.T) {
 		mi, ok := it.(*memtableIRange)
 		assert.True(t, ok)
 
-		mi.prepare()
-		assert.False(t, mi.prepared)
-		assert.ErrorIs(t, mi.err, EOI)
+		assert.False(t, mi.HasNext())
+		assert.ErrorIs(t, mi.nextErr, EOI)
 	})
 }
 
@@ -399,4 +398,23 @@ func TestMemtableIRange_HasNextNext(t *testing.T) {
 	_, err := mi.Next()
 	assert.ErrorIs(t, err, EOI)
 	assert.False(t, mi.HasNext())
+}
+
+func TestMemtableIRangeReverse(t *testing.T) {
+	cfg := testConfig()
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("1"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("2"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("3"), 3))
+
+	it := mem.IRangeReverse(Bytes("a"), Bytes("c"), 3)
+	var keys []string
+	for it.HasPrev() {
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		keys = append(keys, string(rec.GetKey()))
+	}
+	assert.Equal(t, []string{"c", "b", "a"}, keys)
+	_, err := it.Prev()
+	assert.ErrorIs(t, err, EOI)
 }

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -1,7 +1,5 @@
 package rindb
 
-import "errors"
-
 type pqItem struct {
 	rec  Record
 	iter BiIterator[Record]
@@ -52,13 +50,10 @@ func NewMergingIterator(iterators []BiIterator[Record], reverse bool, cleanup fu
 			rec, err = it.Next()
 		}
 		if err != nil {
-			if !errors.Is(err, EOI) {
-				if cleanup != nil {
-					cleanup()
-				}
-				return nil, err
+			if cleanup != nil {
+				cleanup()
 			}
-			continue
+			return nil, err
 		}
 		pq.PushItem(pqItem{rec: rec, iter: it})
 	}
@@ -93,9 +88,7 @@ func (m *MergingIterator) prepare() {
 		}
 	}
 	if err != nil {
-		if !errors.Is(err, EOI) {
-			m.err = err
-		}
+		m.err = err
 	} else {
 		m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
 	}

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -26,9 +26,6 @@ func NewMergingIterator(iterators []BiIterator[Record], reverse bool, cleanup fu
 	less := func(a, b pqItem) bool {
 		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
 		if cmp == CmpEqual {
-			if reverse {
-				return a.rec.GetSequenceNumber() < b.rec.GetSequenceNumber()
-			}
 			return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
 		}
 		if reverse {

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -4,48 +4,69 @@ import "errors"
 
 type pqItem struct {
 	rec  Record
-	iter Iterator[Record]
+	iter BiIterator[Record]
 }
 
 // MergingIterator merges multiple iterators without deduplication. It yields
-// records ordered by key and sequence number (descending).
+// records ordered by key and sequence number (descending), optionally in
+// reverse key order when configured.
 type MergingIterator struct {
 	pq       *PriorityQueue[pqItem]
 	next     Record
 	prepared bool
 	cleanup  func()
 	err      error
+	reverse  bool
 }
 
 // NewMergingIterator constructs a MergingIterator over provided iterators.
-// The optional cleanup function is called when Close is invoked.
-func NewMergingIterator(iterators []Iterator[Record], cleanup func()) (*MergingIterator, error) {
+// If reverse is true, records are yielded in descending key order. The optional
+// cleanup function is called when Close is invoked.
+func NewMergingIterator(iterators []BiIterator[Record], reverse bool, cleanup func()) (*MergingIterator, error) {
 	less := func(a, b pqItem) bool {
 		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
 		if cmp == CmpEqual {
+			if reverse {
+				return a.rec.GetSequenceNumber() < b.rec.GetSequenceNumber()
+			}
 			return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
+		}
+		if reverse {
+			return cmp == CmpGreater
 		}
 		return cmp == CmpLess
 	}
 
 	pq := NewPriorityQueue(less)
 	for _, it := range iterators {
-		if it.HasNext() {
-			rec, err := it.Next()
-			if err != nil {
-				if !errors.Is(err, EOI) {
-					if cleanup != nil {
-						cleanup()
-					}
-					return nil, err
-				}
+		var (
+			rec Record
+			err error
+		)
+		if reverse {
+			if !it.HasPrev() {
 				continue
 			}
-			pq.PushItem(pqItem{rec: rec, iter: it})
+			rec, err = it.Prev()
+		} else {
+			if !it.HasNext() {
+				continue
+			}
+			rec, err = it.Next()
 		}
+		if err != nil {
+			if !errors.Is(err, EOI) {
+				if cleanup != nil {
+					cleanup()
+				}
+				return nil, err
+			}
+			continue
+		}
+		pq.PushItem(pqItem{rec: rec, iter: it})
 	}
 
-	return &MergingIterator{pq: pq, cleanup: cleanup}, nil
+	return &MergingIterator{pq: pq, cleanup: cleanup, reverse: reverse}, nil
 }
 
 func (m *MergingIterator) prepare() {
@@ -57,15 +78,29 @@ func (m *MergingIterator) prepare() {
 	m.next = item.rec
 	m.prepared = true
 
-	if item.iter.HasNext() {
-		rec, err := item.iter.Next()
-		if err != nil {
-			if !errors.Is(err, EOI) {
-				m.err = err
-			}
+	var (
+		rec Record
+		err error
+	)
+	if m.reverse {
+		if item.iter.HasPrev() {
+			rec, err = item.iter.Prev()
 		} else {
-			m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
+			return
 		}
+	} else {
+		if item.iter.HasNext() {
+			rec, err = item.iter.Next()
+		} else {
+			return
+		}
+	}
+	if err != nil {
+		if !errors.Is(err, EOI) {
+			m.err = err
+		}
+	} else {
+		m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
 	}
 }
 

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -27,6 +27,17 @@ func (e *errIterator) Next() (Record, error) {
 	return rec, nil
 }
 
+func (e *errIterator) HasPrev() bool { return e.idx > 0 }
+
+func (e *errIterator) Prev() (Record, error) {
+	if e.idx == 0 {
+		var empty Record
+		return empty, EOI
+	}
+	e.idx--
+	return e.records[e.idx], nil
+}
+
 func TestMergingIterator(t *testing.T) {
 	rec := func(k, v string, seq uint64, typ RecordType) Record {
 		var nv Bytes = nil
@@ -58,12 +69,12 @@ func TestMergingIterator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var iterators []Iterator[Record]
+			var iterators []BiIterator[Record]
 			for _, recs := range tt.iters {
 				iterators = append(iterators, &errIterator{records: recs, failIdx: -1})
 			}
 
-			mi, err := NewMergingIterator(iterators, nil)
+			mi, err := NewMergingIterator(iterators, false, nil)
 			assert.NoError(t, err)
 
 			var got []Record
@@ -77,10 +88,28 @@ func TestMergingIterator(t *testing.T) {
 	}
 }
 
+func TestMergingIteratorReverse(t *testing.T) {
+	rec := func(k string) Record { return newRecord(Bytes(k), nil, 1) }
+
+	it1 := &errIterator{records: []Record{rec("a"), rec("c")}, idx: 2, failIdx: -1}
+	it2 := &errIterator{records: []Record{rec("b")}, idx: 1, failIdx: -1}
+
+	mi, err := NewMergingIterator([]BiIterator[Record]{it1, it2}, true, nil)
+	assert.NoError(t, err)
+
+	var got []string
+	for mi.HasNext() {
+		r, err := mi.Next()
+		assert.NoError(t, err)
+		got = append(got, string(r.GetKey()))
+	}
+	assert.Equal(t, []string{"c", "b", "a"}, got)
+}
+
 func TestMergingIteratorInitialError(t *testing.T) {
 	r := newRecord(Bytes("a"), Bytes("1"), 1)
 	it := &errIterator{records: []Record{r}, failIdx: 0}
-	mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
+	mi, err := NewMergingIterator([]BiIterator[Record]{it}, false, nil)
 	assert.Nil(t, mi)
 	assert.EqualError(t, err, "boom")
 }

--- a/range.go
+++ b/range.go
@@ -4,10 +4,9 @@ import "errors"
 
 // RangeIterator is a user-facing iterator that hides tombstones and
 // duplicates. It wraps a MergingIterator which provides all records in key and
-// sequence order, in either forward or reverse key order.
+// sequence order.
 type RangeIterator struct {
 	mi         *MergingIterator
-	reverse    bool
 	lastKey    Bytes
 	lastKeySet bool
 	next       Record
@@ -16,9 +15,8 @@ type RangeIterator struct {
 }
 
 // NewRangeIterator creates a new RangeIterator from a MergingIterator.
-// If reverse is true, records are expected in descending key order.
-func NewRangeIterator(mi *MergingIterator, reverse bool) *RangeIterator {
-	return &RangeIterator{mi: mi, reverse: reverse}
+func NewRangeIterator(mi *MergingIterator) *RangeIterator {
+	return &RangeIterator{mi: mi}
 }
 
 func (r *RangeIterator) prepare() {

--- a/range.go
+++ b/range.go
@@ -4,9 +4,10 @@ import "errors"
 
 // RangeIterator is a user-facing iterator that hides tombstones and
 // duplicates. It wraps a MergingIterator which provides all records in key and
-// sequence order.
+// sequence order, in either forward or reverse key order.
 type RangeIterator struct {
 	mi         *MergingIterator
+	reverse    bool
 	lastKey    Bytes
 	lastKeySet bool
 	next       Record
@@ -15,8 +16,9 @@ type RangeIterator struct {
 }
 
 // NewRangeIterator creates a new RangeIterator from a MergingIterator.
-func NewRangeIterator(mi *MergingIterator) *RangeIterator {
-	return &RangeIterator{mi: mi}
+// If reverse is true, records are expected in descending key order.
+func NewRangeIterator(mi *MergingIterator, reverse bool) *RangeIterator {
+	return &RangeIterator{mi: mi, reverse: reverse}
 }
 
 func (r *RangeIterator) prepare() {

--- a/range_test.go
+++ b/range_test.go
@@ -53,13 +53,13 @@ func TestRangeIterator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var iterators []Iterator[Record]
+			var iterators []BiIterator[Record]
 			for _, spec := range tt.iters {
 				iterators = append(iterators, &errIterator{records: spec.records, failIdx: spec.failIdx})
 			}
-			mi, err := NewMergingIterator(iterators, nil)
+			mi, err := NewMergingIterator(iterators, false, nil)
 			assert.NoError(t, err)
-			iter := NewRangeIterator(mi)
+			iter := NewRangeIterator(mi, false)
 
 			var got []exp
 			for iter.HasNext() {
@@ -130,10 +130,10 @@ func TestRangeIteratorPrepare(t *testing.T) {
 			},
 			failIdx: -1,
 		}
-		mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
+		mi, err := NewMergingIterator([]BiIterator[Record]{it}, false, nil)
 		assert.NoError(t, err)
 
-		iter := NewRangeIterator(mi)
+		iter := NewRangeIterator(mi, false)
 		iter.prepare()
 		_, err = iter.Next()
 		assert.NoError(t, err)
@@ -152,10 +152,10 @@ func TestRangeIteratorPrepare(t *testing.T) {
 			},
 			failIdx: 1,
 		}
-		mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
+		mi, err := NewMergingIterator([]BiIterator[Record]{it}, false, nil)
 		assert.NoError(t, err)
 
-		iter := NewRangeIterator(mi)
+		iter := NewRangeIterator(mi, false)
 		iter.prepare()
 		_, err = iter.Next()
 		assert.NoError(t, err)

--- a/range_test.go
+++ b/range_test.go
@@ -59,7 +59,7 @@ func TestRangeIterator(t *testing.T) {
 			}
 			mi, err := NewMergingIterator(iterators, false, nil)
 			assert.NoError(t, err)
-			iter := NewRangeIterator(mi, false)
+			iter := NewRangeIterator(mi)
 
 			var got []exp
 			for iter.HasNext() {
@@ -133,7 +133,7 @@ func TestRangeIteratorPrepare(t *testing.T) {
 		mi, err := NewMergingIterator([]BiIterator[Record]{it}, false, nil)
 		assert.NoError(t, err)
 
-		iter := NewRangeIterator(mi, false)
+		iter := NewRangeIterator(mi)
 		iter.prepare()
 		_, err = iter.Next()
 		assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestRangeIteratorPrepare(t *testing.T) {
 		mi, err := NewMergingIterator([]BiIterator[Record]{it}, false, nil)
 		assert.NoError(t, err)
 
-		iter := NewRangeIterator(mi, false)
+		iter := NewRangeIterator(mi)
 		iter.prepare()
 		_, err = iter.Next()
 		assert.NoError(t, err)

--- a/rindb.go
+++ b/rindb.go
@@ -236,6 +236,14 @@ func (r *Rindb) Get(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error
 	return r.SSTableManager.SearchKey(ctx, key, maxSeq)
 }
 
+func cleanupTableEntries(entries []*tableCacheEntry) func() {
+	return func() {
+		for _, e := range entries {
+			e.unref()
+		}
+	}
+}
+
 // IRange returns an iterator over records with keys in [start, end],
 // merged across the memtable and relevant SSTables.
 //
@@ -268,13 +276,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 	if err != nil {
 		return nil, err
 	}
-	opened := entries
-
-	cleanupOpened := func() {
-		for _, o := range opened {
-			o.unref()
-		}
-	}
+	cleanupOpened := cleanupTableEntries(entries)
 
 	for _, entry := range entries {
 		rangeIter, err := entry.Table.IRange(start, end, maxSeq)
@@ -326,13 +328,7 @@ func (r *Rindb) IRangeReverse(ctx context.Context, start, end Bytes, seq ...uint
 	if err != nil {
 		return nil, err
 	}
-	opened := entries
-
-	cleanupOpened := func() {
-		for _, o := range opened {
-			o.unref()
-		}
-	}
+	cleanupOpened := cleanupTableEntries(entries)
 
 	for _, entry := range entries {
 		rangeIter, err := entry.Table.IRangeReverse(start, end, maxSeq)

--- a/rindb.go
+++ b/rindb.go
@@ -291,7 +291,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 		return nil, err
 	}
 
-	return NewRangeIterator(mergeIter, false), nil
+	return NewRangeIterator(mergeIter), nil
 }
 
 // IRangeReverse returns an iterator over records with keys in [start, end]
@@ -349,7 +349,7 @@ func (r *Rindb) IRangeReverse(ctx context.Context, start, end Bytes, seq ...uint
 		return nil, err
 	}
 
-	return NewRangeIterator(mergeIter, true), nil
+	return NewRangeIterator(mergeIter), nil
 }
 
 // Put inserts or updates a key-value pair in the database.

--- a/rindb.go
+++ b/rindb.go
@@ -262,7 +262,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 
 	maxSeq := getMaxSeq(seq...)
 
-	iterators := []Iterator[Record]{r.Memtable.IRange(start, end, maxSeq)}
+	iterators := []BiIterator[Record]{asBiIterator(r.Memtable.IRange(start, end, maxSeq))}
 
 	entries, err := r.SSTableManager.GetRelevantSSTables(ctx, start, end)
 	if err != nil {
@@ -282,16 +282,74 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 			cleanupOpened()
 			return nil, err
 		}
-		iterators = append(iterators, rangeIter)
+		iterators = append(iterators, asBiIterator(rangeIter))
 	}
 
-	mergeIter, err := NewMergingIterator(iterators, cleanupOpened)
+	mergeIter, err := NewMergingIterator(iterators, false, cleanupOpened)
 	if err != nil {
 		cleanupOpened()
 		return nil, err
 	}
 
-	return NewRangeIterator(mergeIter), nil
+	return NewRangeIterator(mergeIter, false), nil
+}
+
+// IRangeReverse returns an iterator over records with keys in [start, end]
+// in descending key order, merged across the memtable and relevant SSTables.
+//
+// The returned iterator must be closed when no longer needed to release
+// any associated resources.
+func (r *Rindb) IRangeReverse(ctx context.Context, start, end Bytes, seq ...uint64) (*RangeIterator, error) {
+	ctx, span := tracer.Start(ctx, "Rindb.IRangeReverse")
+	defer span.End()
+	iRangeCalls.Add(ctx, 1)
+	r.iRangeCalls.Add(1)
+	if span.IsRecording() {
+		span.SetAttributes(
+			attribute.Int("start_key_size", len(start)),
+			attribute.Int("end_key_size", len(end)),
+		)
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.closed {
+		return nil, ErrDatabaseClosed
+	}
+
+	maxSeq := getMaxSeq(seq...)
+
+	iterators := []BiIterator[Record]{r.Memtable.IRangeReverse(start, end, maxSeq)}
+
+	entries, err := r.SSTableManager.GetRelevantSSTables(ctx, start, end)
+	if err != nil {
+		return nil, err
+	}
+	opened := entries
+
+	cleanupOpened := func() {
+		for _, o := range opened {
+			o.unref()
+		}
+	}
+
+	for _, entry := range entries {
+		rangeIter, err := entry.Table.IRangeReverse(start, end, maxSeq)
+		if err != nil {
+			cleanupOpened()
+			return nil, err
+		}
+		iterators = append(iterators, rangeIter)
+	}
+
+	mergeIter, err := NewMergingIterator(iterators, true, cleanupOpened)
+	if err != nil {
+		cleanupOpened()
+		return nil, err
+	}
+
+	return NewRangeIterator(mergeIter, true), nil
 }
 
 // Put inserts or updates a key-value pair in the database.

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -227,6 +227,48 @@ func TestRindb_IRange(t *testing.T) {
 	}
 }
 
+func TestRindb_IRangeReverse(t *testing.T) {
+	ctx := context.Background()
+	cfg := testConfig()
+	ts := newTestRindbSetup(t, ctx, &cfg)
+	defer ts.Cleanup()
+
+	// Create SSTable with older records
+	mem1 := InitMemtable(cfg)
+	mem1.Put(newRecord(Bytes("a"), Bytes("sstA"), 1))
+	mem1.Put(newRecord(Bytes("b"), Bytes("sstB"), 2))
+	sst1, meta1, err := flush(ctx, cfg, mem1, ts.newSSTableFS())
+	assert.NoError(t, err)
+	require.NotZero(t, meta1.Number)
+	ts.AddSSTable(0, &sst1)
+
+	// Memtable with latest update
+	mem := ts.RinDB.Memtable
+	mem.Put(newRecord(Bytes("c"), Bytes("memC"), 3))
+
+	iter, err := ts.RinDB.IRangeReverse(ctx, Bytes("a"), Bytes("c"))
+	assert.NoError(t, err)
+	defer iter.Close()
+
+	expected := []struct{ k, v string }{
+		{"c", "memC"},
+		{"b", "sstB"},
+		{"a", "sstA"},
+	}
+
+	for _, exp := range expected {
+		assert.True(t, iter.HasNext())
+		rec, err := iter.Next()
+		assert.NoError(t, err)
+		assert.Equal(t, exp.k, string(rec.GetKey()))
+		assert.Equal(t, exp.v, string(rec.GetValue()))
+	}
+
+	assert.False(t, iter.HasNext())
+	_, err = iter.Next()
+	assert.ErrorIs(t, err, EOI)
+}
+
 // TestRindb_Remove tests the Remove operation of Rindb.
 func TestRindb_Remove(t *testing.T) {
 	ctx := context.Background()

--- a/skiplist.go
+++ b/skiplist.go
@@ -233,28 +233,6 @@ func (list *SkipList[K, V]) Iterator() Iterator[V] {
 	}
 }
 
-// slIRange iterates over a key range within the skip list.
-type slIRange[K Comparable, V any] struct {
-	node   *SLNode[K, V]
-	endKey K
-}
-
-// HasNext implements Iterator.
-func (s *slIRange[K, V]) HasNext() bool {
-	return s.node != nil && Compare(s.node.Key, s.endKey) != CmpGreater
-}
-
-// Next implements Iterator.
-func (s *slIRange[K, V]) Next() (V, error) {
-	if !s.HasNext() {
-		var empty V
-		return empty, EOI
-	}
-	value := s.node.Value
-	s.node = s.node.Next()
-	return value, nil
-}
-
 // IRange returns an iterator over records with keys in [start, end].
 func (list *SkipList[K, V]) IRange(start, end K) Iterator[V] {
 	rn := list.Head()
@@ -266,10 +244,12 @@ func (list *SkipList[K, V]) IRange(start, end K) Iterator[V] {
 		}
 	}
 	rn = rn.forwards[0]
-	return &slIRange[K, V]{
-		node:   rn,
-		endKey: end,
+	var values []V
+	for rn != nil && Compare(rn.Key, end) != CmpGreater {
+		values = append(values, rn.Value)
+		rn = rn.Next()
 	}
+	return newSliceBiIterator(values)
 }
 
 func intn(m int64) int64 {

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -495,6 +495,23 @@ func TestSkipList_IRange(t *testing.T) {
 	})
 }
 
+func TestSkipList_IRangeReverse(t *testing.T) {
+	cfg := testConfig()
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+	for i := 1; i <= 5; i++ {
+		list.Put(i, i)
+	}
+	it := asBiIterator(list.IRange(1, 5))
+	var vals []int
+	for it.HasPrev() {
+		v, err := it.Prev()
+		assert.NoError(t, err)
+		vals = append(vals, v)
+	}
+	assert.Equal(t, []int{5, 4, 3, 2, 1}, vals)
+}
+
 func TestSkipList_FindGreaterOrEqual(t *testing.T) {
 	cfg := testConfig()
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -41,6 +41,14 @@ func (s *Snapshot) IRange(ctx context.Context, start, end Bytes) (*RangeIterator
 	return s.db.IRange(ctx, start, end, s.sequence)
 }
 
+// IRangeReverse returns an iterator over records with keys in [start, end]
+// in descending key order as of the snapshot's sequence.
+func (s *Snapshot) IRangeReverse(ctx context.Context, start, end Bytes) (*RangeIterator, error) {
+	ctx, span := tracer.Start(ctx, "Snapshot.IRangeReverse")
+	defer span.End()
+	return s.db.IRangeReverse(ctx, start, end, s.sequence)
+}
+
 // Release removes the snapshot from the list of active snapshots.
 func (s *Snapshot) Release(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "Snapshot.Release")

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -165,6 +165,31 @@ func TestSnapshot_IRange(t *testing.T) {
 	assert.NoError(t, snap.Release(ctx))
 }
 
+func TestSnapshot_IRangeReverse(t *testing.T) {
+	ctx := context.Background()
+	rin, cleanup := initRinDBWithCleanup(t, WithDatabaseDir(t.TempDir()))
+	defer cleanup()
+
+	assert.NoError(t, rin.Put(ctx, Bytes("a"), Bytes("v1")))
+	assert.NoError(t, rin.Put(ctx, Bytes("b"), Bytes("v2")))
+	snap, err := rin.NewSnapshot(ctx)
+	require.NoError(t, err)
+
+	assert.NoError(t, rin.Put(ctx, Bytes("c"), Bytes("v3")))
+
+	iter, err := snap.IRangeReverse(ctx, Bytes("a"), Bytes("c"))
+	assert.NoError(t, err)
+	var keys []Bytes
+	for iter.HasNext() {
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		keys = append(keys, rec.GetKey())
+	}
+	assert.Equal(t, []Bytes{Bytes("b"), Bytes("a")}, keys)
+
+	assert.NoError(t, snap.Release(ctx))
+}
+
 func TestSnapshot_ReleaseConcurrent(t *testing.T) {
 	ctx := context.Background()
 	rin, cleanup := initRinDBWithCleanup(t, WithDatabaseDir(t.TempDir()))

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -59,22 +59,32 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 // IRangeReverse returns an iterator over records in [start, end] in descending
 // key order.
 func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (BiIterator[Record], error) {
-	it, err := s.IRange(start, end, seq...)
+	maxSeq := getMaxSeq(seq...)
+	if !s.IsOpened() {
+		if err := s.Open(context.Background()); err != nil {
+			return nil, err
+		}
+	}
+	idx := sort.Search(len(s.SparseIndex), func(i int) bool {
+		return s.SparseIndex[i].key.Compare(end) > 0
+	})
+	var offset int64
+	if idx > 0 {
+		idx--
+		offset = s.SparseIndex[idx].offset
+	}
+
+	tailOffset, err := getSSTableTailOffset(s.FileSystem)
 	if err != nil {
 		return nil, err
 	}
-	var records []Record
-	for it.HasNext() {
-		rec, err := it.Next()
-		if err != nil {
-			if errors.Is(err, EOI) {
-				break
-			}
-			return nil, err
-		}
-		records = append(records, rec)
+	buf := make([]byte, mdByteSize)
+	if _, err := s.FileSystem.ReadAt(buf, tailOffset); err != nil {
+		return nil, err
 	}
-	return newSliceBiIterator(records), nil
+	dataEnd := int64(byteOrder.Uint64(buf))
+
+	return &sstableIRangeRev{s: &s, startKey: start, endKey: end, seq: maxSeq, blockIdx: idx, offset: offset, dataEnd: dataEnd, pos: -1}, nil
 }
 
 type sstableIterator struct {
@@ -163,4 +173,90 @@ func (sri *sstableIRange) Next() (Record, error) {
 	}
 	sri.prepared = false
 	return sri.next, nil
+}
+
+// sstableIRangeRev iterates over a range of keys in reverse order.
+type sstableIRangeRev struct {
+	s        *SStable
+	startKey Bytes
+	endKey   Bytes
+	seq      uint64
+	blockIdx int
+	offset   int64
+	dataEnd  int64
+	buf      []Record
+	pos      int
+	err      error
+}
+
+func (srr *sstableIRangeRev) fillBuf() {
+	if srr.blockIdx < 0 {
+		srr.err = EOI
+		return
+	}
+	var nextOffset int64
+	if srr.blockIdx+1 < len(srr.s.SparseIndex) {
+		nextOffset = srr.s.SparseIndex[srr.blockIdx+1].offset
+	} else {
+		nextOffset = srr.dataEnd
+	}
+	reader := newOffsetReader(srr.s.FileSystem, srr.offset)
+	srr.buf = srr.buf[:0]
+	for reader.Offset() < nextOffset {
+		rec, err := readRecord(reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			srr.err = err
+			return
+		}
+		if rec.GetKey().Compare(srr.startKey) < 0 {
+			continue
+		}
+		if rec.GetKey().Compare(srr.endKey) > 0 {
+			continue
+		}
+		if rec.GetSequenceNumber() > srr.seq {
+			continue
+		}
+		srr.buf = append(srr.buf, rec)
+	}
+	srr.pos = len(srr.buf) - 1
+	srr.blockIdx--
+	if srr.blockIdx >= 0 {
+		srr.offset = srr.s.SparseIndex[srr.blockIdx].offset
+	}
+}
+
+func (srr *sstableIRangeRev) prepare() {
+	for srr.pos < 0 && srr.err == nil {
+		srr.fillBuf()
+	}
+}
+
+// HasNext implements Iterator but always returns false for reverse iterator.
+func (srr *sstableIRangeRev) HasNext() bool { return false }
+
+// Next implements Iterator and always returns EOI.
+func (srr *sstableIRangeRev) Next() (Record, error) {
+	var empty Record
+	return empty, EOI
+}
+
+// HasPrev implements BiIterator.
+func (srr *sstableIRangeRev) HasPrev() bool {
+	srr.prepare()
+	return srr.pos >= 0
+}
+
+// Prev implements BiIterator.
+func (srr *sstableIRangeRev) Prev() (Record, error) {
+	if !srr.HasPrev() {
+		var empty Record
+		return empty, srr.err
+	}
+	rec := srr.buf[srr.pos]
+	srr.pos--
+	return rec, nil
 }

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -267,15 +267,13 @@ func (srr *sstableIRangeRev) prepare() {
 			continue
 		}
 		srr.blockIdx--
-		if srr.blockIdx < 0 {
-			srr.err = EOI
-			return
-		}
-		srr.blockStart = srr.s.SparseIndex[srr.blockIdx].offset
-		if srr.blockIdx+1 < len(srr.s.SparseIndex) {
-			srr.scanEnd = srr.s.SparseIndex[srr.blockIdx+1].offset
-		} else {
-			srr.scanEnd = srr.dataEnd
+		if srr.blockIdx >= 0 {
+			srr.blockStart = srr.s.SparseIndex[srr.blockIdx].offset
+			if srr.blockIdx+1 < len(srr.s.SparseIndex) {
+				srr.scanEnd = srr.s.SparseIndex[srr.blockIdx+1].offset
+			} else {
+				srr.scanEnd = srr.dataEnd
+			}
 		}
 	}
 }

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -184,7 +184,7 @@ type sstableIRangeRev struct {
 	blockIdx int
 	offset   int64
 	dataEnd  int64
-	buf      []Record
+	offsets  []int64
 	pos      int
 	err      error
 }
@@ -201,8 +201,9 @@ func (srr *sstableIRangeRev) fillBuf() {
 		nextOffset = srr.dataEnd
 	}
 	reader := newOffsetReader(srr.s.FileSystem, srr.offset)
-	srr.buf = srr.buf[:0]
+	srr.offsets = srr.offsets[:0]
 	for reader.Offset() < nextOffset {
+		start := reader.Offset()
 		rec, err := readRecord(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -220,9 +221,9 @@ func (srr *sstableIRangeRev) fillBuf() {
 		if rec.GetSequenceNumber() > srr.seq {
 			continue
 		}
-		srr.buf = append(srr.buf, rec)
+		srr.offsets = append(srr.offsets, start)
 	}
-	srr.pos = len(srr.buf) - 1
+	srr.pos = len(srr.offsets) - 1
 	srr.blockIdx--
 	if srr.blockIdx >= 0 {
 		srr.offset = srr.s.SparseIndex[srr.blockIdx].offset
@@ -256,7 +257,13 @@ func (srr *sstableIRangeRev) Prev() (Record, error) {
 		var empty Record
 		return empty, srr.err
 	}
-	rec := srr.buf[srr.pos]
+	off := srr.offsets[srr.pos]
 	srr.pos--
+	reader := newOffsetReader(srr.s.FileSystem, off)
+	rec, err := readRecord(reader)
+	if err != nil {
+		srr.err = err
+		return rec, err
+	}
 	return rec, nil
 }

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -56,6 +56,27 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd}, nil
 }
 
+// IRangeReverse returns an iterator over records in [start, end] in descending
+// key order.
+func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (BiIterator[Record], error) {
+	it, err := s.IRange(start, end, seq...)
+	if err != nil {
+		return nil, err
+	}
+	var records []Record
+	for it.HasNext() {
+		rec, err := it.Next()
+		if err != nil {
+			if errors.Is(err, EOI) {
+				break
+			}
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	return newSliceBiIterator(records), nil
+}
+
 type sstableIterator struct {
 	*FileSystem
 	currentIdx int

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -68,10 +68,10 @@ func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (BiIterator[Reco
 	idx := sort.Search(len(s.SparseIndex), func(i int) bool {
 		return s.SparseIndex[i].key.Compare(end) > 0
 	})
-	var offset int64
-	if idx > 0 {
-		idx--
-		offset = s.SparseIndex[idx].offset
+	blockIdx := idx - 1
+	var blockStart int64
+	if blockIdx >= 0 {
+		blockStart = s.SparseIndex[blockIdx].offset
 	}
 
 	tailOffset, err := getSSTableTailOffset(s.FileSystem)
@@ -84,7 +84,29 @@ func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (BiIterator[Reco
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRangeRev{s: &s, startKey: start, endKey: end, seq: maxSeq, blockIdx: idx, offset: offset, dataEnd: dataEnd, pos: -1}, nil
+	var scanEnd int64
+	if idx < len(s.SparseIndex) {
+		scanEnd = s.SparseIndex[idx].offset
+	} else {
+		scanEnd = dataEnd
+	}
+
+	fwd, err := s.IRange(start, end, maxSeq)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sstableIRangeRev{
+		s:          &s,
+		startKey:   start,
+		endKey:     end,
+		seq:        maxSeq,
+		blockIdx:   blockIdx,
+		blockStart: blockStart,
+		scanEnd:    scanEnd,
+		dataEnd:    dataEnd,
+		fwd:        fwd,
+	}, nil
 }
 
 type sstableIterator struct {
@@ -175,18 +197,21 @@ func (sri *sstableIRange) Next() (Record, error) {
 	return sri.next, nil
 }
 
-// sstableIRangeRev iterates over a range of keys in reverse order.
+// sstableIRangeRev iterates over a range of keys in reverse order while also
+// supporting forward iteration via a separate iterator.
 type sstableIRangeRev struct {
-	s        *SStable
-	startKey Bytes
-	endKey   Bytes
-	seq      uint64
-	blockIdx int
-	offset   int64
-	dataEnd  int64
-	records  []recMeta
-	pos      int
-	err      error
+	s          *SStable
+	startKey   Bytes
+	endKey     Bytes
+	seq        uint64
+	blockIdx   int
+	blockStart int64
+	scanEnd    int64
+	dataEnd    int64
+	cur        recMeta
+	curValid   bool
+	err        error
+	fwd        Iterator[Record]
 }
 
 type recMeta struct {
@@ -197,67 +222,74 @@ type recMeta struct {
 	valueLen uint64
 }
 
-func (srr *sstableIRangeRev) fillBuf() {
-	if srr.blockIdx < 0 {
-		srr.err = EOI
-		return
-	}
-	var nextOffset int64
-	if srr.blockIdx+1 < len(srr.s.SparseIndex) {
-		nextOffset = srr.s.SparseIndex[srr.blockIdx+1].offset
-	} else {
-		nextOffset = srr.dataEnd
-	}
-	reader := newOffsetReader(srr.s.FileSystem, srr.offset)
-	var metas []recMeta
-	for reader.Offset() < nextOffset {
+func (srr *sstableIRangeRev) scanBlockForPrev(start, end int64) (recMeta, int64, bool, error) {
+	reader := newOffsetReader(srr.s.FileSystem, start)
+	var last recMeta
+	lastStart := int64(-1)
+	for reader.Offset() < end {
+		recStart := reader.Offset()
 		key, seq, typ, valueOff, valueLen, err := readRecordMeta(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			srr.err = err
-			return
+			return recMeta{}, 0, false, err
 		}
 		if key.Compare(srr.endKey) > 0 {
 			break
 		}
-		metas = append(metas, recMeta{key: key, seq: seq, typ: typ, valueOff: valueOff, valueLen: valueLen})
-	}
-	left := sort.Search(len(metas), func(i int) bool { return metas[i].key.Compare(srr.startKey) >= 0 })
-	right := sort.Search(len(metas), func(i int) bool { return metas[i].key.Compare(srr.endKey) > 0 })
-	srr.records = srr.records[:0]
-	for i := left; i < right; i++ {
-		if metas[i].seq <= srr.seq {
-			srr.records = append(srr.records, metas[i])
+		if key.Compare(srr.startKey) >= 0 && seq <= srr.seq {
+			last = recMeta{key: key, seq: seq, typ: typ, valueOff: valueOff, valueLen: valueLen}
+			lastStart = recStart
 		}
 	}
-	srr.pos = len(srr.records) - 1
-	srr.blockIdx--
-	if srr.blockIdx >= 0 {
-		srr.offset = srr.s.SparseIndex[srr.blockIdx].offset
+	if lastStart == -1 {
+		return recMeta{}, 0, false, nil
 	}
+	return last, lastStart, true, nil
 }
 
 func (srr *sstableIRangeRev) prepare() {
-	for srr.pos < 0 && srr.err == nil {
-		srr.fillBuf()
+	for !srr.curValid && srr.err == nil {
+		if srr.blockIdx < 0 {
+			srr.err = EOI
+			return
+		}
+		meta, off, ok, err := srr.scanBlockForPrev(srr.blockStart, srr.scanEnd)
+		if err != nil {
+			srr.err = err
+			return
+		}
+		if ok {
+			srr.cur = meta
+			srr.curValid = true
+			srr.scanEnd = off
+			continue
+		}
+		srr.blockIdx--
+		if srr.blockIdx < 0 {
+			srr.err = EOI
+			return
+		}
+		srr.blockStart = srr.s.SparseIndex[srr.blockIdx].offset
+		if srr.blockIdx+1 < len(srr.s.SparseIndex) {
+			srr.scanEnd = srr.s.SparseIndex[srr.blockIdx+1].offset
+		} else {
+			srr.scanEnd = srr.dataEnd
+		}
 	}
 }
 
-// HasNext implements Iterator but always returns false for reverse iterator.
-func (srr *sstableIRangeRev) HasNext() bool { return false }
+// HasNext implements Iterator by delegating to the forward iterator.
+func (srr *sstableIRangeRev) HasNext() bool { return srr.fwd.HasNext() }
 
-// Next implements Iterator and always returns EOI.
-func (srr *sstableIRangeRev) Next() (Record, error) {
-	var empty Record
-	return empty, EOI
-}
+// Next implements Iterator by delegating to the forward iterator.
+func (srr *sstableIRangeRev) Next() (Record, error) { return srr.fwd.Next() }
 
 // HasPrev implements BiIterator.
 func (srr *sstableIRangeRev) HasPrev() bool {
 	srr.prepare()
-	return srr.pos >= 0
+	return srr.curValid
 }
 
 // Prev implements BiIterator.
@@ -266,8 +298,8 @@ func (srr *sstableIRangeRev) Prev() (Record, error) {
 		var empty Record
 		return empty, srr.err
 	}
-	meta := srr.records[srr.pos]
-	srr.pos--
+	meta := srr.cur
+	srr.curValid = false
 	reader := newOffsetReader(srr.s.FileSystem, meta.valueOff)
 	var value Bytes
 	if meta.valueLen > 0 {

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -184,9 +184,17 @@ type sstableIRangeRev struct {
 	blockIdx int
 	offset   int64
 	dataEnd  int64
-	offsets  []int64
+	records  []recMeta
 	pos      int
 	err      error
+}
+
+type recMeta struct {
+	key      Bytes
+	seq      uint64
+	typ      RecordType
+	valueOff int64
+	valueLen uint64
 }
 
 func (srr *sstableIRangeRev) fillBuf() {
@@ -201,14 +209,9 @@ func (srr *sstableIRangeRev) fillBuf() {
 		nextOffset = srr.dataEnd
 	}
 	reader := newOffsetReader(srr.s.FileSystem, srr.offset)
-	var (
-		keys []Bytes
-		seqs []uint64
-		offs []int64
-	)
+	var metas []recMeta
 	for reader.Offset() < nextOffset {
-		start := reader.Offset()
-		key, seq, err := readRecordMeta(reader)
+		key, seq, typ, valueOff, valueLen, err := readRecordMeta(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -219,19 +222,17 @@ func (srr *sstableIRangeRev) fillBuf() {
 		if key.Compare(srr.endKey) > 0 {
 			break
 		}
-		keys = append(keys, key)
-		seqs = append(seqs, seq)
-		offs = append(offs, start)
+		metas = append(metas, recMeta{key: key, seq: seq, typ: typ, valueOff: valueOff, valueLen: valueLen})
 	}
-	left := sort.Search(len(keys), func(i int) bool { return keys[i].Compare(srr.startKey) >= 0 })
-	right := sort.Search(len(keys), func(i int) bool { return keys[i].Compare(srr.endKey) > 0 })
-	srr.offsets = srr.offsets[:0]
+	left := sort.Search(len(metas), func(i int) bool { return metas[i].key.Compare(srr.startKey) >= 0 })
+	right := sort.Search(len(metas), func(i int) bool { return metas[i].key.Compare(srr.endKey) > 0 })
+	srr.records = srr.records[:0]
 	for i := left; i < right; i++ {
-		if seqs[i] <= srr.seq {
-			srr.offsets = append(srr.offsets, offs[i])
+		if metas[i].seq <= srr.seq {
+			srr.records = append(srr.records, metas[i])
 		}
 	}
-	srr.pos = len(srr.offsets) - 1
+	srr.pos = len(srr.records) - 1
 	srr.blockIdx--
 	if srr.blockIdx >= 0 {
 		srr.offset = srr.s.SparseIndex[srr.blockIdx].offset
@@ -265,13 +266,26 @@ func (srr *sstableIRangeRev) Prev() (Record, error) {
 		var empty Record
 		return empty, srr.err
 	}
-	off := srr.offsets[srr.pos]
+	meta := srr.records[srr.pos]
 	srr.pos--
-	reader := newOffsetReader(srr.s.FileSystem, off)
-	rec, err := readRecord(reader)
-	if err != nil {
-		srr.err = err
-		return rec, err
+	reader := newOffsetReader(srr.s.FileSystem, meta.valueOff)
+	var value Bytes
+	if meta.valueLen > 0 {
+		value = make(Bytes, meta.valueLen)
+		if _, err := io.ReadFull(reader, value); err != nil {
+			srr.err = err
+			return nil, err
+		}
 	}
-	return rec, nil
+	var checksumBytes [checksumSize]byte
+	if _, err := io.ReadFull(reader, checksumBytes[:]); err != nil {
+		srr.err = err
+		return nil, err
+	}
+	ikey := EncodeInternalKey(meta.key, meta.seq, meta.typ)
+	if checksum(ikey, value) != byteOrder.Uint32(checksumBytes[:]) {
+		srr.err = ErrChecksumMismatch
+		return nil, ErrChecksumMismatch
+	}
+	return RecordImpl{Key: meta.key, Value: value, SequenceNumber: meta.seq, Type: meta.typ}, nil
 }

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -201,10 +201,14 @@ func (srr *sstableIRangeRev) fillBuf() {
 		nextOffset = srr.dataEnd
 	}
 	reader := newOffsetReader(srr.s.FileSystem, srr.offset)
-	srr.offsets = srr.offsets[:0]
+	var (
+		keys []Bytes
+		seqs []uint64
+		offs []int64
+	)
 	for reader.Offset() < nextOffset {
 		start := reader.Offset()
-		rec, err := readRecord(reader)
+		key, seq, err := readRecordMeta(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -212,16 +216,20 @@ func (srr *sstableIRangeRev) fillBuf() {
 			srr.err = err
 			return
 		}
-		if rec.GetKey().Compare(srr.startKey) < 0 {
-			continue
+		if key.Compare(srr.endKey) > 0 {
+			break
 		}
-		if rec.GetKey().Compare(srr.endKey) > 0 {
-			continue
+		keys = append(keys, key)
+		seqs = append(seqs, seq)
+		offs = append(offs, start)
+	}
+	left := sort.Search(len(keys), func(i int) bool { return keys[i].Compare(srr.startKey) >= 0 })
+	right := sort.Search(len(keys), func(i int) bool { return keys[i].Compare(srr.endKey) > 0 })
+	srr.offsets = srr.offsets[:0]
+	for i := left; i < right; i++ {
+		if seqs[i] <= srr.seq {
+			srr.offsets = append(srr.offsets, offs[i])
 		}
-		if rec.GetSequenceNumber() > srr.seq {
-			continue
-		}
-		srr.offsets = append(srr.offsets, start)
 	}
 	srr.pos = len(srr.offsets) - 1
 	srr.blockIdx--

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -1,0 +1,68 @@
+package rindb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeNumberTest(buf *bytes.Buffer, n uint64) {
+	var b [mdByteSize]byte
+	byteOrder.PutUint64(b[:], n)
+	buf.Write(b[:])
+}
+
+func buildRecordBytes(key Bytes, seq uint64, value Bytes) []byte {
+	ikey := EncodeInternalKey(key, seq, TypeValue)
+	var buf bytes.Buffer
+	writeNumberTest(&buf, uint64(len(ikey)))
+	writeNumberTest(&buf, uint64(len(value)))
+	buf.Write(ikey)
+	buf.Write(value)
+	var c [checksumSize]byte
+	byteOrder.PutUint32(c[:], checksum(ikey, value))
+	buf.Write(c[:])
+	return buf.Bytes()
+}
+
+func TestScanBlockForPrevEOF(t *testing.T) {
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	rec := buildRecordBytes(Bytes("a"), 1, Bytes("v"))
+	_, err := fs.WriteAt(rec, 0)
+	require.NoError(t, err)
+
+	s := &SStable{FileSystem: fs}
+	srr := sstableIRangeRev{s: s, startKey: Bytes("a"), endKey: Bytes("z"), seq: ^uint64(0)}
+
+	meta, off, ok, err := srr.scanBlockForPrev(0, int64(len(rec)+8))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, Bytes("a"), meta.key)
+	assert.Equal(t, int64(0), off)
+}
+
+func TestScanBlockForPrevEndKeyBreak(t *testing.T) {
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	rec1 := buildRecordBytes(Bytes("a"), 1, Bytes("v"))
+	rec2 := buildRecordBytes(Bytes("d"), 1, Bytes("v"))
+	data := append(rec1, rec2...)
+	_, err := fs.WriteAt(data, 0)
+	require.NoError(t, err)
+
+	s := &SStable{FileSystem: fs}
+	srr := sstableIRangeRev{s: s, startKey: Bytes("a"), endKey: Bytes("c"), seq: ^uint64(0)}
+
+	meta, off, ok, err := srr.scanBlockForPrev(0, int64(len(data)))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, Bytes("a"), meta.key)
+	assert.Equal(t, int64(0), off)
+}

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -413,6 +413,24 @@ func TestSSTableIRangeReverseFiltered(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b")}, keys)
 }
 
+func TestSSTableIRangeReverseNextAlwaysEOI(t *testing.T) {
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("1"), 1))
+	sst, _, err := flush(context.Background(), cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.IRangeReverse(Bytes("a"), Bytes("a"))
+	require.NoError(t, err)
+	assert.False(t, it.HasNext())
+	_, err = it.Next()
+	assert.ErrorIs(t, err, EOI)
+}
+
 // TestSStable_GetValueSparseIndexFallback ensures GetValue can retrieve keys
 // when they are absent from the sparse index by scanning from the nearest
 // preceding entry.

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -379,6 +379,40 @@ func TestSSTableIRangeReverse(t *testing.T) {
 	assert.ErrorIs(t, err, EOI)
 }
 
+func TestSSTableIRangeReverseFiltered(t *testing.T) {
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	data := []struct {
+		key   Bytes
+		value Bytes
+	}{
+		{Bytes("a"), Bytes("1")},
+		{Bytes("b"), Bytes("2")},
+		{Bytes("c"), Bytes("3")},
+		{Bytes("d"), Bytes("4")},
+	}
+	mem := InitMemtable(cfg)
+	for i, v := range data {
+		mem.Put(newRecord(v.key, v.value, uint64(i)))
+	}
+	sst, meta, err := flush(context.Background(), cfg, mem, fs)
+	require.NoError(t, err)
+	require.NotZero(t, meta.Number)
+
+	it, err := sst.IRangeReverse(Bytes("b"), Bytes("c"))
+	require.NoError(t, err)
+	var keys []Bytes
+	for it.HasPrev() {
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		keys = append(keys, rec.GetKey())
+	}
+	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b")}, keys)
+}
+
 // TestSStable_GetValueSparseIndexFallback ensures GetValue can retrieve keys
 // when they are absent from the sparse index by scanning from the nearest
 // preceding entry.

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -344,6 +344,41 @@ func TestSStable(t *testing.T) {
 	})
 }
 
+func TestSSTableIRangeReverse(t *testing.T) {
+	cfg := testConfig()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	data := []struct {
+		key   Bytes
+		value Bytes
+	}{
+		{Bytes("a"), Bytes("1")},
+		{Bytes("b"), Bytes("2")},
+		{Bytes("c"), Bytes("3")},
+	}
+	mem := InitMemtable(cfg)
+	for i, v := range data {
+		mem.Put(newRecord(v.key, v.value, uint64(i)))
+	}
+	sst, meta, err := flush(context.Background(), cfg, mem, fs)
+	require.NoError(t, err)
+	require.NotZero(t, meta.Number)
+
+	it, err := sst.IRangeReverse(Bytes("a"), Bytes("c"))
+	require.NoError(t, err)
+	var keys []Bytes
+	for it.HasPrev() {
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		keys = append(keys, rec.GetKey())
+	}
+	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, keys)
+	_, err = it.Prev()
+	assert.ErrorIs(t, err, EOI)
+}
+
 // TestSStable_GetValueSparseIndexFallback ensures GetValue can retrieve keys
 // when they are absent from the sparse index by scanning from the nearest
 // preceding entry.

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -413,7 +413,7 @@ func TestSSTableIRangeReverseFiltered(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b")}, keys)
 }
 
-func TestSSTableIRangeReverseNextAlwaysEOI(t *testing.T) {
+func TestSSTableIRangeReverseForward(t *testing.T) {
 	cfg := testConfig()
 	fss, closer := initTempFileSystems(t, 1, nil)
 	defer closer()
@@ -426,7 +426,10 @@ func TestSSTableIRangeReverseNextAlwaysEOI(t *testing.T) {
 
 	it, err := sst.IRangeReverse(Bytes("a"), Bytes("a"))
 	require.NoError(t, err)
-	assert.False(t, it.HasNext())
+	assert.True(t, it.HasNext())
+	rec, err := it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
 	_, err = it.Next()
 	assert.ErrorIs(t, err, EOI)
 }

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -434,6 +434,16 @@ func TestSSTableIRangeReverseForward(t *testing.T) {
 	assert.ErrorIs(t, err, EOI)
 }
 
+func TestSSTableIRangeReverseRangeError(t *testing.T) {
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	sst := SStable{FileSystem: fs}
+	_, err := sst.IRangeReverse(Bytes("a"), Bytes("b"))
+	require.Error(t, err)
+}
+
 // TestSStable_GetValueSparseIndexFallback ensures GetValue can retrieve keys
 // when they are absent from the sparse index by scanning from the nearest
 // preceding entry.

--- a/sstablemgmt.go
+++ b/sstablemgmt.go
@@ -689,16 +689,16 @@ func mergeSSTablesV2(ctx context.Context, config Config, target *FileSystem, sou
 		return nil, fileMeta{}, nil
 	}
 
-	iterators := make([]Iterator[Record], 0, len(sources))
+	iterators := make([]BiIterator[Record], 0, len(sources))
 	for _, entry := range sources {
 		iter, err := entry.Table.Iterator()
 		if err != nil {
 			return nil, fileMeta{}, err
 		}
-		iterators = append(iterators, iter)
+		iterators = append(iterators, asBiIterator(iter))
 	}
 
-	mergeIter, err := NewMergingIterator(iterators, nil)
+	mergeIter, err := NewMergingIterator(iterators, false, nil)
 	if err != nil {
 		return nil, fileMeta{}, err
 	}


### PR DESCRIPTION
## Summary
- add `BiIterator` for optional backward traversal
- extend `MergingIterator` with reverse ordering and update range merging callers
- introduce reverse range readers for Memtable and SSTable with bidirectional iterators
- expose `IRangeReverse` on `Rindb` and `Snapshot` with direction-aware `RangeIterator`
- test backward traversal across skiplist, memtable, SSTable, and high-level API

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4d99f6c4c832580840476068c836c