### PR TITLE
test: add merging iterator integration tests

### DIFF
--- a/integration/merging_iterator_sources_test.go
+++ b/integration/merging_iterator_sources_test.go
@@ -65,13 +65,11 @@ func TestIRangeAlternatingAcrossMemtableAndSSTable(t *testing.T) {
 	_, err = iter.Next()
 	require.ErrorIs(t, err, rindb.EOI)
 
-	rec, err := iter.Prev()
-	require.NoError(t, err)
-	require.Equal(t, "f", string(rec.GetKey()))
-
-	rec, err = iter.Prev()
-	require.NoError(t, err)
-	require.Equal(t, "e", string(rec.GetKey()))
+	for _, want := range []string{"f", "e"} {
+		rec, err := iter.Prev()
+		require.NoError(t, err)
+		require.Equal(t, want, string(rec.GetKey()))
+	}
 }
 
 func TestIRangeExhaustsSources(t *testing.T) {
@@ -92,50 +90,21 @@ func TestIRangeExhaustsSources(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, iter.Close()) })
 
-	// Exhaust the memtable first.
-	rec, err := iter.Next()
-	require.NoError(t, err)
-	require.Equal(t, "a", string(rec.GetKey()))
-
-	rec, err = iter.Next()
-	require.NoError(t, err)
-	require.Equal(t, "b", string(rec.GetKey()))
-
-	// Now iterate over SSTable records after the memtable is exhausted.
-	rec, err = iter.Next()
-	require.NoError(t, err)
-	require.Equal(t, "c", string(rec.GetKey()))
-
-	rec, err = iter.Next()
-	require.NoError(t, err)
-	require.Equal(t, "d", string(rec.GetKey()))
-
-	rec, err = iter.Next()
-	require.NoError(t, err)
-	require.Equal(t, "e", string(rec.GetKey()))
+	// Exhaust the memtable first, then iterate over SSTable records.
+	for _, want := range []string{"a", "b", "c", "d", "e"} {
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		require.Equal(t, want, string(rec.GetKey()))
+	}
 
 	_, err = iter.Next()
 	require.ErrorIs(t, err, rindb.EOI)
 
-	rec, err = iter.Prev()
-	require.NoError(t, err)
-	require.Equal(t, "e", string(rec.GetKey()))
-
-	rec, err = iter.Prev()
-	require.NoError(t, err)
-	require.Equal(t, "d", string(rec.GetKey()))
-
-	rec, err = iter.Prev()
-	require.NoError(t, err)
-	require.Equal(t, "c", string(rec.GetKey()))
-
-	rec, err = iter.Prev()
-	require.NoError(t, err)
-	require.Equal(t, "b", string(rec.GetKey()))
-
-	rec, err = iter.Prev()
-	require.NoError(t, err)
-	require.Equal(t, "a", string(rec.GetKey()))
+	for _, want := range []string{"e", "d", "c", "b", "a"} {
+		rec, err := iter.Prev()
+		require.NoError(t, err)
+		require.Equal(t, want, string(rec.GetKey()))
+	}
 
 	_, err = iter.Prev()
 	require.ErrorIs(t, err, rindb.EOI)

--- a/integration/merging_iterator_sources_test.go
+++ b/integration/merging_iterator_sources_test.go
@@ -1,0 +1,142 @@
+//go:build integration && smoke
+
+package rindb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/metailurini/rindb"
+)
+
+func TestIRangeAlternatingAcrossMemtableAndSSTable(t *testing.T) {
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(175))
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	// Initial records that get flushed to an SSTable.
+	require.NoError(t, db.Put(ctx, rindb.Bytes("a"), rindb.Bytes("va")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("c"), rindb.Bytes("vc")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("e"), rindb.Bytes("ve")))
+
+	// Records that remain in the memtable.
+	require.NoError(t, db.Put(ctx, rindb.Bytes("b"), rindb.Bytes("vb")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("d"), rindb.Bytes("vd")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("f"), rindb.Bytes("vf")))
+
+	iter, err := db.IRange(ctx, rindb.Bytes("a"), rindb.Bytes("z"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, iter.Close()) })
+
+	type op struct {
+		next bool
+		want string
+	}
+	ops := []op{
+		{true, "a"},
+		{true, "b"},
+		{false, "b"},
+		{true, "b"},
+		{true, "c"},
+		{false, "c"},
+		{true, "c"},
+		{true, "d"},
+		{false, "d"},
+		{true, "d"},
+		{true, "e"},
+		{false, "e"},
+		{true, "e"},
+		{true, "f"},
+	}
+
+	for i, op := range ops {
+		var rec rindb.Record
+		if op.next {
+			rec, err = iter.Next()
+		} else {
+			rec, err = iter.Prev()
+		}
+		require.NoError(t, err, "step %d", i)
+		require.Equal(t, op.want, string(rec.GetKey()), "step %d", i)
+	}
+
+	_, err = iter.Next()
+	require.ErrorIs(t, err, rindb.EOI)
+
+	rec, err := iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "f", string(rec.GetKey()))
+
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "e", string(rec.GetKey()))
+}
+
+func TestIRangeExhaustsSources(t *testing.T) {
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(175))
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	// Records flushed to an SSTable.
+	require.NoError(t, db.Put(ctx, rindb.Bytes("c"), rindb.Bytes("vc")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("d"), rindb.Bytes("vd")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("e"), rindb.Bytes("ve")))
+
+	// Records that remain in the memtable (lower keys).
+	require.NoError(t, db.Put(ctx, rindb.Bytes("a"), rindb.Bytes("va")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("b"), rindb.Bytes("vb")))
+
+	iter, err := db.IRange(ctx, rindb.Bytes("a"), rindb.Bytes("z"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, iter.Close()) })
+
+	// Exhaust the memtable first.
+	rec, err := iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, "a", string(rec.GetKey()))
+
+	rec, err = iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, "b", string(rec.GetKey()))
+
+	// Now iterate over SSTable records after the memtable is exhausted.
+	rec, err = iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, "c", string(rec.GetKey()))
+
+	rec, err = iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, "d", string(rec.GetKey()))
+
+	rec, err = iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, "e", string(rec.GetKey()))
+
+	_, err = iter.Next()
+	require.ErrorIs(t, err, rindb.EOI)
+
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "e", string(rec.GetKey()))
+
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "d", string(rec.GetKey()))
+
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "c", string(rec.GetKey()))
+
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "b", string(rec.GetKey()))
+
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "a", string(rec.GetKey()))
+
+	_, err = iter.Prev()
+	require.ErrorIs(t, err, rindb.EOI)
+}


### PR DESCRIPTION
## Summary
- add integration tests covering iteration across combined memtable and SSTable sources
- exercise alternating Next/Prev and source exhaustion to verify heap rebalancing

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c58dddcd708325a9ae3bd5b0208b97