### PR TITLE
feat: implement two-phase commit in diffharness

### DIFF
--- a/diffharness/cmd/main.go
+++ b/diffharness/cmd/main.go
@@ -63,6 +63,7 @@ func main() {
 
 func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, crashEvery, telemetryEvery int, jaeger string, opts []rindb.Option) error {
 	cleanup := false
+	existed := false
 	if dir == "" {
 		var err error
 		dir, err = os.MkdirTemp("", "diffharness")
@@ -71,12 +72,20 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 		}
 		cleanup = true
 	} else {
+		if _, err := os.Stat(dir); err == nil {
+			existed = true
+		} else if !os.IsNotExist(err) {
+			return err
+		}
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err
 		}
 	}
 	if cleanup {
 		defer os.RemoveAll(dir)
+	}
+	if dir != "" {
+		logPath = filepath.Join(dir, logPath)
 	}
 	dbDir := filepath.Join(dir, "db")
 	refPath := filepath.Join(dir, "ref.db")
@@ -100,10 +109,19 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 	if err != nil {
 		return err
 	}
+	var startSeq uint64
+	if existed {
+		if _, err := os.Stat(logPath); err == nil {
+			if startSeq, err = diffharness.Replay(ctx, eng, ref, logPath); err != nil {
+				return err
+			}
+		}
+	}
 	h, err := diffharness.NewHarness(eng, ref, seed, logPath)
 	if err != nil {
 		return err
 	}
+	h.Seq = startSeq
 	defer func() {
 		_ = h.Close()
 		_ = eng.Close()

--- a/diffharness/engine.go
+++ b/diffharness/engine.go
@@ -7,6 +7,9 @@ type KV struct{ K, V []byte }
 
 // Engine is the common interface implemented by RinDB and the oracle.
 type Engine interface {
+	Begin(ctx context.Context) error
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
 	Put(ctx context.Context, k, v []byte) error // insert or replace key with value
 	Delete(ctx context.Context, k []byte) error // delete key (tombstone)
 	Get(ctx context.Context, k []byte, snapshot uint64) ([]byte, bool, error)

--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -223,6 +223,161 @@ func (h *Harness) SetCrashHook(fn func() error) { h.crash = fn }
 // It receives the current sequence and op count.
 func (h *Harness) SetTelemetryHook(fn func(seq uint64, ops int)) { h.telemetry = fn }
 
+type phaseLogger func(Phase) error
+type phaseHook func() error
+
+func applyPut(ctx context.Context, my Engine, ref *SQLiteOracle, op Op, seq uint64, start Phase, log phaseLogger, hook phaseHook) (uint64, error) {
+	finalSeq := seq + 1
+	switch start {
+	case PhasePrepared:
+		if err := my.Begin(ctx); err != nil {
+			return 0, err
+		}
+		if err := my.Put(ctx, op.K, op.V); err != nil {
+			_ = my.Rollback(ctx)
+			return 0, err
+		}
+		if err := my.Commit(ctx); err != nil {
+			return 0, err
+		}
+		if err := log(PhaseMyDone); err != nil {
+			return 0, err
+		}
+		if hook != nil {
+			if err := hook(); err != nil {
+				return 0, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if ref != nil {
+			if err := ref.Begin(ctx); err != nil {
+				return 0, err
+			}
+			if err := ref.PutWithSeq(op.K, op.V, finalSeq); err != nil {
+				_ = ref.Rollback(ctx)
+				return 0, err
+			}
+			if err := ref.Commit(ctx); err != nil {
+				return 0, err
+			}
+		}
+		if err := log(PhaseRefDone); err != nil {
+			return 0, err
+		}
+		if hook != nil {
+			if err := hook(); err != nil {
+				return 0, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log(PhaseCommitted); err != nil {
+			return 0, err
+		}
+	}
+	return finalSeq, nil
+}
+
+func applyDel(ctx context.Context, my Engine, ref *SQLiteOracle, op Op, seq uint64, start Phase, log phaseLogger, hook phaseHook) (uint64, error) {
+	finalSeq := seq + 1
+	switch start {
+	case PhasePrepared:
+		if err := my.Begin(ctx); err != nil {
+			return 0, err
+		}
+		if err := my.Delete(ctx, op.K); err != nil {
+			_ = my.Rollback(ctx)
+			return 0, err
+		}
+		if err := my.Commit(ctx); err != nil {
+			return 0, err
+		}
+		if err := log(PhaseMyDone); err != nil {
+			return 0, err
+		}
+		if hook != nil {
+			if err := hook(); err != nil {
+				return 0, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if ref != nil {
+			if err := ref.Begin(ctx); err != nil {
+				return 0, err
+			}
+			if err := ref.DelWithSeq(op.K, finalSeq); err != nil {
+				_ = ref.Rollback(ctx)
+				return 0, err
+			}
+			if err := ref.Commit(ctx); err != nil {
+				return 0, err
+			}
+		}
+		if err := log(PhaseRefDone); err != nil {
+			return 0, err
+		}
+		if hook != nil {
+			if err := hook(); err != nil {
+				return 0, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log(PhaseCommitted); err != nil {
+			return 0, err
+		}
+	}
+	return finalSeq, nil
+}
+
+func applySnap(ctx context.Context, my Engine, ref *SQLiteOracle, seq uint64, start Phase, log phaseLogger, hook phaseHook) (uint64, error) {
+	switch start {
+	case PhasePrepared:
+		s, err := my.NewSnapshot(ctx)
+		if err != nil {
+			return 0, err
+		}
+		if s != seq {
+			return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, have=%d", seq, s)
+		}
+		if err := log(PhaseMyDone); err != nil {
+			return 0, err
+		}
+		if hook != nil {
+			if err := hook(); err != nil {
+				return 0, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if ref != nil {
+			refSeq, err := ref.NewSnapshot(ctx)
+			if err != nil {
+				return 0, err
+			}
+			if refSeq != seq {
+				return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seq, refSeq)
+			}
+		}
+		if err := log(PhaseRefDone); err != nil {
+			return 0, err
+		}
+		if hook != nil {
+			if err := hook(); err != nil {
+				return 0, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log(PhaseCommitted); err != nil {
+			return 0, err
+		}
+	}
+	return seq, nil
+}
+
 // Step applies a single operation, logging it before execution.
 func (h *Harness) Step(ctx context.Context, op Op) error {
 	i := h.ops
@@ -247,89 +402,22 @@ func (h *Harness) Step(ctx context.Context, op Op) error {
 		}
 	}
 	h.ops++
+	committed := false
 	switch op.Kind {
 	case OpPut:
 		h.Seq++
-		if err := h.My.Begin(ctx); err != nil {
-			return h.fail(i, op, err)
-		}
-		if err := h.My.Put(ctx, op.K, op.V); err != nil {
-			_ = h.My.Rollback(ctx)
-			return h.fail(i, op, err)
-		}
-		if err := h.My.Commit(ctx); err != nil {
+		if _, err := applyPut(ctx, h.My, h.Ref, op, seq, PhasePrepared, logPhase, h.crash); err != nil {
 			return h.fail(i, op, err)
 		}
 		h.addKey(op.K)
-		if err := logPhase(PhaseMyDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-		if h.Ref != nil {
-			if err := h.Ref.Begin(ctx); err != nil {
-				return h.fail(i, op, err)
-			}
-			if err := h.Ref.PutWithSeq(op.K, op.V, h.Seq); err != nil {
-				_ = h.Ref.Rollback(ctx)
-				return h.fail(i, op, err)
-			}
-			if err := h.Ref.Commit(ctx); err != nil {
-				return h.fail(i, op, err)
-			}
-		}
-		if err := logPhase(PhaseRefDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
+		committed = true
 	case OpDel:
 		h.Seq++
-		if err := h.My.Begin(ctx); err != nil {
-			return h.fail(i, op, err)
-		}
-		if err := h.My.Delete(ctx, op.K); err != nil {
-			_ = h.My.Rollback(ctx)
-			return h.fail(i, op, err)
-		}
-		if err := h.My.Commit(ctx); err != nil {
+		if _, err := applyDel(ctx, h.My, h.Ref, op, seq, PhasePrepared, logPhase, h.crash); err != nil {
 			return h.fail(i, op, err)
 		}
 		h.delKey(op.K)
-		if err := logPhase(PhaseMyDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-		if h.Ref != nil {
-			if err := h.Ref.Begin(ctx); err != nil {
-				return h.fail(i, op, err)
-			}
-			if err := h.Ref.DelWithSeq(op.K, h.Seq); err != nil {
-				_ = h.Ref.Rollback(ctx)
-				return h.fail(i, op, err)
-			}
-			if err := h.Ref.Commit(ctx); err != nil {
-				return h.fail(i, op, err)
-			}
-		}
-		if err := logPhase(PhaseRefDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
+		committed = true
 	case OpGet:
 		mv, mok, me := h.My.Get(ctx, op.K, op.SnapSeq)
 		if me != nil {
@@ -391,39 +479,17 @@ func (h *Harness) Step(ctx context.Context, op Op) error {
 			}
 		}
 	case OpSnap:
-		seqSnap, err := h.My.NewSnapshot(ctx)
-		if err != nil {
+		seqSnap := h.Seq
+		if _, err := applySnap(ctx, h.My, h.Ref, seqSnap, PhasePrepared, logPhase, h.crash); err != nil {
 			return h.fail(i, op, err)
 		}
-		if err := logPhase(PhaseMyDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-		if h.Ref != nil {
-			refSeq, err := h.Ref.NewSnapshot(ctx)
-			if err != nil {
-				return h.fail(i, op, err)
-			}
-			if seqSnap != refSeq {
-				return h.fail(i, op, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq))
-			}
-		}
 		h.Snapshots = append(h.Snapshots, seqSnap)
-		if err := logPhase(PhaseRefDone); err != nil {
+		committed = true
+	}
+	if !committed {
+		if err := logPhase(PhaseCommitted); err != nil {
 			return err
 		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-	}
-	if err := logPhase(PhaseCommitted); err != nil {
-		return err
 	}
 	return nil
 }
@@ -659,219 +725,35 @@ func Replay(ctx context.Context, my Engine, ref *SQLiteOracle, logPath string) (
 	}
 	last := entries[len(entries)-1]
 	finalize := func(entry logEntry) (uint64, error) {
-		appendEntry := func(p Phase) error {
-			e := logEntry{I: entry.I, Seq: entry.Seq, Op: entry.Op, Phase: p}
-			if err := write(e); err != nil {
-				return err
-			}
-			entries = append(entries, e)
-			return nil
+		logPhase := func(p Phase) error {
+			return write(logEntry{I: entry.I, Seq: entry.Seq, Op: entry.Op, Phase: p})
 		}
-		seq := entry.Seq
 		switch entry.Op.Kind {
 		case OpPut:
-			finalSeq := seq + 1
-			switch entry.Phase {
-			case PhasePrepared:
-				if err := my.Begin(ctx); err != nil {
-					return 0, err
-				}
-				if err := my.Put(ctx, entry.Op.K, entry.Op.V); err != nil {
-					_ = my.Rollback(ctx)
-					return 0, err
-				}
-				if err := my.Commit(ctx); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseMyDone); err != nil {
-					return 0, err
-				}
-				if ref != nil {
-					if err := ref.Begin(ctx); err != nil {
-						return 0, err
-					}
-					if err := ref.PutWithSeq(entry.Op.K, entry.Op.V, finalSeq); err != nil {
-						_ = ref.Rollback(ctx)
-						return 0, err
-					}
-					if err := ref.Commit(ctx); err != nil {
-						return 0, err
-					}
-				}
-				if err := appendEntry(PhaseRefDone); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseMyDone:
-				if ref != nil {
-					if err := ref.Begin(ctx); err != nil {
-						return 0, err
-					}
-					if err := ref.PutWithSeq(entry.Op.K, entry.Op.V, finalSeq); err != nil {
-						_ = ref.Rollback(ctx)
-						return 0, err
-					}
-					if err := ref.Commit(ctx); err != nil {
-						return 0, err
-					}
-				}
-				if err := appendEntry(PhaseRefDone); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseRefDone:
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			}
-			return finalSeq, nil
+			return applyPut(ctx, my, ref, entry.Op, entry.Seq, entry.Phase, logPhase, nil)
 		case OpDel:
-			finalSeq := seq + 1
-			switch entry.Phase {
-			case PhasePrepared:
-				if err := my.Begin(ctx); err != nil {
-					return 0, err
-				}
-				if err := my.Delete(ctx, entry.Op.K); err != nil {
-					_ = my.Rollback(ctx)
-					return 0, err
-				}
-				if err := my.Commit(ctx); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseMyDone); err != nil {
-					return 0, err
-				}
-				if ref != nil {
-					if err := ref.Begin(ctx); err != nil {
-						return 0, err
-					}
-					if err := ref.DelWithSeq(entry.Op.K, finalSeq); err != nil {
-						_ = ref.Rollback(ctx)
-						return 0, err
-					}
-					if err := ref.Commit(ctx); err != nil {
-						return 0, err
-					}
-				}
-				if err := appendEntry(PhaseRefDone); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseMyDone:
-				if ref != nil {
-					if err := ref.Begin(ctx); err != nil {
-						return 0, err
-					}
-					if err := ref.DelWithSeq(entry.Op.K, finalSeq); err != nil {
-						_ = ref.Rollback(ctx)
-						return 0, err
-					}
-					if err := ref.Commit(ctx); err != nil {
-						return 0, err
-					}
-				}
-				if err := appendEntry(PhaseRefDone); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseRefDone:
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			}
-			return finalSeq, nil
+			return applyDel(ctx, my, ref, entry.Op, entry.Seq, entry.Phase, logPhase, nil)
 		case OpSnap:
-			seqSnap := entry.Seq
-			switch entry.Phase {
-			case PhasePrepared:
-				if _, err := my.NewSnapshot(ctx); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseMyDone); err != nil {
-					return 0, err
-				}
-				if ref != nil {
-					refSeq, err := ref.NewSnapshot(ctx)
-					if err != nil {
-						return 0, err
-					}
-					if refSeq != seqSnap {
-						return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq)
-					}
-				}
-				if err := appendEntry(PhaseRefDone); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseMyDone:
-				if _, err := my.NewSnapshot(ctx); err != nil {
-					return 0, err
-				}
-				if ref != nil {
-					refSeq, err := ref.NewSnapshot(ctx)
-					if err != nil {
-						return 0, err
-					}
-					if refSeq != seqSnap {
-						return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq)
-					}
-				}
-				if err := appendEntry(PhaseRefDone); err != nil {
-					return 0, err
-				}
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseRefDone:
-				if _, err := my.NewSnapshot(ctx); err != nil {
-					return 0, err
-				}
-				if ref != nil {
-					refSeq, err := ref.NewSnapshot(ctx)
-					if err != nil {
-						return 0, err
-					}
-					if refSeq != seqSnap {
-						return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq)
-					}
-				}
-				if err := appendEntry(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseCommitted:
-				// nothing to do
-			}
-			return seqSnap, nil
+			return applySnap(ctx, my, ref, entry.Seq, entry.Phase, logPhase, nil)
 		default:
 			switch entry.Phase {
 			case PhasePrepared:
-				if err := appendEntry(PhaseCommitted); err != nil {
+				if err := logPhase(PhaseCommitted); err != nil {
 					return 0, err
 				}
 			case PhaseMyDone:
-				if err := appendEntry(PhaseRefDone); err != nil {
+				if err := logPhase(PhaseRefDone); err != nil {
 					return 0, err
 				}
-				if err := appendEntry(PhaseCommitted); err != nil {
+				if err := logPhase(PhaseCommitted); err != nil {
 					return 0, err
 				}
 			case PhaseRefDone:
-				if err := appendEntry(PhaseCommitted); err != nil {
+				if err := logPhase(PhaseCommitted); err != nil {
 					return 0, err
 				}
 			}
-			return seq, nil
+			return entry.Seq, nil
 		}
 	}
 	var finalSeq uint64

--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -35,6 +35,15 @@ type Op struct {
 	Limit   int
 }
 
+type Phase string
+
+const (
+	PhasePrepared  Phase = "prepared"
+	PhaseMyDone    Phase = "my_done"
+	PhaseRefDone   Phase = "ref_done"
+	PhaseCommitted Phase = "committed"
+)
+
 // Harness coordinates both engines and records every executed operation.
 type Harness struct {
 	Seed int64
@@ -70,7 +79,7 @@ type Cfg struct {
 
 // NewHarness creates a harness with the given engines and log file path.
 func NewHarness(my Engine, ref *SQLiteOracle, seed int64, logPath string) (*Harness, error) {
-	f, err := os.Create(logPath)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, err
 	}
@@ -216,43 +225,123 @@ func (h *Harness) SetTelemetryHook(fn func(seq uint64, ops int)) { h.telemetry =
 
 // Step applies a single operation, logging it before execution.
 func (h *Harness) Step(ctx context.Context, op Op) error {
-	if err := h.enc.Encode(struct {
-		I   int    `json:"i"`
-		Seq uint64 `json:"seq"`
-		Op  Op     `json:"op"`
-	}{h.ops, h.Seq, op}); err != nil {
+	i := h.ops
+	seq := h.Seq
+	logPhase := func(p Phase) error {
+		if err := h.enc.Encode(struct {
+			I     int    `json:"i"`
+			Seq   uint64 `json:"seq"`
+			Op    Op     `json:"op"`
+			Phase Phase  `json:"phase"`
+		}{i, seq, op, p}); err != nil {
+			return err
+		}
+		return h.log.Sync()
+	}
+	if err := logPhase(PhasePrepared); err != nil {
 		return err
 	}
-	i := h.ops
+	if h.crash != nil {
+		if err := h.crash(); err != nil {
+			return err
+		}
+	}
 	h.ops++
-
 	switch op.Kind {
 	case OpPut:
 		h.Seq++
+		if err := h.My.Begin(ctx); err != nil {
+			return h.fail(i, op, err)
+		}
 		if err := h.My.Put(ctx, op.K, op.V); err != nil {
+			_ = h.My.Rollback(ctx)
+			return h.fail(i, op, err)
+		}
+		if err := h.My.Commit(ctx); err != nil {
 			return h.fail(i, op, err)
 		}
 		h.addKey(op.K)
+		if err := logPhase(PhaseMyDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
+		}
 		if h.Ref != nil {
-			if err := h.Ref.PutWithSeq(op.K, op.V, h.Seq); err != nil {
+			if err := h.Ref.Begin(ctx); err != nil {
 				return h.fail(i, op, err)
+			}
+			if err := h.Ref.PutWithSeq(op.K, op.V, h.Seq); err != nil {
+				_ = h.Ref.Rollback(ctx)
+				return h.fail(i, op, err)
+			}
+			if err := h.Ref.Commit(ctx); err != nil {
+				return h.fail(i, op, err)
+			}
+		}
+		if err := logPhase(PhaseRefDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
 			}
 		}
 	case OpDel:
 		h.Seq++
+		if err := h.My.Begin(ctx); err != nil {
+			return h.fail(i, op, err)
+		}
 		if err := h.My.Delete(ctx, op.K); err != nil {
+			_ = h.My.Rollback(ctx)
+			return h.fail(i, op, err)
+		}
+		if err := h.My.Commit(ctx); err != nil {
 			return h.fail(i, op, err)
 		}
 		h.delKey(op.K)
+		if err := logPhase(PhaseMyDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
+		}
 		if h.Ref != nil {
-			if err := h.Ref.DelWithSeq(op.K, h.Seq); err != nil {
+			if err := h.Ref.Begin(ctx); err != nil {
 				return h.fail(i, op, err)
+			}
+			if err := h.Ref.DelWithSeq(op.K, h.Seq); err != nil {
+				_ = h.Ref.Rollback(ctx)
+				return h.fail(i, op, err)
+			}
+			if err := h.Ref.Commit(ctx); err != nil {
+				return h.fail(i, op, err)
+			}
+		}
+		if err := logPhase(PhaseRefDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
 			}
 		}
 	case OpGet:
 		mv, mok, me := h.My.Get(ctx, op.K, op.SnapSeq)
 		if me != nil {
 			return h.fail(i, op, me)
+		}
+		if err := logPhase(PhaseMyDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
 		}
 		if h.Ref != nil {
 			sv, sok, se := h.Ref.GetWithSeq(op.K, op.SnapSeq)
@@ -263,10 +352,26 @@ func (h *Harness) Step(ctx context.Context, op Op) error {
 				return h.mismatch(i, op, mv, mok, sv, sok)
 			}
 		}
+		if err := logPhase(PhaseRefDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
+		}
 	case OpRange:
 		mres, me := h.My.Range(ctx, op.Lo, op.Hi, op.SnapSeq, op.Limit)
 		if me != nil {
 			return h.fail(i, op, me)
+		}
+		if err := logPhase(PhaseMyDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
 		}
 		if h.Ref != nil {
 			sres, se := h.Ref.RangeWithSeq(op.Lo, op.Hi, op.SnapSeq, op.Limit)
@@ -277,21 +382,48 @@ func (h *Harness) Step(ctx context.Context, op Op) error {
 				return h.fail(i, op, err)
 			}
 		}
+		if err := logPhase(PhaseRefDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
+		}
 	case OpSnap:
-		seq, err := h.My.NewSnapshot(ctx)
+		seqSnap, err := h.My.NewSnapshot(ctx)
 		if err != nil {
 			return h.fail(i, op, err)
+		}
+		if err := logPhase(PhaseMyDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
 		}
 		if h.Ref != nil {
 			refSeq, err := h.Ref.NewSnapshot(ctx)
 			if err != nil {
 				return h.fail(i, op, err)
 			}
-			if seq != refSeq {
-				return h.fail(i, op, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seq, refSeq))
+			if seqSnap != refSeq {
+				return h.fail(i, op, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq))
 			}
 		}
-		h.Snapshots = append(h.Snapshots, seq)
+		h.Snapshots = append(h.Snapshots, seqSnap)
+		if err := logPhase(PhaseRefDone); err != nil {
+			return err
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return err
+			}
+		}
+	}
+	if err := logPhase(PhaseCommitted); err != nil {
+		return err
 	}
 	return nil
 }
@@ -489,34 +621,275 @@ func (h *Harness) checkInvariants(ctx context.Context, r *rand.Rand, cfg Cfg) er
 // Replay replays operations from logPath against the provided engines.
 // It returns the final sequence after applying all operations.
 func Replay(ctx context.Context, my Engine, ref *SQLiteOracle, logPath string) (uint64, error) {
-	log, err := os.Open(logPath)
+	f, err := os.OpenFile(logPath, os.O_RDWR, 0)
 	if err != nil {
 		return 0, err
 	}
-	defer log.Close()
-	dec := json.NewDecoder(log)
-	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	if err != nil {
-		return 0, err
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	type logEntry struct {
+		I     int    `json:"i"`
+		Seq   uint64 `json:"seq"`
+		Op    Op     `json:"op"`
+		Phase Phase  `json:"phase"`
 	}
-	defer devnull.Close()
-	h := &Harness{My: my, Ref: ref, log: devnull, enc: json.NewEncoder(devnull)}
-	h.Snapshots = append(h.Snapshots, h.Seq)
-	var entry struct {
-		Seq uint64 `json:"seq"`
-		Op  Op     `json:"op"`
-	}
+	var entries []logEntry
 	for {
-		if err := dec.Decode(&entry); err != nil {
+		var e logEntry
+		if err := dec.Decode(&e); err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
 			return 0, err
 		}
-		h.Seq = entry.Seq
-		if err := h.Step(ctx, entry.Op); err != nil {
-			return 0, err
+		entries = append(entries, e)
+	}
+	if len(entries) == 0 {
+		return 0, nil
+	}
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		return 0, err
+	}
+	enc := json.NewEncoder(f)
+	write := func(e logEntry) error {
+		if err := enc.Encode(e); err != nil {
+			return err
+		}
+		return f.Sync()
+	}
+	last := entries[len(entries)-1]
+	finalize := func(entry logEntry) (uint64, error) {
+		appendEntry := func(p Phase) error {
+			e := logEntry{I: entry.I, Seq: entry.Seq, Op: entry.Op, Phase: p}
+			if err := write(e); err != nil {
+				return err
+			}
+			entries = append(entries, e)
+			return nil
+		}
+		seq := entry.Seq
+		switch entry.Op.Kind {
+		case OpPut:
+			finalSeq := seq + 1
+			switch entry.Phase {
+			case PhasePrepared:
+				if err := my.Begin(ctx); err != nil {
+					return 0, err
+				}
+				if err := my.Put(ctx, entry.Op.K, entry.Op.V); err != nil {
+					_ = my.Rollback(ctx)
+					return 0, err
+				}
+				if err := my.Commit(ctx); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseMyDone); err != nil {
+					return 0, err
+				}
+				if ref != nil {
+					if err := ref.Begin(ctx); err != nil {
+						return 0, err
+					}
+					if err := ref.PutWithSeq(entry.Op.K, entry.Op.V, finalSeq); err != nil {
+						_ = ref.Rollback(ctx)
+						return 0, err
+					}
+					if err := ref.Commit(ctx); err != nil {
+						return 0, err
+					}
+				}
+				if err := appendEntry(PhaseRefDone); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseMyDone:
+				if ref != nil {
+					if err := ref.Begin(ctx); err != nil {
+						return 0, err
+					}
+					if err := ref.PutWithSeq(entry.Op.K, entry.Op.V, finalSeq); err != nil {
+						_ = ref.Rollback(ctx)
+						return 0, err
+					}
+					if err := ref.Commit(ctx); err != nil {
+						return 0, err
+					}
+				}
+				if err := appendEntry(PhaseRefDone); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseRefDone:
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			}
+			return finalSeq, nil
+		case OpDel:
+			finalSeq := seq + 1
+			switch entry.Phase {
+			case PhasePrepared:
+				if err := my.Begin(ctx); err != nil {
+					return 0, err
+				}
+				if err := my.Delete(ctx, entry.Op.K); err != nil {
+					_ = my.Rollback(ctx)
+					return 0, err
+				}
+				if err := my.Commit(ctx); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseMyDone); err != nil {
+					return 0, err
+				}
+				if ref != nil {
+					if err := ref.Begin(ctx); err != nil {
+						return 0, err
+					}
+					if err := ref.DelWithSeq(entry.Op.K, finalSeq); err != nil {
+						_ = ref.Rollback(ctx)
+						return 0, err
+					}
+					if err := ref.Commit(ctx); err != nil {
+						return 0, err
+					}
+				}
+				if err := appendEntry(PhaseRefDone); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseMyDone:
+				if ref != nil {
+					if err := ref.Begin(ctx); err != nil {
+						return 0, err
+					}
+					if err := ref.DelWithSeq(entry.Op.K, finalSeq); err != nil {
+						_ = ref.Rollback(ctx)
+						return 0, err
+					}
+					if err := ref.Commit(ctx); err != nil {
+						return 0, err
+					}
+				}
+				if err := appendEntry(PhaseRefDone); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseRefDone:
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			}
+			return finalSeq, nil
+		case OpSnap:
+			seqSnap := entry.Seq
+			switch entry.Phase {
+			case PhasePrepared:
+				if _, err := my.NewSnapshot(ctx); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseMyDone); err != nil {
+					return 0, err
+				}
+				if ref != nil {
+					refSeq, err := ref.NewSnapshot(ctx)
+					if err != nil {
+						return 0, err
+					}
+					if refSeq != seqSnap {
+						return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq)
+					}
+				}
+				if err := appendEntry(PhaseRefDone); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseMyDone:
+				if _, err := my.NewSnapshot(ctx); err != nil {
+					return 0, err
+				}
+				if ref != nil {
+					refSeq, err := ref.NewSnapshot(ctx)
+					if err != nil {
+						return 0, err
+					}
+					if refSeq != seqSnap {
+						return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq)
+					}
+				}
+				if err := appendEntry(PhaseRefDone); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseRefDone:
+				if _, err := my.NewSnapshot(ctx); err != nil {
+					return 0, err
+				}
+				if ref != nil {
+					refSeq, err := ref.NewSnapshot(ctx)
+					if err != nil {
+						return 0, err
+					}
+					if refSeq != seqSnap {
+						return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seqSnap, refSeq)
+					}
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseCommitted:
+				// nothing to do
+			}
+			return seqSnap, nil
+		default:
+			switch entry.Phase {
+			case PhasePrepared:
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseMyDone:
+				if err := appendEntry(PhaseRefDone); err != nil {
+					return 0, err
+				}
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			case PhaseRefDone:
+				if err := appendEntry(PhaseCommitted); err != nil {
+					return 0, err
+				}
+			}
+			return seq, nil
 		}
 	}
-	return h.Seq, nil
+	var finalSeq uint64
+	for _, e := range entries {
+		if e.Phase == PhaseCommitted {
+			if e.Op.Kind == OpPut || e.Op.Kind == OpDel {
+				finalSeq = e.Seq + 1
+			} else {
+				finalSeq = e.Seq
+			}
+		}
+	}
+	if last.Phase != PhaseCommitted {
+		fs, err := finalize(last)
+		if err != nil {
+			return 0, err
+		}
+		finalSeq = fs
+	}
+	return finalSeq, nil
 }

--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -724,6 +724,30 @@ func Replay(ctx context.Context, my Engine, ref *SQLiteOracle, logPath string) (
 		return f.Sync()
 	}
 	last := entries[len(entries)-1]
+
+	// Reapply committed mutations to the reference engine in case it lost
+	// state during a crash. Inserts use OR IGNORE semantics so replays are
+	// idempotent.
+	for _, e := range entries {
+		if e.Phase != PhaseCommitted {
+			continue
+		}
+		switch e.Op.Kind {
+		case OpPut:
+			if ref != nil {
+				if err := ref.PutWithSeq(e.Op.K, e.Op.V, e.Seq+1); err != nil {
+					return 0, err
+				}
+			}
+		case OpDel:
+			if ref != nil {
+				if err := ref.DelWithSeq(e.Op.K, e.Seq+1); err != nil {
+					return 0, err
+				}
+			}
+		}
+	}
+
 	finalize := func(entry logEntry) (uint64, error) {
 		logPhase := func(p Phase) error {
 			return write(logEntry{I: entry.I, Seq: entry.Seq, Op: entry.Op, Phase: p})
@@ -734,7 +758,30 @@ func Replay(ctx context.Context, my Engine, ref *SQLiteOracle, logPath string) (
 		case OpDel:
 			return applyDel(ctx, my, ref, entry.Op, entry.Seq, entry.Phase, logPhase, nil)
 		case OpSnap:
-			return applySnap(ctx, my, ref, entry.Seq, entry.Phase, logPhase, nil)
+			seq, err := applySnap(ctx, my, ref, entry.Seq, entry.Phase, logPhase, nil)
+			if err != nil {
+				return 0, err
+			}
+			// Replay doesn't retain snapshot handles, so release any
+			// snapshots created while finalizing the log entry.
+			switch entry.Phase {
+			case PhasePrepared:
+				if err := my.ReleaseSnapshot(ctx, seq); err != nil {
+					return 0, err
+				}
+				if ref != nil {
+					if err := ref.ReleaseSnapshot(ctx, seq); err != nil {
+						return 0, err
+					}
+				}
+			case PhaseMyDone:
+				if ref != nil {
+					if err := ref.ReleaseSnapshot(ctx, seq); err != nil {
+						return 0, err
+					}
+				}
+			}
+			return seq, nil
 		default:
 			switch entry.Phase {
 			case PhasePrepared:

--- a/diffharness/harness_test.go
+++ b/diffharness/harness_test.go
@@ -3,6 +3,7 @@ package diffharness
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,17 +36,19 @@ func TestHarnessLogsAndSnapshots(t *testing.T) {
 	data, err := os.ReadFile(logPath)
 	require.NoError(t, err)
 	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
-	require.Len(t, lines, 2)
+	require.Len(t, lines, 8)
 
 	var first struct {
-		I   int    `json:"i"`
-		Seq uint64 `json:"seq"`
-		Op  Op     `json:"op"`
+		I     int    `json:"i"`
+		Seq   uint64 `json:"seq"`
+		Op    Op     `json:"op"`
+		Phase Phase  `json:"phase"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(lines[0]), &first))
 	require.Equal(t, 0, first.I)
 	require.Equal(t, uint64(0), first.Seq)
 	require.Equal(t, OpPut, first.Op.Kind)
+	require.Equal(t, PhasePrepared, first.Phase)
 }
 
 // sqliteEngine adapts SQLiteOracle to the Engine interface for testing.
@@ -79,6 +82,10 @@ func (e *sqliteEngine) ReleaseSnapshot(ctx context.Context, seq uint64) error {
 }
 
 func (e *sqliteEngine) Close() error { return e.o.Close() }
+
+func (e *sqliteEngine) Begin(ctx context.Context) error    { return e.o.Begin(ctx) }
+func (e *sqliteEngine) Commit(ctx context.Context) error   { return e.o.Commit(ctx) }
+func (e *sqliteEngine) Rollback(ctx context.Context) error { return e.o.Rollback(ctx) }
 
 func TestHistoricalReads(t *testing.T) {
 	dir := t.TempDir()
@@ -247,56 +254,54 @@ func TestHarnessCrashAndTelemetryHooks(t *testing.T) {
 	require.Greater(t, telem, 0)
 }
 
-func TestReplayReproducesState(t *testing.T) {
+func TestReplayRecoversAfterCrash(t *testing.T) {
 	dir := t.TempDir()
-	ref, err := OpenSQLiteOracle(filepath.Join(dir, "ref.db"))
+	ctx := context.Background()
+	refPath := filepath.Join(dir, "ref.db")
+	ref, err := OpenSQLiteOracle(refPath)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = ref.Close() })
-
-	myOracle, err := OpenSQLiteOracle(filepath.Join(dir, "my.db"))
+	dbDir := filepath.Join(dir, "db")
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dbDir))
 	require.NoError(t, err)
-	eng := &sqliteEngine{o: myOracle}
-
+	eng := NewRinDBEngine(db)
 	logPath := filepath.Join(dir, "log.jsonl")
 	h, err := NewHarness(eng, ref, 1, logPath)
 	require.NoError(t, err)
-	eng.seq = &h.Seq
-	t.Cleanup(func() { _ = h.Close(); _ = eng.Close() })
+	h.Snapshots = append(h.Snapshots, h.Seq)
 
-	cfg := Cfg{
-		KeyLen:    10,
-		ValLenMax: 100,
-		RangeMax:  100,
-		Weights: map[OpKind]int{
-			OpPut:   1,
-			OpDel:   1,
-			OpGet:   1,
-			OpRange: 1,
-			OpSnap:  1,
-		},
-	}
-	ctx := context.Background()
-	require.NoError(t, h.Run(ctx, cfg, 30))
-	finalSeq := h.Seq
-	lo := []byte{0x00, 0x00}
-	hi := []byte{0xff, 0xff}
-	exp, err := ref.RangeWithSeq(lo, hi, finalSeq, 1000)
-	require.NoError(t, err)
+	calls := 0
+	h.SetCrashHook(func() error {
+		calls++
+		if calls == 2 {
+			_ = eng.Close()
+			_ = ref.Close()
+			return fmt.Errorf("crash")
+		}
+		return nil
+	})
 
-	// Replay
-	ref2, err := OpenSQLiteOracle(filepath.Join(dir, "ref2.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = ref2.Close() })
-	dbDir2 := filepath.Join(dir, "db2")
-	db2, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dbDir2))
+	err = h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v")})
+	require.Error(t, err)
+	require.Equal(t, 2, calls)
+	_ = h.Close()
+
+	db2, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dbDir))
 	require.NoError(t, err)
 	eng2 := NewRinDBEngine(db2)
-	t.Cleanup(func() { _ = eng2.Close() })
-	seq2, err := Replay(ctx, eng2, ref2, logPath)
+	ref2, err := OpenSQLiteOracle(refPath)
 	require.NoError(t, err)
-	got, err := ref2.RangeWithSeq(lo, hi, seq2, 1000)
+
+	seq, err := Replay(ctx, eng2, ref2, logPath)
 	require.NoError(t, err)
-	require.Equal(t, exp, got)
+
+	mv, mok, err := eng2.Get(ctx, []byte("k"), seq)
+	require.NoError(t, err)
+	rv, rok, err := ref2.GetWithSeq([]byte("k"), seq)
+	require.NoError(t, err)
+	require.Equal(t, mok, rok)
+	if mok {
+		require.Equal(t, mv, rv)
+	}
 }
 
 func TestHarnessCloseWithoutSnapshots(t *testing.T) {

--- a/diffharness/rindb_engine.go
+++ b/diffharness/rindb_engine.go
@@ -18,6 +18,10 @@ func NewRinDBEngine(db *rindb.Rindb) *RinDBEngine {
 	return &RinDBEngine{db: db, snaps: make(map[uint64]*rindb.Snapshot)}
 }
 
+func (e *RinDBEngine) Begin(ctx context.Context) error    { return nil }
+func (e *RinDBEngine) Commit(ctx context.Context) error   { return nil }
+func (e *RinDBEngine) Rollback(ctx context.Context) error { return nil }
+
 func (e *RinDBEngine) Put(ctx context.Context, k, v []byte) error {
 	return e.db.Put(ctx, rindb.Bytes(k), rindb.Bytes(v))
 }

--- a/diffharness/sqlite_oracle.go
+++ b/diffharness/sqlite_oracle.go
@@ -77,12 +77,12 @@ func (o *SQLiteOracle) exec(query string, args ...any) error {
 
 // PutWithSeq inserts or replaces a value at the given sequence number.
 func (o *SQLiteOracle) PutWithSeq(k, v []byte, seq uint64) error {
-	return o.exec(`INSERT INTO kv (k, seq, v, del) VALUES (?, ?, ?, 0)`, k, seq, v)
+	return o.exec(`INSERT OR IGNORE INTO kv (k, seq, v, del) VALUES (?, ?, ?, 0)`, k, seq, v)
 }
 
 // DelWithSeq records a tombstone for the key at the provided sequence number.
 func (o *SQLiteOracle) DelWithSeq(k []byte, seq uint64) error {
-	return o.exec(`INSERT INTO kv (k, seq, v, del) VALUES (?, ?, NULL, 1)`, k, seq)
+	return o.exec(`INSERT OR IGNORE INTO kv (k, seq, v, del) VALUES (?, ?, NULL, 1)`, k, seq)
 }
 
 // GetWithSeq retrieves the latest value for k at or before the snapshot

--- a/diffharness/sqlite_oracle.go
+++ b/diffharness/sqlite_oracle.go
@@ -13,6 +13,7 @@ import (
 // so reads can be performed at past snapshots.
 type SQLiteOracle struct {
 	db *sql.DB
+	tx *sql.Tx
 }
 
 // OpenSQLiteOracle opens or creates a SQLite database at the given path and
@@ -38,16 +39,50 @@ CREATE TABLE IF NOT EXISTS kv (
 	return &SQLiteOracle{db: db}, nil
 }
 
+func (o *SQLiteOracle) Begin(ctx context.Context) error {
+	tx, err := o.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	o.tx = tx
+	return nil
+}
+
+func (o *SQLiteOracle) Commit(ctx context.Context) error {
+	if o.tx == nil {
+		return nil
+	}
+	err := o.tx.Commit()
+	o.tx = nil
+	return err
+}
+
+func (o *SQLiteOracle) Rollback(ctx context.Context) error {
+	if o.tx == nil {
+		return nil
+	}
+	err := o.tx.Rollback()
+	o.tx = nil
+	return err
+}
+
+func (o *SQLiteOracle) exec(query string, args ...any) error {
+	if o.tx != nil {
+		_, err := o.tx.Exec(query, args...)
+		return err
+	}
+	_, err := o.db.Exec(query, args...)
+	return err
+}
+
 // PutWithSeq inserts or replaces a value at the given sequence number.
 func (o *SQLiteOracle) PutWithSeq(k, v []byte, seq uint64) error {
-	_, err := o.db.Exec(`INSERT INTO kv (k, seq, v, del) VALUES (?, ?, ?, 0)`, k, seq, v)
-	return err
+	return o.exec(`INSERT INTO kv (k, seq, v, del) VALUES (?, ?, ?, 0)`, k, seq, v)
 }
 
 // DelWithSeq records a tombstone for the key at the provided sequence number.
 func (o *SQLiteOracle) DelWithSeq(k []byte, seq uint64) error {
-	_, err := o.db.Exec(`INSERT INTO kv (k, seq, v, del) VALUES (?, ?, NULL, 1)`, k, seq)
-	return err
+	return o.exec(`INSERT INTO kv (k, seq, v, del) VALUES (?, ?, NULL, 1)`, k, seq)
 }
 
 // GetWithSeq retrieves the latest value for k at or before the snapshot


### PR DESCRIPTION
## Summary
- add transaction hooks to Engine and SQLite oracle
- log diffharness ops with 2PC phases and crash points
- recover incomplete ops on restart via Replay
- cover crash recovery with new test
- replay harness log when restarting diffharness CLI

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`
- `timeout 30 make diffharness-local`
- `timeout 10 make diffharness-local`


------
https://chatgpt.com/codex/tasks/task_e_68c4ecb6a8bc832595c4183ed588df9b