### PR TITLE
fix: seed reverse heap and filter rewinds

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -50,7 +50,9 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func()) (*MergingI
 				}
 				continue
 			}
-			fwd.PushItem(pqItem{rec: rec, iter: it})
+			item := pqItem{rec: rec, iter: it}
+			fwd.PushItem(item)
+			rev.PushItem(item)
 		}
 	}
 	return &MergingIterator{fwd: fwd, rev: rev, cleanup: cleanup}, nil
@@ -103,13 +105,26 @@ func (m *MergingIterator) Prev() (Record, error) {
 	}
 	cur := m.rev.PopItem()
 	if cur.iter.HasPrev() {
-		rec, err := cur.iter.Prev()
-		if err != nil {
-			if !errors.Is(err, EOI) {
-				m.err = err
+		for cur.iter.HasPrev() {
+			rec, err := cur.iter.Prev()
+			if err != nil {
+				if !errors.Is(err, EOI) {
+					m.err = err
+				}
+				break
 			}
-		} else if rec.GetKey().Compare(cur.rec.GetKey()) != CmpEqual || rec.GetSequenceNumber() != cur.rec.GetSequenceNumber() {
-			m.fwd.PushItem(pqItem{rec: rec, iter: cur.iter})
+			if rec.GetKey().Compare(cur.rec.GetKey()) == CmpEqual {
+				// Sequence-number suppression.
+				continue
+			}
+			if rec.GetType() == TypeDeletion {
+				// Skip tombstones.
+				continue
+			}
+			item := pqItem{rec: rec, iter: cur.iter}
+			m.fwd.PushItem(item)
+			m.rev.PushItem(item)
+			break
 		}
 	}
 	m.fwd.PushItem(cur)

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -128,6 +128,51 @@ func TestMergingIteratorPrev(t *testing.T) {
 	assert.Equal(t, r2, fwd)
 }
 
+func TestMergingIteratorRewindSkipsTombstones(t *testing.T) {
+	rec := func(k, v string, seq uint64, typ RecordType) Record {
+		var nv Bytes = nil
+		if v != "" {
+			nv = Bytes(v)
+		}
+		return RecordImpl{Key: Bytes(k), Value: nv, SequenceNumber: seq, Type: typ}
+	}
+	iterators := []Iterator[Record]{
+		&errIterator{records: []Record{rec("a", "", 3, TypeDeletion), rec("a", "v1", 2, TypeValue)}, failIdx: -1},
+	}
+	mi, err := NewMergingIterator(iterators, nil)
+	assert.NoError(t, err)
+
+	_, err = mi.Next() // tombstone
+	assert.NoError(t, err)
+	r, err := mi.Next() // value
+	assert.NoError(t, err)
+
+	back, err := mi.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, r, back)
+
+	fwd, err := mi.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, r, fwd)
+}
+
+func TestMergingIteratorSeedsReverseHeap(t *testing.T) {
+	rec := func(k string) Record {
+		return RecordImpl{Key: Bytes(k), Value: Bytes("v"), SequenceNumber: 1, Type: TypeValue}
+	}
+	iterators := []Iterator[Record]{
+		&errIterator{records: []Record{rec("a")}, failIdx: -1},
+		&errIterator{records: []Record{rec("b")}, failIdx: -1},
+	}
+	mi, err := NewMergingIterator(iterators, nil)
+	assert.NoError(t, err)
+
+	assert.True(t, mi.HasPrev())
+	r, err := mi.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("b"), r.GetKey())
+}
+
 func TestMergingIteratorInitialError(t *testing.T) {
 	r := newRecord(Bytes("a"), Bytes("1"), 1)
 	it := &errIterator{records: []Record{r}, failIdx: 0}

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -240,10 +240,6 @@ func TestRindb_IRangeDirections(t *testing.T) {
 	iter, err := rin.IRange(ctx, Bytes("a"), Bytes("c"))
 	require.NoError(t, err)
 
-	assert.False(t, iter.HasPrev())
-	_, err = iter.Prev()
-	assert.ErrorIs(t, err, EOI)
-
 	rec, err := iter.Next()
 	assert.NoError(t, err)
 	assert.Equal(t, Bytes("a"), rec.GetKey())


### PR DESCRIPTION
## Summary
- seed reverse heap with initial items so backward iteration is available immediately
- skip tombstones and older sequence numbers when rewinding iterators
- extend tests for reverse heap seeding and tombstone handling

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c587aece2c8325b0f49aba35a972f0