### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     <img src='https://img.shields.io/codecov/c/github/metailurini/rindb.svg?maxAge=2592000'>
     <img src='https://qlty.sh/gh/metailurini/projects/rindb/maintainability.svg'>
     <img src='https://img.shields.io/github/license/metailurini/rindb'>
+    <a href="https://deepwiki.com/metailurini/rindb">
+        <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">
+    </a>
 </p>
 
 


### PR DESCRIPTION
## Summary
- add DeepWiki badge linking to project documentation

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4f8dac54083259497287819c77321