### PR TITLE
refactor: streamline iteration and cleanup

### DIFF
--- a/io.go
+++ b/io.go
@@ -103,7 +103,9 @@ func readRecordMeta(r *offsetReader) (key Bytes, seq uint64, typ RecordType, val
 	}
 
 	valueOff = r.Offset()
-	r.offset += int64(valueLen) + checksumSize
+	if _, err := io.CopyN(io.Discard, r, int64(valueLen)+checksumSize); err != nil {
+		return nil, 0, 0, 0, 0, fmt.Errorf("failed to skip value and checksum: %w", err)
+	}
 	return key, seq, typ, valueOff, valueLen, nil
 }
 

--- a/io_test.go
+++ b/io_test.go
@@ -225,3 +225,18 @@ func BenchmarkReadRecord(b *testing.B) {
 		}
 	}
 }
+
+func TestReadRecordMetaSkipError(t *testing.T) {
+	ikey := EncodeInternalKey(Bytes("k"), 1, TypeValue)
+	var buf bytes.Buffer
+	writeNumberBuf(&buf, uint64(len(ikey)))
+	writeNumberBuf(&buf, 1)
+	buf.Write(ikey)
+
+	fss, closer := initTempFileSystems(t, 1, [][]byte{buf.Bytes()})
+	defer closer()
+	reader := newOffsetReader(fss[0], 0)
+	_, _, _, _, _, err := readRecordMeta(reader)
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to skip value and checksum")
+}

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -1,7 +1,5 @@
 package rindb
 
-import "errors"
-
 type pqItem struct {
 	rec  Record
 	iter BiIterator[Record]
@@ -52,13 +50,10 @@ func NewMergingIterator(iterators []BiIterator[Record], reverse bool, cleanup fu
 			rec, err = it.Next()
 		}
 		if err != nil {
-			if !errors.Is(err, EOI) {
-				if cleanup != nil {
-					cleanup()
-				}
-				return nil, err
+			if cleanup != nil {
+				cleanup()
 			}
-			continue
+			return nil, err
 		}
 		pq.PushItem(pqItem{rec: rec, iter: it})
 	}
@@ -93,9 +88,7 @@ func (m *MergingIterator) prepare() {
 		}
 	}
 	if err != nil {
-		if !errors.Is(err, EOI) {
-			m.err = err
-		}
+		m.err = err
 	} else {
 		m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
 	}

--- a/rindb.go
+++ b/rindb.go
@@ -236,6 +236,14 @@ func (r *Rindb) Get(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error
 	return r.SSTableManager.SearchKey(ctx, key, maxSeq)
 }
 
+func cleanupTableEntries(entries []*tableCacheEntry) func() {
+	return func() {
+		for _, e := range entries {
+			e.unref()
+		}
+	}
+}
+
 // IRange returns an iterator over records with keys in [start, end],
 // merged across the memtable and relevant SSTables.
 //
@@ -268,13 +276,7 @@ func (r *Rindb) IRange(ctx context.Context, start, end Bytes, seq ...uint64) (*R
 	if err != nil {
 		return nil, err
 	}
-	opened := entries
-
-	cleanupOpened := func() {
-		for _, o := range opened {
-			o.unref()
-		}
-	}
+	cleanupOpened := cleanupTableEntries(entries)
 
 	for _, entry := range entries {
 		rangeIter, err := entry.Table.IRange(start, end, maxSeq)
@@ -326,13 +328,7 @@ func (r *Rindb) IRangeReverse(ctx context.Context, start, end Bytes, seq ...uint
 	if err != nil {
 		return nil, err
 	}
-	opened := entries
-
-	cleanupOpened := func() {
-		for _, o := range opened {
-			o.unref()
-		}
-	}
+	cleanupOpened := cleanupTableEntries(entries)
 
 	for _, entry := range entries {
 		rangeIter, err := entry.Table.IRangeReverse(start, end, maxSeq)

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -267,15 +267,13 @@ func (srr *sstableIRangeRev) prepare() {
 			continue
 		}
 		srr.blockIdx--
-		if srr.blockIdx < 0 {
-			srr.err = EOI
-			return
-		}
-		srr.blockStart = srr.s.SparseIndex[srr.blockIdx].offset
-		if srr.blockIdx+1 < len(srr.s.SparseIndex) {
-			srr.scanEnd = srr.s.SparseIndex[srr.blockIdx+1].offset
-		} else {
-			srr.scanEnd = srr.dataEnd
+		if srr.blockIdx >= 0 {
+			srr.blockStart = srr.s.SparseIndex[srr.blockIdx].offset
+			if srr.blockIdx+1 < len(srr.s.SparseIndex) {
+				srr.scanEnd = srr.s.SparseIndex[srr.blockIdx+1].offset
+			} else {
+				srr.scanEnd = srr.dataEnd
+			}
 		}
 	}
 }

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -68,10 +68,10 @@ func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (BiIterator[Reco
 	idx := sort.Search(len(s.SparseIndex), func(i int) bool {
 		return s.SparseIndex[i].key.Compare(end) > 0
 	})
-	var offset int64
-	if idx > 0 {
-		idx--
-		offset = s.SparseIndex[idx].offset
+	blockIdx := idx - 1
+	var blockStart int64
+	if blockIdx >= 0 {
+		blockStart = s.SparseIndex[blockIdx].offset
 	}
 
 	tailOffset, err := getSSTableTailOffset(s.FileSystem)
@@ -84,7 +84,29 @@ func (s SStable) IRangeReverse(start, end Bytes, seq ...uint64) (BiIterator[Reco
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRangeRev{s: &s, startKey: start, endKey: end, seq: maxSeq, blockIdx: idx, offset: offset, dataEnd: dataEnd, pos: -1}, nil
+	var scanEnd int64
+	if idx < len(s.SparseIndex) {
+		scanEnd = s.SparseIndex[idx].offset
+	} else {
+		scanEnd = dataEnd
+	}
+
+	fwd, err := s.IRange(start, end, maxSeq)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sstableIRangeRev{
+		s:          &s,
+		startKey:   start,
+		endKey:     end,
+		seq:        maxSeq,
+		blockIdx:   blockIdx,
+		blockStart: blockStart,
+		scanEnd:    scanEnd,
+		dataEnd:    dataEnd,
+		fwd:        fwd,
+	}, nil
 }
 
 type sstableIterator struct {
@@ -175,18 +197,21 @@ func (sri *sstableIRange) Next() (Record, error) {
 	return sri.next, nil
 }
 
-// sstableIRangeRev iterates over a range of keys in reverse order.
+// sstableIRangeRev iterates over a range of keys in reverse order while also
+// supporting forward iteration via a separate iterator.
 type sstableIRangeRev struct {
-	s        *SStable
-	startKey Bytes
-	endKey   Bytes
-	seq      uint64
-	blockIdx int
-	offset   int64
-	dataEnd  int64
-	records  []recMeta
-	pos      int
-	err      error
+	s          *SStable
+	startKey   Bytes
+	endKey     Bytes
+	seq        uint64
+	blockIdx   int
+	blockStart int64
+	scanEnd    int64
+	dataEnd    int64
+	cur        recMeta
+	curValid   bool
+	err        error
+	fwd        Iterator[Record]
 }
 
 type recMeta struct {
@@ -197,67 +222,74 @@ type recMeta struct {
 	valueLen uint64
 }
 
-func (srr *sstableIRangeRev) fillBuf() {
-	if srr.blockIdx < 0 {
-		srr.err = EOI
-		return
-	}
-	var nextOffset int64
-	if srr.blockIdx+1 < len(srr.s.SparseIndex) {
-		nextOffset = srr.s.SparseIndex[srr.blockIdx+1].offset
-	} else {
-		nextOffset = srr.dataEnd
-	}
-	reader := newOffsetReader(srr.s.FileSystem, srr.offset)
-	var metas []recMeta
-	for reader.Offset() < nextOffset {
+func (srr *sstableIRangeRev) scanBlockForPrev(start, end int64) (recMeta, int64, bool, error) {
+	reader := newOffsetReader(srr.s.FileSystem, start)
+	var last recMeta
+	lastStart := int64(-1)
+	for reader.Offset() < end {
+		recStart := reader.Offset()
 		key, seq, typ, valueOff, valueLen, err := readRecordMeta(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			srr.err = err
-			return
+			return recMeta{}, 0, false, err
 		}
 		if key.Compare(srr.endKey) > 0 {
 			break
 		}
-		metas = append(metas, recMeta{key: key, seq: seq, typ: typ, valueOff: valueOff, valueLen: valueLen})
-	}
-	left := sort.Search(len(metas), func(i int) bool { return metas[i].key.Compare(srr.startKey) >= 0 })
-	right := sort.Search(len(metas), func(i int) bool { return metas[i].key.Compare(srr.endKey) > 0 })
-	srr.records = srr.records[:0]
-	for i := left; i < right; i++ {
-		if metas[i].seq <= srr.seq {
-			srr.records = append(srr.records, metas[i])
+		if key.Compare(srr.startKey) >= 0 && seq <= srr.seq {
+			last = recMeta{key: key, seq: seq, typ: typ, valueOff: valueOff, valueLen: valueLen}
+			lastStart = recStart
 		}
 	}
-	srr.pos = len(srr.records) - 1
-	srr.blockIdx--
-	if srr.blockIdx >= 0 {
-		srr.offset = srr.s.SparseIndex[srr.blockIdx].offset
+	if lastStart == -1 {
+		return recMeta{}, 0, false, nil
 	}
+	return last, lastStart, true, nil
 }
 
 func (srr *sstableIRangeRev) prepare() {
-	for srr.pos < 0 && srr.err == nil {
-		srr.fillBuf()
+	for !srr.curValid && srr.err == nil {
+		if srr.blockIdx < 0 {
+			srr.err = EOI
+			return
+		}
+		meta, off, ok, err := srr.scanBlockForPrev(srr.blockStart, srr.scanEnd)
+		if err != nil {
+			srr.err = err
+			return
+		}
+		if ok {
+			srr.cur = meta
+			srr.curValid = true
+			srr.scanEnd = off
+			continue
+		}
+		srr.blockIdx--
+		if srr.blockIdx < 0 {
+			srr.err = EOI
+			return
+		}
+		srr.blockStart = srr.s.SparseIndex[srr.blockIdx].offset
+		if srr.blockIdx+1 < len(srr.s.SparseIndex) {
+			srr.scanEnd = srr.s.SparseIndex[srr.blockIdx+1].offset
+		} else {
+			srr.scanEnd = srr.dataEnd
+		}
 	}
 }
 
-// HasNext implements Iterator but always returns false for reverse iterator.
-func (srr *sstableIRangeRev) HasNext() bool { return false }
+// HasNext implements Iterator by delegating to the forward iterator.
+func (srr *sstableIRangeRev) HasNext() bool { return srr.fwd.HasNext() }
 
-// Next implements Iterator and always returns EOI.
-func (srr *sstableIRangeRev) Next() (Record, error) {
-	var empty Record
-	return empty, EOI
-}
+// Next implements Iterator by delegating to the forward iterator.
+func (srr *sstableIRangeRev) Next() (Record, error) { return srr.fwd.Next() }
 
 // HasPrev implements BiIterator.
 func (srr *sstableIRangeRev) HasPrev() bool {
 	srr.prepare()
-	return srr.pos >= 0
+	return srr.curValid
 }
 
 // Prev implements BiIterator.
@@ -266,8 +298,8 @@ func (srr *sstableIRangeRev) Prev() (Record, error) {
 		var empty Record
 		return empty, srr.err
 	}
-	meta := srr.records[srr.pos]
-	srr.pos--
+	meta := srr.cur
+	srr.curValid = false
 	reader := newOffsetReader(srr.s.FileSystem, meta.valueOff)
 	var value Bytes
 	if meta.valueLen > 0 {

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -1,0 +1,68 @@
+package rindb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeNumberTest(buf *bytes.Buffer, n uint64) {
+	var b [mdByteSize]byte
+	byteOrder.PutUint64(b[:], n)
+	buf.Write(b[:])
+}
+
+func buildRecordBytes(key Bytes, seq uint64, value Bytes) []byte {
+	ikey := EncodeInternalKey(key, seq, TypeValue)
+	var buf bytes.Buffer
+	writeNumberTest(&buf, uint64(len(ikey)))
+	writeNumberTest(&buf, uint64(len(value)))
+	buf.Write(ikey)
+	buf.Write(value)
+	var c [checksumSize]byte
+	byteOrder.PutUint32(c[:], checksum(ikey, value))
+	buf.Write(c[:])
+	return buf.Bytes()
+}
+
+func TestScanBlockForPrevEOF(t *testing.T) {
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	rec := buildRecordBytes(Bytes("a"), 1, Bytes("v"))
+	_, err := fs.WriteAt(rec, 0)
+	require.NoError(t, err)
+
+	s := &SStable{FileSystem: fs}
+	srr := sstableIRangeRev{s: s, startKey: Bytes("a"), endKey: Bytes("z"), seq: ^uint64(0)}
+
+	meta, off, ok, err := srr.scanBlockForPrev(0, int64(len(rec)+8))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, Bytes("a"), meta.key)
+	assert.Equal(t, int64(0), off)
+}
+
+func TestScanBlockForPrevEndKeyBreak(t *testing.T) {
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	rec1 := buildRecordBytes(Bytes("a"), 1, Bytes("v"))
+	rec2 := buildRecordBytes(Bytes("d"), 1, Bytes("v"))
+	data := append(rec1, rec2...)
+	_, err := fs.WriteAt(data, 0)
+	require.NoError(t, err)
+
+	s := &SStable{FileSystem: fs}
+	srr := sstableIRangeRev{s: s, startKey: Bytes("a"), endKey: Bytes("c"), seq: ^uint64(0)}
+
+	meta, off, ok, err := srr.scanBlockForPrev(0, int64(len(data)))
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, Bytes("a"), meta.key)
+	assert.Equal(t, int64(0), off)
+}

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -413,7 +413,7 @@ func TestSSTableIRangeReverseFiltered(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b")}, keys)
 }
 
-func TestSSTableIRangeReverseNextAlwaysEOI(t *testing.T) {
+func TestSSTableIRangeReverseForward(t *testing.T) {
 	cfg := testConfig()
 	fss, closer := initTempFileSystems(t, 1, nil)
 	defer closer()
@@ -426,7 +426,10 @@ func TestSSTableIRangeReverseNextAlwaysEOI(t *testing.T) {
 
 	it, err := sst.IRangeReverse(Bytes("a"), Bytes("a"))
 	require.NoError(t, err)
-	assert.False(t, it.HasNext())
+	assert.True(t, it.HasNext())
+	rec, err := it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
 	_, err = it.Next()
 	assert.ErrorIs(t, err, EOI)
 }

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -434,6 +434,16 @@ func TestSSTableIRangeReverseForward(t *testing.T) {
 	assert.ErrorIs(t, err, EOI)
 }
 
+func TestSSTableIRangeReverseRangeError(t *testing.T) {
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	sst := SStable{FileSystem: fs}
+	_, err := sst.IRangeReverse(Bytes("a"), Bytes("b"))
+	require.Error(t, err)
+}
+
 // TestSStable_GetValueSparseIndexFallback ensures GetValue can retrieve keys
 // when they are absent from the sparse index by scanning from the nearest
 // preceding entry.


### PR DESCRIPTION
## Summary
- remove manual offset manipulation in record metadata parsing
- consolidate table entry cleanup logic
- streamline iterator error handling and reverse SSTable iteration

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4ffeeb610832586f740e7932e67d9