### PR TITLE
feat: enable reverse traversal for SSTable iterators

### DIFF
--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -9,6 +9,42 @@ import (
 
 const maxSSTableIteratorOffsets = 1 << 16
 
+type offsetStack struct {
+	buf   []int64
+	start int
+	count int
+}
+
+func newOffsetStack(n int) *offsetStack {
+	return &offsetStack{buf: make([]int64, n)}
+}
+
+func (o *offsetStack) push(v int64) {
+	if len(o.buf) == 0 {
+		return
+	}
+	if o.count < len(o.buf) {
+		idx := (o.start + o.count) % len(o.buf)
+		o.buf[idx] = v
+		o.count++
+		return
+	}
+	o.buf[o.start] = v
+	o.start = (o.start + 1) % len(o.buf)
+}
+
+func (o *offsetStack) pop() (int64, bool) {
+	if o.count == 0 {
+		return 0, false
+	}
+	idx := (o.start + o.count - 1) % len(o.buf)
+	v := o.buf[idx]
+	o.count--
+	return v, true
+}
+
+func (o *offsetStack) len() int { return o.count }
+
 var _ Iterator[Record] = (*sstableIterator)(nil)
 
 func (s SStable) Iterator() (Iterator[Record], error) {
@@ -19,11 +55,10 @@ func (s SStable) Iterator() (Iterator[Record], error) {
 	}
 
 	return &sstableIterator{
-		currentIdx: 0,
-		maxIdx:     len(s.SparseIndex),
 		FileSystem: s.FileSystem,
+		dataEnd:    s.dataEnd,
 		offset:     0,
-		offsets:    []int64{0},
+		offs:       newOffsetStack(maxSSTableIteratorOffsets),
 	}, nil
 }
 
@@ -56,44 +91,39 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd, offs: []int64{startOffset}}, nil
+	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd, offs: newOffsetStack(maxSSTableIteratorOffsets)}, nil
 }
 
 type sstableIterator struct {
 	*FileSystem
-	currentIdx int
-	maxIdx     int
-	offset     int64
-	offsets    []int64
+	offset  int64
+	dataEnd int64
+	offs    *offsetStack
 }
 
 // HasNext implements Iterator.
 func (s *sstableIterator) HasNext() bool {
-	return s.currentIdx < s.maxIdx
+	return s.offset < s.dataEnd
 }
 
 // Next implements Iterator.
 func (s *sstableIterator) Next() (Record, error) {
-	if s.HasNext() {
-		s.offsets = append(s.offsets, s.offset)
-		if len(s.offsets) > maxSSTableIteratorOffsets {
-			s.offsets = s.offsets[1:]
-		}
-		reader := newOffsetReader(s.FileSystem, s.offset)
-		record, err := readRecord(reader)
-		if err != nil {
-			return nil, err
-		}
-		s.offset = reader.Offset()
-		s.currentIdx++
-		return record, nil
+	if !s.HasNext() {
+		return nil, EOI
 	}
-	return nil, EOI
+	s.offs.push(s.offset)
+	reader := newOffsetReader(s.FileSystem, s.offset)
+	record, err := readRecord(reader)
+	if err != nil {
+		return nil, err
+	}
+	s.offset = reader.Offset()
+	return record, nil
 }
 
 // HasPrev implements Iterator.
 func (s *sstableIterator) HasPrev() bool {
-	return len(s.offsets) > 1
+	return s.offs.len() > 0
 }
 
 // Prev implements Iterator.
@@ -101,15 +131,14 @@ func (s *sstableIterator) Prev() (Record, error) {
 	if !s.HasPrev() {
 		return nil, EOI
 	}
-	prev := s.offsets[len(s.offsets)-1]
-	s.offsets = s.offsets[:len(s.offsets)-1]
+	prev, ok := s.offs.pop()
+	if !ok {
+		return nil, EOI
+	}
 	reader := newOffsetReader(s.FileSystem, prev)
 	record, err := readRecord(reader)
 	if err != nil {
 		return nil, err
-	}
-	if s.currentIdx > 0 {
-		s.currentIdx--
 	}
 	s.offset = prev
 	return record, nil
@@ -126,7 +155,7 @@ type sstableIRange struct {
 	next     Record
 	err      error
 	prepared bool
-	offs     []int64
+	offs     *offsetStack
 }
 
 func (sri *sstableIRange) prepare() {
@@ -157,10 +186,7 @@ func (sri *sstableIRange) prepare() {
 		if rec.GetSequenceNumber() > sri.seq {
 			continue
 		}
-		sri.offs = append(sri.offs, cur)
-		if len(sri.offs) > maxSSTableIteratorOffsets {
-			sri.offs = sri.offs[1:]
-		}
+		sri.offs.push(cur)
 		sri.next = rec
 		sri.prepared = true
 	}
@@ -184,7 +210,7 @@ func (sri *sstableIRange) Next() (Record, error) {
 
 // HasPrev implements Iterator.
 func (sri *sstableIRange) HasPrev() bool {
-	return len(sri.offs) > 1
+	return sri.offs.len() > 0
 }
 
 // Prev implements Iterator.
@@ -193,8 +219,11 @@ func (sri *sstableIRange) Prev() (Record, error) {
 		var empty Record
 		return empty, EOI
 	}
-	prev := sri.offs[len(sri.offs)-1]
-	sri.offs = sri.offs[:len(sri.offs)-1]
+	prev, ok := sri.offs.pop()
+	if !ok {
+		var empty Record
+		return empty, EOI
+	}
 	reader := newOffsetReader(sri.s.FileSystem, prev)
 	rec, err := readRecord(reader)
 	if err != nil {

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 )
 
+const maxSSTableIteratorOffsets = 1 << 16
+
 var _ Iterator[Record] = (*sstableIterator)(nil)
 
 func (s SStable) Iterator() (Iterator[Record], error) {
@@ -21,6 +23,7 @@ func (s SStable) Iterator() (Iterator[Record], error) {
 		maxIdx:     len(s.SparseIndex),
 		FileSystem: s.FileSystem,
 		offset:     0,
+		offsets:    []int64{0},
 	}, nil
 }
 
@@ -53,7 +56,7 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd}, nil
+	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd, offs: []int64{startOffset}}, nil
 }
 
 type sstableIterator struct {
@@ -61,6 +64,7 @@ type sstableIterator struct {
 	currentIdx int
 	maxIdx     int
 	offset     int64
+	offsets    []int64
 }
 
 // HasNext implements Iterator.
@@ -71,6 +75,10 @@ func (s *sstableIterator) HasNext() bool {
 // Next implements Iterator.
 func (s *sstableIterator) Next() (Record, error) {
 	if s.HasNext() {
+		s.offsets = append(s.offsets, s.offset)
+		if len(s.offsets) > maxSSTableIteratorOffsets {
+			s.offsets = s.offsets[1:]
+		}
 		reader := newOffsetReader(s.FileSystem, s.offset)
 		record, err := readRecord(reader)
 		if err != nil {
@@ -85,12 +93,26 @@ func (s *sstableIterator) Next() (Record, error) {
 
 // HasPrev implements Iterator.
 func (s *sstableIterator) HasPrev() bool {
-	return false
+	return len(s.offsets) > 1
 }
 
 // Prev implements Iterator.
 func (s *sstableIterator) Prev() (Record, error) {
-	return nil, EOI
+	if !s.HasPrev() {
+		return nil, EOI
+	}
+	prev := s.offsets[len(s.offsets)-1]
+	s.offsets = s.offsets[:len(s.offsets)-1]
+	reader := newOffsetReader(s.FileSystem, prev)
+	record, err := readRecord(reader)
+	if err != nil {
+		return nil, err
+	}
+	if s.currentIdx > 0 {
+		s.currentIdx--
+	}
+	s.offset = prev
+	return record, nil
 }
 
 // sstableIRange iterates over a range of keys in an SSTable.
@@ -104,6 +126,7 @@ type sstableIRange struct {
 	next     Record
 	err      error
 	prepared bool
+	offs     []int64
 }
 
 func (sri *sstableIRange) prepare() {
@@ -112,7 +135,8 @@ func (sri *sstableIRange) prepare() {
 			sri.err = EOI
 			return
 		}
-		reader := newOffsetReader(sri.s.FileSystem, sri.offset)
+		cur := sri.offset
+		reader := newOffsetReader(sri.s.FileSystem, cur)
 		rec, err := readRecord(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
@@ -132,6 +156,10 @@ func (sri *sstableIRange) prepare() {
 		}
 		if rec.GetSequenceNumber() > sri.seq {
 			continue
+		}
+		sri.offs = append(sri.offs, cur)
+		if len(sri.offs) > maxSSTableIteratorOffsets {
+			sri.offs = sri.offs[1:]
 		}
 		sri.next = rec
 		sri.prepared = true
@@ -156,11 +184,24 @@ func (sri *sstableIRange) Next() (Record, error) {
 
 // HasPrev implements Iterator.
 func (sri *sstableIRange) HasPrev() bool {
-	return false
+	return len(sri.offs) > 1
 }
 
 // Prev implements Iterator.
 func (sri *sstableIRange) Prev() (Record, error) {
-	var empty Record
-	return empty, EOI
+	if !sri.HasPrev() {
+		var empty Record
+		return empty, EOI
+	}
+	prev := sri.offs[len(sri.offs)-1]
+	sri.offs = sri.offs[:len(sri.offs)-1]
+	reader := newOffsetReader(sri.s.FileSystem, prev)
+	rec, err := readRecord(reader)
+	if err != nil {
+		return nil, err
+	}
+	sri.offset = prev
+	sri.prepared = false
+	sri.err = nil
+	return rec, nil
 }

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -131,10 +131,7 @@ func (s *sstableIterator) Prev() (Record, error) {
 	if !s.HasPrev() {
 		return nil, EOI
 	}
-	prev, ok := s.offs.pop()
-	if !ok {
-		return nil, EOI
-	}
+	prev, _ := s.offs.pop()
 	reader := newOffsetReader(s.FileSystem, prev)
 	record, err := readRecord(reader)
 	if err != nil {
@@ -219,11 +216,7 @@ func (sri *sstableIRange) Prev() (Record, error) {
 		var empty Record
 		return empty, EOI
 	}
-	prev, ok := sri.offs.pop()
-	if !ok {
-		var empty Record
-		return empty, EOI
-	}
+	prev, _ := sri.offs.pop()
 	reader := newOffsetReader(sri.s.FileSystem, prev)
 	rec, err := readRecord(reader)
 	if err != nil {

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -1,0 +1,119 @@
+package rindb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSTableIteratorReverse(t *testing.T) {
+	cfg := testConfig()
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc"), 3))
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.Iterator()
+	require.NoError(t, err)
+
+	var fwd []Bytes
+	for it.HasNext() {
+		rec, err := it.Next()
+		require.NoError(t, err)
+		fwd = append(fwd, rec.GetKey())
+	}
+
+	var rev []Bytes
+	for it.HasPrev() {
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		rev = append(rev, rec.GetKey())
+	}
+
+	assert.Equal(t, []Bytes{Bytes("a"), Bytes("b"), Bytes("c")}, fwd)
+	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, rev)
+}
+
+func TestSSTableIteratorMixed(t *testing.T) {
+	cfg := testConfig()
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb"), 2))
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.Iterator()
+	require.NoError(t, err)
+
+	assert.True(t, it.HasNext())
+	rec, err := it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+
+	assert.True(t, it.HasPrev())
+	rec, err = it.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+
+	assert.True(t, it.HasNext())
+	rec, err = it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+
+	assert.True(t, it.HasNext())
+	rec, err = it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+}
+
+func TestSSTableIRangeReverse(t *testing.T) {
+	cfg := testConfig()
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc"), 3))
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.IRange(Bytes("a"), Bytes("c"))
+	require.NoError(t, err)
+
+	var fwd []Bytes
+	for it.HasNext() {
+		rec, err := it.Next()
+		require.NoError(t, err)
+		fwd = append(fwd, rec.GetKey())
+	}
+
+	var rev []Bytes
+	for it.HasPrev() {
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		rev = append(rev, rec.GetKey())
+	}
+
+	assert.Equal(t, []Bytes{Bytes("a"), Bytes("b"), Bytes("c")}, fwd)
+	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, rev)
+}


### PR DESCRIPTION
## Summary
- support stepping backward in `sstableIterator` and `sstableIRange` using a bounded offset stack
- add tests exercising reverse and mixed traversal paths for SSTable iterators

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c56265338c8325adaa90f64dbc5716