### PR TITLE
feat: add bidirectional merging and range iterators

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -8,27 +8,36 @@ type pqItem struct {
 }
 
 // MergingIterator merges multiple iterators without deduplication. It yields
-// records ordered by key and sequence number (descending).
+// records ordered by key and sequence number (descending) and supports
+// bidirectional traversal.
 type MergingIterator struct {
-	pq       *PriorityQueue[pqItem]
-	next     Record
-	prepared bool
-	cleanup  func()
-	err      error
+	fwd     *PriorityQueue[pqItem]
+	rev     *PriorityQueue[pqItem]
+	cur     pqItem
+	curSet  bool
+	cleanup func()
+	err     error
 }
 
 // NewMergingIterator constructs a MergingIterator over provided iterators.
 // The optional cleanup function is called when Close is invoked.
 func NewMergingIterator(iterators []Iterator[Record], cleanup func()) (*MergingIterator, error) {
-	less := func(a, b pqItem) bool {
+	lessFwd := func(a, b pqItem) bool {
 		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
 		if cmp == CmpEqual {
 			return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
 		}
 		return cmp == CmpLess
 	}
-
-	pq := NewPriorityQueue(less)
+	lessRev := func(a, b pqItem) bool {
+		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
+		if cmp == CmpEqual {
+			return a.rec.GetSequenceNumber() < b.rec.GetSequenceNumber()
+		}
+		return cmp == CmpGreater
+	}
+	fwd := NewPriorityQueue(lessFwd)
+	rev := NewPriorityQueue(lessRev)
 	for _, it := range iterators {
 		if it.HasNext() {
 			rec, err := it.Next()
@@ -41,38 +50,15 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func()) (*MergingI
 				}
 				continue
 			}
-			pq.PushItem(pqItem{rec: rec, iter: it})
+			fwd.PushItem(pqItem{rec: rec, iter: it})
 		}
 	}
-
-	return &MergingIterator{pq: pq, cleanup: cleanup}, nil
-}
-
-func (m *MergingIterator) prepare() {
-	if m.prepared || m.err != nil || m.pq.Len() == 0 {
-		return
-	}
-
-	item := m.pq.PopItem()
-	m.next = item.rec
-	m.prepared = true
-
-	if item.iter.HasNext() {
-		rec, err := item.iter.Next()
-		if err != nil {
-			if !errors.Is(err, EOI) {
-				m.err = err
-			}
-		} else {
-			m.pq.PushItem(pqItem{rec: rec, iter: item.iter})
-		}
-	}
+	return &MergingIterator{fwd: fwd, rev: rev, cleanup: cleanup}, nil
 }
 
 // HasNext implements Iterator[Record].
 func (m *MergingIterator) HasNext() bool {
-	m.prepare()
-	return m.prepared
+	return m.err == nil && m.fwd.Len() > 0
 }
 
 // Next implements Iterator[Record].
@@ -84,19 +70,59 @@ func (m *MergingIterator) Next() (Record, error) {
 		}
 		return empty, EOI
 	}
-	m.prepared = false
-	return m.next, nil
+	item := m.fwd.PopItem()
+	m.rev.PushItem(item)
+	m.cur = item
+	m.curSet = true
+	if item.iter.HasNext() {
+		rec, err := item.iter.Next()
+		if err != nil {
+			if !errors.Is(err, EOI) {
+				m.err = err
+			}
+		} else {
+			m.fwd.PushItem(pqItem{rec: rec, iter: item.iter})
+		}
+	}
+	return item.rec, nil
 }
 
 // HasPrev implements Iterator[Record].
 func (m *MergingIterator) HasPrev() bool {
-	return false
+	return m.err == nil && m.rev.Len() > 1
 }
 
 // Prev implements Iterator[Record].
 func (m *MergingIterator) Prev() (Record, error) {
-	var empty Record
-	return empty, EOI
+	if !m.HasPrev() {
+		var empty Record
+		if m.err != nil {
+			return empty, m.err
+		}
+		return empty, EOI
+	}
+	cur := m.rev.PopItem()
+	if cur.iter.HasPrev() {
+		rec, err := cur.iter.Prev()
+		if err != nil {
+			if !errors.Is(err, EOI) {
+				m.err = err
+			}
+		} else if rec.GetKey().Compare(cur.rec.GetKey()) != CmpEqual || rec.GetSequenceNumber() != cur.rec.GetSequenceNumber() {
+			item := pqItem{rec: rec, iter: cur.iter}
+			m.fwd.PushItem(item)
+			m.rev.PushItem(item)
+		}
+	}
+	m.fwd.PushItem(cur)
+	if m.rev.Len() == 0 {
+		var empty Record
+		return empty, EOI
+	}
+	prev := m.rev.PeekItem()
+	m.cur = prev
+	m.curSet = true
+	return prev.rec, nil
 }
 
 // Close releases any resources held by the iterator. It is safe to call

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -22,16 +22,28 @@ func (e *errIterator) Next() (Record, error) {
 		var empty Record
 		return empty, errors.New("boom")
 	}
+	if e.idx >= len(e.records) {
+		var empty Record
+		return empty, EOI
+	}
 	rec := e.records[e.idx]
 	e.idx++
 	return rec, nil
 }
 
-func (e *errIterator) HasPrev() bool { return false }
+func (e *errIterator) HasPrev() bool { return e.idx > 0 }
 
 func (e *errIterator) Prev() (Record, error) {
-	var empty Record
-	return empty, EOI
+	if !e.HasPrev() {
+		var empty Record
+		return empty, EOI
+	}
+	e.idx--
+	if e.idx == e.failIdx {
+		var empty Record
+		return empty, errors.New("boom")
+	}
+	return e.records[e.idx], nil
 }
 
 func TestMergingIterator(t *testing.T) {
@@ -82,6 +94,38 @@ func TestMergingIterator(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMergingIteratorPrev(t *testing.T) {
+	rec := func(k, v string, seq uint64, typ RecordType) Record {
+		var nv Bytes = nil
+		if v != "" {
+			nv = Bytes(v)
+		}
+		return RecordImpl{Key: Bytes(k), Value: nv, SequenceNumber: seq, Type: typ}
+	}
+	iterators := []Iterator[Record]{
+		&errIterator{records: []Record{rec("a", "va", 1, TypeValue), rec("c", "vc", 1, TypeValue)}, failIdx: -1},
+		&errIterator{records: []Record{rec("b", "vb", 1, TypeValue)}, failIdx: -1},
+	}
+	mi, err := NewMergingIterator(iterators, nil)
+	assert.NoError(t, err)
+
+	r1, err := mi.Next()
+	assert.NoError(t, err)
+	assert.False(t, mi.HasPrev())
+
+	r2, err := mi.Next()
+	assert.NoError(t, err)
+	assert.True(t, mi.HasPrev())
+
+	back, err := mi.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, r1, back)
+
+	fwd, err := mi.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, r2, fwd)
 }
 
 func TestMergingIteratorInitialError(t *testing.T) {

--- a/priority_queue.go
+++ b/priority_queue.go
@@ -43,3 +43,6 @@ func (pq *PriorityQueue[T]) PushItem(item T) { heap.Push(pq, item) }
 
 // PopItem pops the highest priority item from the queue.
 func (pq *PriorityQueue[T]) PopItem() T { return heap.Pop(pq).(T) }
+
+// PeekItem returns, but does not remove, the highest priority item from the queue.
+func (pq PriorityQueue[T]) PeekItem() T { return pq.items[0] }

--- a/range.go
+++ b/range.go
@@ -6,12 +6,14 @@ import "errors"
 // duplicates. It wraps a MergingIterator which provides all records in key and
 // sequence order.
 type RangeIterator struct {
-	mi         *MergingIterator
-	lastKey    Bytes
-	lastKeySet bool
-	next       Record
-	prepared   bool
-	err        error
+	mi           *MergingIterator
+	lastKey      Bytes
+	lastKeySet   bool
+	next         Record
+	prev         Record
+	nextPrepared bool
+	prevPrepared bool
+	err          error
 }
 
 // NewRangeIterator creates a new RangeIterator from a MergingIterator.
@@ -19,8 +21,8 @@ func NewRangeIterator(mi *MergingIterator) *RangeIterator {
 	return &RangeIterator{mi: mi}
 }
 
-func (r *RangeIterator) prepare() {
-	for !r.prepared && r.err == nil {
+func (r *RangeIterator) prepareNext() {
+	for !r.nextPrepared && r.err == nil {
 		rec, err := r.mi.Next()
 		if err != nil {
 			if errors.Is(err, EOI) {
@@ -38,14 +40,43 @@ func (r *RangeIterator) prepare() {
 			continue
 		}
 		r.next = rec
-		r.prepared = true
+		r.nextPrepared = true
+	}
+	if r.nextPrepared {
+		r.prevPrepared = false
+	}
+}
+
+func (r *RangeIterator) preparePrev() {
+	for !r.prevPrepared && r.err == nil {
+		rec, err := r.mi.Prev()
+		if err != nil {
+			if errors.Is(err, EOI) {
+				return
+			}
+			r.err = err
+			return
+		}
+		if r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual {
+			continue
+		}
+		r.lastKey = rec.GetKey().Clone()
+		r.lastKeySet = true
+		if rec.GetType() == TypeDeletion {
+			continue
+		}
+		r.prev = rec
+		r.prevPrepared = true
+	}
+	if r.prevPrepared {
+		r.nextPrepared = false
 	}
 }
 
 // HasNext implements Iterator[Record].
 func (r *RangeIterator) HasNext() bool {
-	r.prepare()
-	return r.prepared
+	r.prepareNext()
+	return r.nextPrepared
 }
 
 // Next implements Iterator[Record].
@@ -57,19 +88,27 @@ func (r *RangeIterator) Next() (Record, error) {
 		}
 		return empty, EOI
 	}
-	r.prepared = false
+	r.nextPrepared = false
 	return r.next, nil
 }
 
 // HasPrev implements Iterator[Record].
 func (r *RangeIterator) HasPrev() bool {
-	return false
+	r.preparePrev()
+	return r.prevPrepared
 }
 
 // Prev implements Iterator[Record].
 func (r *RangeIterator) Prev() (Record, error) {
-	var empty Record
-	return empty, EOI
+	if !r.HasPrev() {
+		var empty Record
+		if r.err != nil {
+			return empty, r.err
+		}
+		return empty, EOI
+	}
+	r.prevPrepared = false
+	return r.prev, nil
 }
 
 // Close releases any resources held by the iterator.

--- a/range_test.go
+++ b/range_test.go
@@ -79,6 +79,51 @@ func TestRangeIterator(t *testing.T) {
 	}
 }
 
+func TestRangeIteratorReverse(t *testing.T) {
+	rec := func(k, v string, seq uint64, typ RecordType) Record {
+		var nv Bytes = nil
+		if v != "" {
+			nv = Bytes(v)
+		}
+		return RecordImpl{Key: Bytes(k), Value: nv, SequenceNumber: seq, Type: typ}
+	}
+	type iterSpec struct {
+		records []Record
+		failIdx int
+	}
+	type exp struct {
+		k, v string
+	}
+	iters := []iterSpec{
+		{records: []Record{rec("a", "va", 1, TypeValue)}, failIdx: -1},
+		{records: []Record{rec("b", "vb", 1, TypeValue)}, failIdx: -1},
+		{records: []Record{rec("c", "vc", 1, TypeValue)}, failIdx: -1},
+	}
+	var iterators []Iterator[Record]
+	for _, spec := range iters {
+		iterators = append(iterators, &errIterator{records: spec.records, failIdx: spec.failIdx})
+	}
+	mi, err := NewMergingIterator(iterators, nil)
+	assert.NoError(t, err)
+	iter := NewRangeIterator(mi)
+
+	var forward []exp
+	for iter.HasNext() {
+		r, err := iter.Next()
+		assert.NoError(t, err)
+		forward = append(forward, exp{string(r.GetKey()), string(r.GetValue())})
+	}
+	assert.Equal(t, []exp{{"a", "va"}, {"b", "vb"}, {"c", "vc"}}, forward)
+
+	var backward []exp
+	for iter.HasPrev() {
+		r, err := iter.Prev()
+		assert.NoError(t, err)
+		backward = append(backward, exp{string(r.GetKey()), string(r.GetValue())})
+	}
+	assert.Equal(t, []exp{{"b", "vb"}, {"a", "va"}}, backward)
+}
+
 func TestIRangeCloseReleasesSSTables(t *testing.T) {
 	cfg := testConfig()
 	ctx := context.Background()
@@ -134,12 +179,12 @@ func TestRangeIteratorPrepare(t *testing.T) {
 		assert.NoError(t, err)
 
 		iter := NewRangeIterator(mi)
-		iter.prepare()
+		iter.prepareNext()
 		_, err = iter.Next()
 		assert.NoError(t, err)
 
-		iter.prepare()
-		assert.True(t, iter.prepared)
+		iter.prepareNext()
+		assert.True(t, iter.nextPrepared)
 		assert.Equal(t, "b", string(iter.next.GetKey()))
 		assert.Equal(t, "vb", string(iter.next.GetValue()))
 	})
@@ -156,15 +201,15 @@ func TestRangeIteratorPrepare(t *testing.T) {
 		assert.NoError(t, err)
 
 		iter := NewRangeIterator(mi)
-		iter.prepare()
+		iter.prepareNext()
 		_, err = iter.Next()
 		assert.NoError(t, err)
 
-		iter.prepare()
+		iter.prepareNext()
 		assert.EqualError(t, iter.err, "boom")
 
-		iter.prepared = false
-		iter.prepare()
-		assert.False(t, iter.prepared)
+		iter.nextPrepared = false
+		iter.prepareNext()
+		assert.False(t, iter.nextPrepared)
 	})
 }


### PR DESCRIPTION
## Summary
- support reverse traversal via dual-heap merging iterator
- expose previous/next navigation in RangeIterator
- cover reverse iteration in unit tests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c56fc7ebd88325b9518571812508a9