### PR TITLE
feat: enable reverse iteration in memtables

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -7,10 +7,12 @@ import "errors"
 //lint:ignore ST1012 this is a sentinel error, not a typical error
 var EOI = errors.New("EOI")
 
-// Iterator defines the minimal forward-only iteration contract. It is
-// exported so callers can provide their own iterator implementations that work
-// with Rindb primitives.
+// Iterator defines the iteration contract. Implementations may support
+// moving both forward and backward. It is exported so callers can provide
+// their own iterator implementations that work with Rindb primitives.
 type Iterator[T any] interface {
 	HasNext() bool
 	Next() (T, error)
+	HasPrev() bool
+	Prev() (T, error)
 }

--- a/iterator.go
+++ b/iterator.go
@@ -8,11 +8,21 @@ import "errors"
 var EOI = errors.New("EOI")
 
 // Iterator defines the iteration contract. Implementations may support
-// moving both forward and backward. It is exported so callers can provide
-// their own iterator implementations that work with Rindb primitives.
+// moving both forward and backward. Iterators start positioned before the
+// first element. Next advances to the next element and returns it. Prev
+// returns the current element and moves the iterator one step backward; as a
+// consequence, a Prev call immediately after a successful Next returns the
+// same element again. It is exported so callers can provide their own iterator
+// implementations that work with Rindb primitives.
 type Iterator[T any] interface {
+	// HasNext reports whether calling Next will succeed.
 	HasNext() bool
+	// Next advances to the next element and returns it. It returns EOI
+	// when the iteration is exhausted.
 	Next() (T, error)
+	// HasPrev reports whether calling Prev will succeed.
 	HasPrev() bool
+	// Prev returns the current element and moves the iterator one step
+	// backward. It returns EOI when no more elements remain.
 	Prev() (T, error)
 }

--- a/memtable.go
+++ b/memtable.go
@@ -101,17 +101,18 @@ func (m *memtable) IRange(start, end Bytes, seq uint64) Iterator[Record] {
 }
 
 type memtableIRange struct {
-	it       Iterator[Record]
-	seq      uint64
-	next     Record
-	prepared bool
-	err      error
+	it           Iterator[Record]
+	seq          uint64
+	next         Record
+	preparedNext bool
+	prev         Record
+	preparedPrev bool
+	err          error
 }
 
-func (mi *memtableIRange) prepare() {
-	for !mi.prepared && mi.err == nil {
+func (mi *memtableIRange) prepareNext() {
+	for !mi.preparedNext && mi.err == nil {
 		if !mi.it.HasNext() {
-			mi.err = EOI
 			return
 		}
 		rec, err := mi.it.Next()
@@ -123,13 +124,13 @@ func (mi *memtableIRange) prepare() {
 			continue
 		}
 		mi.next = rec
-		mi.prepared = true
+		mi.preparedNext = true
 	}
 }
 
 func (mi *memtableIRange) HasNext() bool {
-	mi.prepare()
-	return mi.prepared
+	mi.prepareNext()
+	return mi.preparedNext
 }
 
 func (mi *memtableIRange) Next() (Record, error) {
@@ -140,8 +141,47 @@ func (mi *memtableIRange) Next() (Record, error) {
 		}
 		return empty, EOI
 	}
-	mi.prepared = false
+	mi.preparedNext = false
+	mi.preparedPrev = false
 	return mi.next, nil
+}
+
+func (mi *memtableIRange) preparePrev() {
+	for !mi.preparedPrev && mi.err == nil {
+		if !mi.it.HasPrev() {
+			return
+		}
+		rec, err := mi.it.Prev()
+		if err != nil {
+			mi.err = err
+			return
+		}
+		if rec.GetSequenceNumber() > mi.seq {
+			continue
+		}
+		mi.prev = rec
+		mi.preparedPrev = true
+	}
+}
+
+// HasPrev implements Iterator[Record].
+func (mi *memtableIRange) HasPrev() bool {
+	mi.preparePrev()
+	return mi.preparedPrev
+}
+
+// Prev implements Iterator[Record].
+func (mi *memtableIRange) Prev() (Record, error) {
+	if !mi.HasPrev() {
+		var empty Record
+		if mi.err != nil {
+			return empty, mi.err
+		}
+		return empty, EOI
+	}
+	mi.preparedPrev = false
+	mi.preparedNext = false
+	return mi.prev, nil
 }
 
 // Cleanup removes records with sequence numbers less than minSeq.

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -349,8 +349,8 @@ func TestMemtableIRange_Prepare(t *testing.T) {
 		mi, ok := it.(*memtableIRange)
 		assert.True(t, ok)
 
-		mi.prepare()
-		assert.True(t, mi.prepared)
+		mi.prepareNext()
+		assert.True(t, mi.preparedNext)
 		assert.Equal(t, uint64(5), mi.next.GetSequenceNumber())
 		assert.NoError(t, mi.err)
 	})
@@ -360,9 +360,9 @@ func TestMemtableIRange_Prepare(t *testing.T) {
 		mi, ok := it.(*memtableIRange)
 		assert.True(t, ok)
 
-		mi.prepare()
-		assert.False(t, mi.prepared)
-		assert.ErrorIs(t, mi.err, EOI)
+		mi.prepareNext()
+		assert.False(t, mi.preparedNext)
+		assert.NoError(t, mi.err)
 	})
 }
 
@@ -399,4 +399,27 @@ func TestMemtableIRange_HasNextNext(t *testing.T) {
 	_, err := mi.Next()
 	assert.ErrorIs(t, err, EOI)
 	assert.False(t, mi.HasNext())
+}
+
+func TestMemtableIRange_Reverse(t *testing.T) {
+	cfg := testConfig()
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va1"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb2"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc3"), 3))
+
+	it := mem.IRange(Bytes("a"), Bytes("c"), 2)
+	for it.HasNext() {
+		_, err := it.Next()
+		assert.NoError(t, err)
+	}
+
+	var keys []Bytes
+	for it.HasPrev() {
+		rec, err := it.Prev()
+		assert.NoError(t, err)
+		keys = append(keys, rec.GetKey())
+	}
+
+	assert.Equal(t, []Bytes{Bytes("b"), Bytes("a")}, keys)
 }

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -88,6 +88,17 @@ func (m *MergingIterator) Next() (Record, error) {
 	return m.next, nil
 }
 
+// HasPrev implements Iterator[Record].
+func (m *MergingIterator) HasPrev() bool {
+	return false
+}
+
+// Prev implements Iterator[Record].
+func (m *MergingIterator) Prev() (Record, error) {
+	var empty Record
+	return empty, EOI
+}
+
 // Close releases any resources held by the iterator. It is safe to call
 // multiple times.
 func (m *MergingIterator) Close() error {

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -27,6 +27,13 @@ func (e *errIterator) Next() (Record, error) {
 	return rec, nil
 }
 
+func (e *errIterator) HasPrev() bool { return false }
+
+func (e *errIterator) Prev() (Record, error) {
+	var empty Record
+	return empty, EOI
+}
+
 func TestMergingIterator(t *testing.T) {
 	rec := func(k, v string, seq uint64, typ RecordType) Record {
 		var nv Bytes = nil

--- a/range.go
+++ b/range.go
@@ -61,6 +61,17 @@ func (r *RangeIterator) Next() (Record, error) {
 	return r.next, nil
 }
 
+// HasPrev implements Iterator[Record].
+func (r *RangeIterator) HasPrev() bool {
+	return false
+}
+
+// Prev implements Iterator[Record].
+func (r *RangeIterator) Prev() (Record, error) {
+	var empty Record
+	return empty, EOI
+}
+
 // Close releases any resources held by the iterator.
 func (r *RangeIterator) Close() error {
 	return r.mi.Close()

--- a/skiplist.go
+++ b/skiplist.go
@@ -19,6 +19,7 @@ type SLNode[K Comparable, V any] struct {
 	Key      K
 	Value    V
 	forwards []*SLNode[K, V]
+	backward *SLNode[K, V]
 }
 
 // Next returns the node's immediate successor on the lowest level.
@@ -91,6 +92,13 @@ func (list *SkipList[K, V]) Put(searchKey K, newValue V) {
 			newLevel--
 			newNode.forwards[newLevel] = update[newLevel].forwards[newLevel]
 			update[newLevel].forwards[newLevel] = newNode
+		}
+
+		pred := update[0]
+		succ := newNode.forwards[0]
+		newNode.backward = pred
+		if succ != nil {
+			succ.backward = newNode
 		}
 
 		list.length++
@@ -170,6 +178,12 @@ func (list *SkipList[K, V]) Remove(searchKey K) error {
 			}
 			update[i].forwards[i] = rn.forwards[i]
 		}
+		succ := rn.forwards[0]
+		pred := rn.backward
+		if succ != nil {
+			succ.backward = pred
+		}
+		rn.backward = nil
 		for list.level > 1 && list.Head().forwards[list.level-1] == nil {
 			list.level--
 		}
@@ -207,12 +221,13 @@ func (list *SkipList[K, V]) Len() uint {
 var _ Iterator[any] = (*slIterator[Comparable, any])(nil)
 
 type slIterator[K Comparable, V any] struct {
-	node *SLNode[K, V]
+	head *SLNode[K, V]
+	curr *SLNode[K, V]
 }
 
 // HasNext implements Iterator.
 func (s *slIterator[K, V]) HasNext() bool {
-	return s.node != nil
+	return s.curr != nil && s.curr.Next() != nil
 }
 
 // Next implements Iterator.
@@ -221,27 +236,45 @@ func (s *slIterator[K, V]) Next() (V, error) {
 		var empty V
 		return empty, EOI
 	}
-	value := s.node.Value
-	s.node = s.node.Next()
+	s.curr = s.curr.Next()
+	return s.curr.Value, nil
+}
+
+// HasPrev implements Iterator.
+func (s *slIterator[K, V]) HasPrev() bool {
+	return s.curr != nil && s.curr != s.head
+}
+
+// Prev implements Iterator.
+func (s *slIterator[K, V]) Prev() (V, error) {
+	if !s.HasPrev() {
+		var empty V
+		return empty, EOI
+	}
+	value := s.curr.Value
+	s.curr = s.curr.backward
 	return value, nil
 }
 
-// Iterator returns a forward iterator over the list's values.
+// Iterator returns a bidirectional iterator over the list's values.
 func (list *SkipList[K, V]) Iterator() Iterator[V] {
+	h := list.Head()
 	return &slIterator[K, V]{
-		node: list.Head().Next(),
+		head: h,
+		curr: h,
 	}
 }
 
 // slIRange iterates over a key range within the skip list.
 type slIRange[K Comparable, V any] struct {
-	node   *SLNode[K, V]
-	endKey K
+	curr     *SLNode[K, V]
+	startKey K
+	endKey   K
 }
 
 // HasNext implements Iterator.
 func (s *slIRange[K, V]) HasNext() bool {
-	return s.node != nil && Compare(s.node.Key, s.endKey) != CmpGreater
+	return s.curr != nil && s.curr.Next() != nil && Compare(s.curr.Next().Key, s.endKey) != CmpGreater
 }
 
 // Next implements Iterator.
@@ -250,8 +283,23 @@ func (s *slIRange[K, V]) Next() (V, error) {
 		var empty V
 		return empty, EOI
 	}
-	value := s.node.Value
-	s.node = s.node.Next()
+	s.curr = s.curr.Next()
+	return s.curr.Value, nil
+}
+
+// HasPrev implements Iterator.
+func (s *slIRange[K, V]) HasPrev() bool {
+	return s.curr != nil && Compare(s.curr.Key, s.startKey) != CmpLess
+}
+
+// Prev implements Iterator.
+func (s *slIRange[K, V]) Prev() (V, error) {
+	if !s.HasPrev() {
+		var empty V
+		return empty, EOI
+	}
+	value := s.curr.Value
+	s.curr = s.curr.backward
 	return value, nil
 }
 
@@ -265,10 +313,11 @@ func (list *SkipList[K, V]) IRange(start, end K) Iterator[V] {
 			rn = rn.forwards[rl]
 		}
 	}
-	rn = rn.forwards[0]
+	curr := rn
 	return &slIRange[K, V]{
-		node:   rn,
-		endKey: end,
+		curr:     curr,
+		startKey: start,
+		endKey:   end,
 	}
 }
 

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -221,6 +221,87 @@ func TestSkipList_Remove(t *testing.T) {
 	}
 }
 
+func TestSkipList_IteratorReverse(t *testing.T) {
+	cfg := testConfig()
+
+	t.Run("basic", func(t *testing.T) {
+		list, err := InitSkipList[int, int](cfg)
+		assert.NoError(t, err)
+
+		for i := 1; i <= 3; i++ {
+			list.Put(i, i)
+		}
+
+		it, ok := list.Iterator().(*slIterator[int, int])
+		assert.True(t, ok)
+
+		for it.HasNext() {
+			_, err := it.Next()
+			assert.NoError(t, err)
+		}
+
+		var rev []int
+		for it.HasPrev() {
+			v, err := it.Prev()
+			assert.NoError(t, err)
+			rev = append(rev, v)
+		}
+
+		assert.Equal(t, []int{3, 2, 1}, rev)
+	})
+
+	t.Run("after remove", func(t *testing.T) {
+		list, err := InitSkipList[int, int](cfg)
+		assert.NoError(t, err)
+
+		for i := 1; i <= 3; i++ {
+			list.Put(i, i)
+		}
+		assert.NoError(t, list.Remove(2))
+
+		it, ok := list.Iterator().(*slIterator[int, int])
+		assert.True(t, ok)
+		for it.HasNext() {
+			_, err := it.Next()
+			assert.NoError(t, err)
+		}
+		var rev []int
+		for it.HasPrev() {
+			v, err := it.Prev()
+			assert.NoError(t, err)
+			rev = append(rev, v)
+		}
+		assert.Equal(t, []int{3, 1}, rev)
+	})
+}
+
+func TestSkipList_IRangeReverse(t *testing.T) {
+	cfg := testConfig()
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	for i := 1; i <= 5; i++ {
+		list.Put(i, i)
+	}
+
+	it, ok := list.IRange(2, 4).(*slIRange[int, int])
+	assert.True(t, ok)
+
+	for it.HasNext() {
+		_, err := it.Next()
+		assert.NoError(t, err)
+	}
+
+	var rev []int
+	for it.HasPrev() {
+		v, err := it.Prev()
+		assert.NoError(t, err)
+		rev = append(rev, v)
+	}
+
+	assert.Equal(t, []int{4, 3, 2}, rev)
+}
+
 func TestSkipList_Clear(t *testing.T) {
 	cfg := testConfig()
 	t.Run("Clear list properly", func(t *testing.T) {

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -275,6 +275,43 @@ func TestSkipList_IteratorReverse(t *testing.T) {
 	})
 }
 
+func TestSkipList_IteratorMixed(t *testing.T) {
+	cfg := testConfig()
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	for i := 1; i <= 3; i++ {
+		list.Put(i, i)
+	}
+
+	it, ok := list.Iterator().(*slIterator[int, int])
+	assert.True(t, ok)
+
+	// Move forward one step then backward again. Prev returns the same
+	// element that Next produced.
+	assert.True(t, it.HasNext())
+	v, err := it.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, v)
+
+	assert.True(t, it.HasPrev())
+	v, err = it.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, v)
+
+	// Next after Prev yields the same element again.
+	assert.True(t, it.HasNext())
+	v, err = it.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, v)
+
+	// Advance once more to move past the first element.
+	assert.True(t, it.HasNext())
+	v, err = it.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, v)
+}
+
 func TestSkipList_IRangeReverse(t *testing.T) {
 	cfg := testConfig()
 	list, err := InitSkipList[int, int](cfg)
@@ -300,6 +337,42 @@ func TestSkipList_IRangeReverse(t *testing.T) {
 	}
 
 	assert.Equal(t, []int{4, 3, 2}, rev)
+}
+
+func TestSkipList_IRangeMixed(t *testing.T) {
+	cfg := testConfig()
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	for i := 1; i <= 5; i++ {
+		list.Put(i, i)
+	}
+
+	it, ok := list.IRange(2, 4).(*slIRange[int, int])
+	assert.True(t, ok)
+
+	assert.True(t, it.HasNext())
+	v, err := it.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, v)
+
+	assert.True(t, it.HasPrev())
+	v, err = it.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, v)
+
+	// Resume forward iteration
+	// Next after Prev returns the same element again.
+	assert.True(t, it.HasNext())
+	v, err = it.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, v)
+
+	// Further Next calls resume forward iteration.
+	assert.True(t, it.HasNext())
+	v, err = it.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, v)
 }
 
 func TestSkipList_Clear(t *testing.T) {

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -83,6 +83,16 @@ func (s *sstableIterator) Next() (Record, error) {
 	return nil, EOI
 }
 
+// HasPrev implements Iterator.
+func (s *sstableIterator) HasPrev() bool {
+	return false
+}
+
+// Prev implements Iterator.
+func (s *sstableIterator) Prev() (Record, error) {
+	return nil, EOI
+}
+
 // sstableIRange iterates over a range of keys in an SSTable.
 type sstableIRange struct {
 	s        *SStable
@@ -142,4 +152,15 @@ func (sri *sstableIRange) Next() (Record, error) {
 	}
 	sri.prepared = false
 	return sri.next, nil
+}
+
+// HasPrev implements Iterator.
+func (sri *sstableIRange) HasPrev() bool {
+	return false
+}
+
+// Prev implements Iterator.
+func (sri *sstableIRange) Prev() (Record, error) {
+	var empty Record
+	return empty, EOI
 }


### PR DESCRIPTION
## Summary
- maintain backward links in skiplist nodes
- add Prev/HasPrev to skiplist and memtable iterators
- test forward and reverse traversal for skiplist and memtable

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c5589ae46c83259b2e0fff2576cd3c