### PR TITLE
docs: refine reverse iteration plan

### DIFF
--- a/docs/dev/54/merging_range_iterators_plan.md
+++ b/docs/dev/54/merging_range_iterators_plan.md
@@ -2,9 +2,10 @@
 
 This document expands step 4 of the reverse range scanning plan, detailing how multiple iterators can be merged while supporting backward traversal.
 
-1. Maintain two heaps: `fwd` (min-heap) and `rev` (max-heap) containing the same `pqItem` pointers.
+1. Seed both heaps with the first record from every source iterator. `fwd` is a min-heap by key/seq; `rev` is a max-heap containing the same `pqItem` pointers.
 2. `Next` pops from `fwd`, pushes the item onto `rev`, and advances the underlying iterator; `Prev` removes the current item from `rev`, rewinds its source, and returns the new top of `rev`.
-3. Tombstones and sequence-number de-duplication occur in both directions before returning each record.
+3. Tombstones and sequence-number de-duplication occur in both directions before items are pushed onto either heap.
+4. Remove exhausted sources from both heaps to keep `HasPrev`/`HasNext` accurate.
 
 ```go
 type MergingIterator struct {
@@ -16,7 +17,7 @@ type MergingIterator struct {
 func (m *MergingIterator) Next() (Record, error) {
     m.cur = heap.Pop(&m.fwd).(pqItem)
     heap.Push(&m.rev, m.cur)
-    advance(m.cur.src) // may push new item into fwd
+    advance(m.cur.src) // may push new item into both heaps
     return m.cur.rec, nil
 }
 
@@ -26,7 +27,7 @@ func (m *MergingIterator) Prev() (Record, error) {
     cur := heap.Pop(&m.rev).(pqItem)
     heap.Push(&m.fwd, cur)
     if prev := rewind(cur.src); prev != nil {
-        heap.Push(&m.fwd, prev) // candidate for forward scan
+        heap.Push(&m.fwd, prev)
         heap.Push(&m.rev, prev)
     }
     m.cur = m.rev.Peek().(pqItem)
@@ -34,6 +35,26 @@ func (m *MergingIterator) Prev() (Record, error) {
 }
 ```
 
+```go
+func advance(src Iterator) {
+    if rec, err := src.Next(); err == nil && !isTombstoned(rec) && isNewest(rec) {
+        item := pqItem{rec: rec, src: src}
+        heap.Push(&m.fwd, item)
+        heap.Push(&m.rev, item)
+    } else if err == io.EOF {
+        dropSource(src) // remove from both heaps
+    }
+}
+
+func rewind(src Iterator) *pqItem {
+    if rec, err := src.Prev(); err == nil && !isTombstoned(rec) && isNewest(rec) {
+        return &pqItem{rec: rec, src: src}
+    }
+    return nil
+}
+```
+
 Concerns:
-- Rewind helpers must reapply tombstone filtering so that deleted keys stay hidden.
+- Rewind helpers must reapply tombstone filtering and sequence-number suppression so deleted or stale keys stay hidden.
 - Dual heaps require rebalancing when sources are exhausted, otherwise `HasPrev` may leak duplicates.
+- Edge tests should exhaust a source, alternate `Next`/`Prev`, and traverse across memtables and SSTables to verify correctness.

--- a/docs/dev/54/merging_range_iterators_plan.md
+++ b/docs/dev/54/merging_range_iterators_plan.md
@@ -3,7 +3,7 @@
 This document expands step 4 of the reverse range scanning plan, detailing how multiple iterators can be merged while supporting backward traversal.
 
 1. Seed both heaps with the first record from every source iterator. `fwd` is a min-heap by key/seq; `rev` is a max-heap containing the same `pqItem` pointers.
-2. `Next` pops from `fwd`, pushes the item onto `rev`, and advances the underlying iterator; `Prev` removes the current item from `rev`, rewinds its source, and returns the new top of `rev`.
+2. `Next` pops from `fwd`, pushes the item onto `rev`, and advances the underlying iterator; `Prev` removes the current item from `rev`, rewinds its source, and returns the new top of `rev`, or `EOI` if the heap becomes empty.
 3. Tombstones and sequence-number de-duplication occur in both directions before items are pushed onto either heap.
 4. Remove exhausted sources from both heaps to keep `HasPrev`/`HasNext` accurate.
 
@@ -29,6 +29,9 @@ func (m *MergingIterator) Prev() (Record, error) {
     if prev := rewind(cur.src); prev != nil {
         heap.Push(&m.fwd, prev)
         heap.Push(&m.rev, prev)
+    }
+    if m.rev.Len() == 0 {
+        return Record{}, io.EOF
     }
     m.cur = m.rev.Peek().(pqItem)
     return m.cur.rec, nil

--- a/docs/dev/54/overall_plan.md
+++ b/docs/dev/54/overall_plan.md
@@ -12,7 +12,7 @@ Complexity is rated from **1** (trivial) to **10** (major cross-cutting change).
    }
    ```
 
-2. **Make SkipList/Memtable iterators bidirectional** *(Complexity: 5/10)*
+2. **Make SkipList/Memtable iterators bidirectional** *(Complexity: 5/10 — requires dedicated plan file)*
    ```go
    type SLNode[K Comparable,V any] struct {
        Key   K
@@ -58,7 +58,7 @@ Complexity is rated from **1** (trivial) to **10** (major cross-cutting change).
        return rec, err
    }
    ```
-   Apply the same technique to `sstableIRange`, storing only offsets already visited—no boolean flags or full-table buffering.
+   Seed the offset stack with the file start and bound its length (e.g., 64K entries) to limit memory growth. Apply the same technique to `sstableIRange`, storing only offsets already visited—no boolean flags or full-table buffering.
 
 4. **Redesign MergingIterator & RangeIterator for two-way traversal** *(Complexity: 9/10 — requires dedicated plan file)*
    ```go
@@ -85,7 +85,7 @@ Complexity is rated from **1** (trivial) to **10** (major cross-cutting change).
        return m.cur.rec, m.err
    }
    ```
-   `RangeIterator` simply forwards `HasPrev`/`Prev` to the merging iterator while continuing to filter tombstones and duplicates.
+   `RangeIterator` simply forwards `HasPrev`/`Prev` to the merging iterator while continuing to filter tombstones and duplicates. Both heaps drop exhausted sources and reapply tombstone filtering and sequence-number suppression when rewinding.
 
 5. **Update public APIs & tests** *(Complexity: 4/10)*
    ```go
@@ -100,9 +100,10 @@ Complexity is rated from **1** (trivial) to **10** (major cross-cutting change).
        }
    }
    ```
-   Revise `Rindb.IRange`, `Memtable.Iterator`, and related tests to exercise forward and backward scans.
+   Revise `Rindb.IRange`, `Memtable.Iterator`, and related tests to exercise forward and backward scans, including calls to `Prev` before `Next`, alternating directions, and empty iterators.
 
 Dedicated plan files:
 
+- Step 2: [skiplist_backward_links_plan.md](./skiplist_backward_links_plan.md)
 - Step 3: [sstable_iterator_plan.md](./sstable_iterator_plan.md)
 - Step 4: [merging_range_iterators_plan.md](./merging_range_iterators_plan.md)

--- a/docs/dev/54/skiplist_backward_links_plan.md
+++ b/docs/dev/54/skiplist_backward_links_plan.md
@@ -3,11 +3,30 @@
 This document expands step 2 of the reverse range scanning plan and explains how level-0 `backward` links remain valid during mutations.
 
 1. **Update `Put`**
-   - When inserting a node, set its `backward` pointer to the previous level-0 node and update the next node's pointer if needed.
+   - When inserting a node, set its `backward` pointer to the previous level-0 node and update the subsequent node's `backward` pointer to point to the new node.
    - Handle concurrent inserts by holding the existing memtable lock; iterators rely on the immutability of nodes once linked.
+   - Example:
+     ```go
+     func (m *memtable) Put(k, v []byte) {
+         pred, succ := findSplice(k)
+         n := newNode(k, v)
+         n.backward = pred
+         if succ != nil { succ.backward = n }
+         insertBetween(pred, n, succ)
+     }
+     ```
 2. **Update `Remove`**
    - Splice the target from level-0 forward and backward lists.
    - Rewire the successor's `backward` pointer to the predecessor so iterators can continue stepping backward.
+   - Example:
+     ```go
+     func (m *memtable) Remove(k []byte) {
+         n := findNode(k)
+         pred, succ := n.backward, n.forwards[0]
+         if succ != nil { succ.backward = pred }
+         unlink(n)
+     }
+     ```
 3. **Concurrency assumptions**
    - Memtable mutations are serialized with existing locking; readers may traverse concurrently because nodes are never modified after unlink.
 4. **Testing**

--- a/docs/dev/54/skiplist_backward_links_plan.md
+++ b/docs/dev/54/skiplist_backward_links_plan.md
@@ -1,0 +1,15 @@
+# Skiplist backward links maintenance plan
+
+This document expands step 2 of the reverse range scanning plan and explains how level-0 `backward` links remain valid during mutations.
+
+1. **Update `Put`**
+   - When inserting a node, set its `backward` pointer to the previous level-0 node and update the next node's pointer if needed.
+   - Handle concurrent inserts by holding the existing memtable lock; iterators rely on the immutability of nodes once linked.
+2. **Update `Remove`**
+   - Splice the target from level-0 forward and backward lists.
+   - Rewire the successor's `backward` pointer to the predecessor so iterators can continue stepping backward.
+3. **Concurrency assumptions**
+   - Memtable mutations are serialized with existing locking; readers may traverse concurrently because nodes are never modified after unlink.
+4. **Testing**
+   - Add unit tests that interleave `Put` and `Remove` with forward and reverse iteration, verifying order and absence of stale pointers.
+   - Include cases that insert and delete around the iterator's current position.

--- a/docs/dev/54/sstable_iterator_plan.md
+++ b/docs/dev/54/sstable_iterator_plan.md
@@ -2,9 +2,11 @@
 
 This document expands step 3 of the reverse range scanning plan and outlines how to walk an SSTable in both directions without materializing all records.
 
-1. Push the file offset of each returned record onto a stack. `Prev` pops the stack and seeks to that offset.
-2. When the iterator reaches a new block, preload its footer and remember the previous block's starting offset to allow rewinding.
-3. Extend `sstableIterator` and `sstableIRange` to share the stack and expose `HasPrev`/`Prev` while staying compatible with the table cache.
+1. Seed the offset stack with the file's starting offset so `HasPrev` is false before the first `Next`.
+2. Push the offset of each returned record onto the stack. `Prev` pops the stack and seeks to that offset.
+3. Bound the stack by a configurable `maxOffs`. When the length exceeds `maxOffs`, drop the oldest entry; attempting to `Prev` past this point will return `EOI`.
+4. When the iterator reaches a new block, preload its footer and remember the previous block's starting offset to allow rewinding.
+5. Extend `sstableIterator` and `sstableIRange` to share the stack and expose `HasPrev`/`Prev` while staying compatible with the table cache.
 
 ```go
 type sstableIterator struct {
@@ -37,5 +39,5 @@ func (it *sstableIterator) Prev() (*Record, error) {
 ```
 
 Considerations:
-- Keep the stack bounded by dropping offsets when the iterator moves far ahead.
+- Make `maxOffs` large enough to cover typical scan ranges (e.g., 64K entries) while keeping memory usage predictable.
 - Ensure block-prefetch and cache eviction strategies remain valid when seeking backwards.

--- a/docs/dev/54/sstable_iterator_plan.md
+++ b/docs/dev/54/sstable_iterator_plan.md
@@ -3,7 +3,7 @@
 This document expands step 3 of the reverse range scanning plan and outlines how to walk an SSTable in both directions without materializing all records.
 
 1. Seed the offset stack with the file's starting offset so `HasPrev` is false before the first `Next`.
-2. Push the offset of each returned record onto the stack. `Prev` pops the stack and seeks to that offset.
+2. Push the offset of each returned record onto the stack. `Prev` pops the current record's offset and seeks to the new top-of-stack to reread the previous record.
 3. Bound the stack by a configurable `maxOffs`. When the length exceeds `maxOffs`, drop the oldest entry; attempting to `Prev` past this point will return `EOI`.
 4. When the iterator reaches a new block, preload its footer and remember the previous block's starting offset to allow rewinding.
 5. Extend `sstableIterator` and `sstableIRange` to share the stack and expose `HasPrev`/`Prev` while staying compatible with the table cache.


### PR DESCRIPTION
## Summary
- document policy for bounding SSTable iterator offset stack
- clarify heap management, deduplication, and rebalancing in merging iterators
- add dedicated skiplist backward link maintenance plan

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c54c935b4c8325adfa57410450c9fc