### PR TITLE
feat: make SSTable iterator history configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -95,6 +95,11 @@ type Config struct {
 	// no limit is enforced, which may lead to resource exhaustion on busy
 	// systems. Provide an implementation to bound FD usage.
 	fdLimiter FDLimiter
+
+	// sstableIterMaxHistory bounds the number of previous offsets retained
+	// by SSTable iterators to support Prev(). Older offsets are discarded
+	// once this limit is exceeded.
+	sstableIterMaxHistory int
 }
 
 // Option defines a functional option type for Config.
@@ -140,6 +145,7 @@ func DefaultConfig() Config {
 		cacheCorruptTTL:           5 * time.Minute,
 		cacheTombstoneTTL:         0,
 		fdLimiter:                 noopFDLimiter{},
+		sstableIterMaxHistory:     1 << 16,
 	}
 }
 
@@ -220,6 +226,9 @@ func (c Config) Validate() {
 	if c.cacheTombstoneTTL < 0 {
 		panic("cacheTombstoneTTL must be >= 0")
 	}
+	if c.sstableIterMaxHistory < 0 {
+		panic("sstableIterMaxHistory must be >= 0")
+	}
 }
 
 func WithConfig(cfg Config) Option {
@@ -266,6 +275,12 @@ func WithCacheTombstoneTTL(d time.Duration) Option {
 // unlimited implementation.
 func WithFDLimiter(l FDLimiter) Option {
 	return func(c *Config) { c.fdLimiter = l }
+}
+
+// WithSSTableIterMaxHistory sets the maximum number of offsets retained by
+// SSTable iterators to support Prev().
+func WithSSTableIterMaxHistory(n int) Option {
+	return func(c *Config) { c.sstableIterMaxHistory = n }
 }
 
 // WithMaxMemtableSize sets the maximum number of entries allowed in the memtable before flushing.

--- a/sstable.go
+++ b/sstable.go
@@ -34,9 +34,10 @@ type (
 
 type SStable struct {
 	*FileSystem
-	SparseIndex SparseIndex
-	Bloom       *BloomFilter
-	dataEnd     int64
+	SparseIndex    SparseIndex
+	Bloom          *BloomFilter
+	dataEnd        int64
+	iterMaxHistory int
 }
 
 func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, error) {
@@ -84,7 +85,7 @@ func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, er
 	}
 
 	info(ctx, "Successfully created SSTable at %s with %d sparse index entries", fs.Path(), len(sparseIndex))
-	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom, dataEnd: int64(f.indexOffset)}, nil
+	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom, dataEnd: int64(f.indexOffset), iterMaxHistory: config.sstableIterMaxHistory}, nil
 }
 
 func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -168,7 +168,7 @@ func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, meta fileMeta,
 	}
 
 	b.built = true
-	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom, dataEnd: indexOffset}
+	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom, dataEnd: indexOffset, iterMaxHistory: b.config.sstableIterMaxHistory}
 	num, nerr := fileNum(b.fs.Path())
 	if nerr != nil {
 		err = fmt.Errorf("invalid sstable path %s: %w", b.fs.Path(), nerr)

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 )
 
-const maxSSTableIteratorOffsets = 1 << 16
-
 type offsetStack struct {
 	buf   []int64
 	start int
@@ -58,7 +56,7 @@ func (s SStable) Iterator() (Iterator[Record], error) {
 		FileSystem: s.FileSystem,
 		dataEnd:    s.dataEnd,
 		offset:     0,
-		offs:       newOffsetStack(maxSSTableIteratorOffsets),
+		offs:       newOffsetStack(s.iterMaxHistory),
 	}, nil
 }
 
@@ -91,7 +89,7 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd, offs: newOffsetStack(maxSSTableIteratorOffsets)}, nil
+	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd, offs: newOffsetStack(s.iterMaxHistory)}, nil
 }
 
 type sstableIterator struct {

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -117,3 +117,113 @@ func TestSSTableIRangeReverse(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("a"), Bytes("b"), Bytes("c")}, fwd)
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, rev)
 }
+
+func TestSSTableIteratorHistoryLimit(t *testing.T) {
+	cases := []struct {
+		name    string
+		history int
+	}{
+		{"h0", 0},
+		{"h1", 1},
+		{"h2", 2},
+	}
+	keys := []string{"a", "b", "c", "d", "e"}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.sstableIterMaxHistory = tc.history
+			ctx := context.Background()
+			fss, closer := initTempFileSystems(t, 1, nil)
+			defer closer()
+			fs := fss[0]
+
+			mem := InitMemtable(cfg)
+			for i, k := range keys {
+				mem.Put(newRecord(Bytes(k), Bytes("v"), uint64(i+1)))
+			}
+
+			sst, _, err := flush(ctx, cfg, mem, fs)
+			require.NoError(t, err)
+
+			it, err := sst.Iterator()
+			require.NoError(t, err)
+
+			for range keys {
+				_, err := it.Next()
+				require.NoError(t, err)
+			}
+
+			si := it.(*sstableIterator)
+			assert.Equal(t, tc.history, len(si.offs.buf))
+			expLen := tc.history
+			if expLen > len(keys) {
+				expLen = len(keys)
+			}
+			assert.Equal(t, expLen, si.offs.len())
+
+			for i := 0; i < tc.history && i < len(keys); i++ {
+				rec, err := it.Prev()
+				require.NoError(t, err)
+				assert.Equal(t, Bytes(keys[len(keys)-1-i]), rec.GetKey())
+			}
+
+			_, err = it.Prev()
+			assert.ErrorIs(t, err, EOI)
+		})
+	}
+}
+
+func TestSSTableIRangeHistoryLimit(t *testing.T) {
+	cases := []struct {
+		name    string
+		history int
+	}{
+		{"h0", 0},
+		{"h1", 1},
+		{"h2", 2},
+	}
+	keys := []string{"a", "b", "c", "d", "e"}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.sstableIterMaxHistory = tc.history
+			ctx := context.Background()
+			fss, closer := initTempFileSystems(t, 1, nil)
+			defer closer()
+			fs := fss[0]
+
+			mem := InitMemtable(cfg)
+			for i, k := range keys {
+				mem.Put(newRecord(Bytes(k), Bytes("v"), uint64(i+1)))
+			}
+
+			sst, _, err := flush(ctx, cfg, mem, fs)
+			require.NoError(t, err)
+
+			it, err := sst.IRange(Bytes("a"), Bytes("e"))
+			require.NoError(t, err)
+
+			for range keys {
+				_, err := it.Next()
+				require.NoError(t, err)
+			}
+
+			sri := it.(*sstableIRange)
+			assert.Equal(t, tc.history, len(sri.offs.buf))
+			expLen := tc.history
+			if expLen > len(keys) {
+				expLen = len(keys)
+			}
+			assert.Equal(t, expLen, sri.offs.len())
+
+			for i := 0; i < tc.history && i < len(keys); i++ {
+				rec, err := it.Prev()
+				require.NoError(t, err)
+				assert.Equal(t, Bytes(keys[len(keys)-1-i]), rec.GetKey())
+			}
+
+			_, err = it.Prev()
+			assert.ErrorIs(t, err, EOI)
+		})
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -90,6 +90,9 @@ func newTestRindbSetup(t *testing.T, ctx context.Context, cfg *Config) *testRind
 		if finalCfg.skipListP == 0.0 {
 			finalCfg.skipListP = defaultCfg.skipListP
 		}
+		if finalCfg.sstableIterMaxHistory == 0 {
+			finalCfg.sstableIterMaxHistory = defaultCfg.sstableIterMaxHistory
+		}
 	}
 
 	tempDir := t.TempDir()


### PR DESCRIPTION
## Summary
- allow configuring the number of offsets kept for iterator `Prev`
- propagate history limit to SSTable iterators
- test iterator and range iterators with bounded history

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c5854d295c832588ca3d393d5f8f04