### PR TITLE
docs: detail reverse range iterator plans

### DIFF
--- a/docs/dev/54/merging_range_iterators_plan.md
+++ b/docs/dev/54/merging_range_iterators_plan.md
@@ -1,0 +1,35 @@
+# Bidirectional merging and range iterators plan
+
+This document expands step 4 of the reverse range scanning plan, detailing how multiple iterators can be merged while supporting backward traversal.
+
+1. Maintain two heaps: `fwd` (min-heap) and `rev` (max-heap) containing the same `pqItem` pointers.
+2. `Next` pops from `fwd`, pushes the item onto `rev`, and advances the underlying iterator; `Prev` mirrors this process.
+3. Tombstones and sequence-number de-duplication occur in both directions before returning each record.
+
+```go
+type MergingIterator struct {
+    fwd pqMin
+    rev pqMax
+    cur pqItem
+}
+
+func (m *MergingIterator) Next() (Record, error) {
+    m.cur = heap.Pop(&m.fwd).(pqItem)
+    heap.Push(&m.rev, m.cur)
+    advance(m.cur.src) // may push new item into fwd
+    return m.cur.rec, nil
+}
+
+func (m *MergingIterator) HasPrev() bool { return m.rev.Len() > 0 }
+
+func (m *MergingIterator) Prev() (Record, error) {
+    m.cur = heap.Pop(&m.rev).(pqItem)
+    heap.Push(&m.fwd, m.cur)
+    rewind(m.cur.src) // may push item into rev
+    return m.cur.rec, nil
+}
+```
+
+Concerns:
+- Rewind helpers must reapply tombstone filtering so that deleted keys stay hidden.
+- Dual heaps require rebalancing when sources are exhausted, otherwise `HasPrev` may leak duplicates.

--- a/docs/dev/54/merging_range_iterators_plan.md
+++ b/docs/dev/54/merging_range_iterators_plan.md
@@ -3,7 +3,7 @@
 This document expands step 4 of the reverse range scanning plan, detailing how multiple iterators can be merged while supporting backward traversal.
 
 1. Maintain two heaps: `fwd` (min-heap) and `rev` (max-heap) containing the same `pqItem` pointers.
-2. `Next` pops from `fwd`, pushes the item onto `rev`, and advances the underlying iterator; `Prev` mirrors this process.
+2. `Next` pops from `fwd`, pushes the item onto `rev`, and advances the underlying iterator; `Prev` removes the current item from `rev`, rewinds its source, and returns the new top of `rev`.
 3. Tombstones and sequence-number de-duplication occur in both directions before returning each record.
 
 ```go
@@ -20,12 +20,16 @@ func (m *MergingIterator) Next() (Record, error) {
     return m.cur.rec, nil
 }
 
-func (m *MergingIterator) HasPrev() bool { return m.rev.Len() > 0 }
+func (m *MergingIterator) HasPrev() bool { return m.rev.Len() > 1 }
 
 func (m *MergingIterator) Prev() (Record, error) {
-    m.cur = heap.Pop(&m.rev).(pqItem)
-    heap.Push(&m.fwd, m.cur)
-    rewind(m.cur.src) // may push item into rev
+    cur := heap.Pop(&m.rev).(pqItem)
+    heap.Push(&m.fwd, cur)
+    if prev := rewind(cur.src); prev != nil {
+        heap.Push(&m.fwd, prev) // candidate for forward scan
+        heap.Push(&m.rev, prev)
+    }
+    m.cur = m.rev.Peek().(pqItem)
     return m.cur.rec, nil
 }
 ```

--- a/docs/dev/54/overall_plan.md
+++ b/docs/dev/54/overall_plan.md
@@ -1,0 +1,104 @@
+# Support reverse range scanning
+
+Complexity is rated from **1** (trivial) to **10** (major cross-cutting change). Steps marked as requiring a dedicated plan file will be expanded separately.
+
+1. **Extend the core Iterator contract** *(Complexity: 3/10)*
+   ```go
+   type Iterator[T any] interface {
+       HasNext() bool
+       Next() (T, error)
+       HasPrev() bool
+       Prev() (T, error)
+   }
+   ```
+
+2. **Make SkipList/Memtable iterators bidirectional** *(Complexity: 5/10)*
+   ```go
+   type SLNode[K Comparable,V any] struct {
+       Key   K
+       Value V
+       forwards []*SLNode[K,V]
+       backward *SLNode[K,V] // level-0 link
+   }
+
+   type slIterator[K Comparable,V any] struct {
+       curr *SLNode[K,V]
+   }
+   func (it *slIterator[K,V]) HasPrev() bool { return it.curr.backward != nil }
+   func (it *slIterator[K,V]) Prev() (V, error) {
+       if !it.HasPrev() { return *new(V), EOI }
+       it.curr = it.curr.backward
+       return it.curr.Value, nil
+   }
+   ```
+   Maintain `backward` links in `Put`/`Remove` so the memtable iterator automatically gains `Prev`.
+
+3. **Enable SSTable iterators to step backward without full buffering** *(Complexity: 8/10 — requires dedicated plan file)*
+   ```go
+   type sstableIterator struct {
+       fs *FileSystem
+       offsets []int64 // stack of visited record starts
+       cur int64
+   }
+   func (s *sstableIterator) Next() (Record, error) {
+       s.offsets = append(s.offsets, s.cur)
+       r := newOffsetReader(s.fs, s.cur)
+       rec, err := readRecord(r)
+       s.cur = r.Offset()
+       return rec, err
+   }
+   func (s *sstableIterator) HasPrev() bool { return len(s.offsets) > 0 }
+   func (s *sstableIterator) Prev() (Record, error) {
+       if !s.HasPrev() { return nil, EOI }
+       prev := s.offsets[len(s.offsets)-1]
+       s.offsets = s.offsets[:len(s.offsets)-1]
+       r := newOffsetReader(s.fs, prev)
+       rec, err := readRecord(r)
+       s.cur = prev
+       return rec, err
+   }
+   ```
+   Apply the same technique to `sstableIRange`, storing only offsets already visited—no boolean flags or full-table buffering.
+
+4. **Redesign MergingIterator & RangeIterator for two-way traversal** *(Complexity: 9/10 — requires dedicated plan file)*
+   ```go
+   type MergingIterator struct {
+       fwd *PriorityQueue[pqItem] // min-heap by key,seq
+       rev *PriorityQueue[pqItem] // max-heap
+       cur pqItem
+       err error
+   }
+   func (m *MergingIterator) Next() (Record, error) {
+       m.cur = m.fwd.PopItem()
+       m.rev.PushItem(m.cur)
+       advanceForward(m.cur)
+       return m.cur.rec, m.err
+   }
+   func (m *MergingIterator) Prev() (Record, error) {
+       m.cur = m.rev.PopItem()
+       m.fwd.PushItem(m.cur)
+       advanceBackward(m.cur)
+       return m.cur.rec, m.err
+   }
+   ```
+   `RangeIterator` simply forwards `HasPrev`/`Prev` to the merging iterator while continuing to filter tombstones and duplicates.
+
+5. **Update public APIs & tests** *(Complexity: 4/10)*
+   ```go
+   func TestRangeIteratorReverse(t *testing.T) {
+       it := setupRangeIterator(t)
+       var last Record
+       for it.HasNext() { last, _ = it.Next() }
+       for it.HasPrev() {
+           rec, _ := it.Prev()
+           // assert ordering and values
+           last = rec
+       }
+   }
+   ```
+   Revise `Rindb.IRange`, `Memtable.Iterator`, and related tests to exercise forward and backward scans.
+
+Dedicated plan files:
+
+- Step 3: [sstable_iterator_plan.md](./sstable_iterator_plan.md)
+- Step 4: [merging_range_iterators_plan.md](./merging_range_iterators_plan.md)

--- a/docs/dev/54/overall_plan.md
+++ b/docs/dev/54/overall_plan.md
@@ -47,14 +47,14 @@ Complexity is rated from **1** (trivial) to **10** (major cross-cutting change).
        s.cur = r.Offset()
        return rec, err
    }
-   func (s *sstableIterator) HasPrev() bool { return len(s.offsets) > 0 }
+   func (s *sstableIterator) HasPrev() bool { return len(s.offsets) > 1 }
    func (s *sstableIterator) Prev() (Record, error) {
        if !s.HasPrev() { return nil, EOI }
-       prev := s.offsets[len(s.offsets)-1]
+       prev := s.offsets[len(s.offsets)-2]
        s.offsets = s.offsets[:len(s.offsets)-1]
        r := newOffsetReader(s.fs, prev)
        rec, err := readRecord(r)
-       s.cur = prev
+       s.cur = r.Offset()
        return rec, err
    }
    ```
@@ -75,9 +75,13 @@ Complexity is rated from **1** (trivial) to **10** (major cross-cutting change).
        return m.cur.rec, m.err
    }
    func (m *MergingIterator) Prev() (Record, error) {
-       m.cur = m.rev.PopItem()
-       m.fwd.PushItem(m.cur)
-       advanceBackward(m.cur)
+       cur := m.rev.PopItem()
+       m.fwd.PushItem(cur)
+       if prev := rewind(cur.src); prev != nil {
+           m.fwd.PushItem(prev)
+           m.rev.PushItem(prev)
+       }
+       m.cur = m.rev.PeekItem()
        return m.cur.rec, m.err
    }
    ```

--- a/docs/dev/54/sstable_iterator_plan.md
+++ b/docs/dev/54/sstable_iterator_plan.md
@@ -14,10 +14,13 @@ type sstableIterator struct {
 }
 
 func (it *sstableIterator) Next() (*Record, error) {
-    off, _ := it.r.Seek(0, io.SeekCurrent)
+    off, err := it.r.Seek(0, io.SeekCurrent)
+    if err != nil { return nil, err }
     it.offs = append(it.offs, off)
-    it.rec = readRecord(it.r)
-    return it.rec, nil
+    rec, err := readRecord(it.r)
+    if err != nil { return nil, err }
+    it.rec = rec
+    return rec, nil
 }
 
 func (it *sstableIterator) HasPrev() bool { return len(it.offs) > 1 }
@@ -25,9 +28,11 @@ func (it *sstableIterator) HasPrev() bool { return len(it.offs) > 1 }
 func (it *sstableIterator) Prev() (*Record, error) {
     last := it.offs[len(it.offs)-2]
     it.offs = it.offs[:len(it.offs)-1]
-    it.r.Seek(last, io.SeekStart)
-    it.rec = readRecord(it.r)
-    return it.rec, nil
+    if _, err := it.r.Seek(last, io.SeekStart); err != nil { return nil, err }
+    rec, err := readRecord(it.r)
+    if err != nil { return nil, err }
+    it.rec = rec
+    return rec, nil
 }
 ```
 

--- a/docs/dev/54/sstable_iterator_plan.md
+++ b/docs/dev/54/sstable_iterator_plan.md
@@ -1,0 +1,36 @@
+# Bidirectional SSTable iterator plan
+
+This document expands step 3 of the reverse range scanning plan and outlines how to walk an SSTable in both directions without materializing all records.
+
+1. Push the file offset of each returned record onto a stack. `Prev` pops the stack and seeks to that offset.
+2. When the iterator reaches a new block, preload its footer and remember the previous block's starting offset to allow rewinding.
+3. Extend `sstableIterator` and `sstableIRange` to share the stack and expose `HasPrev`/`Prev` while staying compatible with the table cache.
+
+```go
+type sstableIterator struct {
+    r    io.ReadSeeker
+    offs []int64 // stack of visited offsets
+    rec  *Record
+}
+
+func (it *sstableIterator) Next() (*Record, error) {
+    off, _ := it.r.Seek(0, io.SeekCurrent)
+    it.offs = append(it.offs, off)
+    it.rec = readRecord(it.r)
+    return it.rec, nil
+}
+
+func (it *sstableIterator) HasPrev() bool { return len(it.offs) > 1 }
+
+func (it *sstableIterator) Prev() (*Record, error) {
+    last := it.offs[len(it.offs)-2]
+    it.offs = it.offs[:len(it.offs)-1]
+    it.r.Seek(last, io.SeekStart)
+    it.rec = readRecord(it.r)
+    return it.rec, nil
+}
+```
+
+Considerations:
+- Keep the stack bounded by dropping offsets when the iterator moves far ahead.
+- Ensure block-prefetch and cache eviction strategies remain valid when seeking backwards.


### PR DESCRIPTION
## Summary
- flesh out bidirectional SSTable iterator design with offset stack and sample `Next`/`Prev` code
- expand merging/range iterator plan with dual-heap approach and example methods

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c5398db6a48325b405e2f1ada8a878