### PR TITLE
docs: clarify merging iterator initialization

### DIFF
--- a/docs/dev/54/merging_range_iterators_plan.md
+++ b/docs/dev/54/merging_range_iterators_plan.md
@@ -2,10 +2,10 @@
 
 This document expands step 4 of the reverse range scanning plan, detailing how multiple iterators can be merged while supporting backward traversal.
 
-1. Seed both heaps with the first record from every source iterator. `fwd` is a min-heap by key/seq; `rev` is a max-heap containing the same `pqItem` pointers.
+1. Seed `fwd` with the first record from every source iterator; `rev` starts empty so calling `Prev` before any `Next` returns `EOI`.
 2. `Next` pops from `fwd`, pushes the item onto `rev`, and advances the underlying iterator; `Prev` removes the current item from `rev`, rewinds its source, and returns the new top of `rev`, or `EOI` if the heap becomes empty.
-3. Tombstones and sequence-number de-duplication occur in both directions before items are pushed onto either heap.
-4. Remove exhausted sources from both heaps to keep `HasPrev`/`HasNext` accurate.
+3. Tombstone filtering and sequence-number suppression is handled by the `RangeIterator` before records reach the `MergingIterator`.
+4. Remove exhausted sources from the heaps to keep `HasPrev`/`HasNext` accurate.
 
 ```go
 type MergingIterator struct {
@@ -17,11 +17,11 @@ type MergingIterator struct {
 func (m *MergingIterator) Next() (Record, error) {
     m.cur = heap.Pop(&m.fwd).(pqItem)
     heap.Push(&m.rev, m.cur)
-    advance(m.cur.src) // may push new item into both heaps
+    advance(m.cur.src) // may push new item into fwd
     return m.cur.rec, nil
 }
 
-func (m *MergingIterator) HasPrev() bool { return m.rev.Len() > 1 }
+func (m *MergingIterator) HasPrev() bool { return m.rev.Len() > 0 }
 
 func (m *MergingIterator) Prev() (Record, error) {
     cur := heap.Pop(&m.rev).(pqItem)
@@ -40,17 +40,16 @@ func (m *MergingIterator) Prev() (Record, error) {
 
 ```go
 func advance(src Iterator) {
-    if rec, err := src.Next(); err == nil && !isTombstoned(rec) && isNewest(rec) {
+    if rec, err := src.Next(); err == nil {
         item := pqItem{rec: rec, src: src}
         heap.Push(&m.fwd, item)
-        heap.Push(&m.rev, item)
     } else if err == io.EOF {
-        dropSource(src) // remove from both heaps
+        dropSource(src) // remove from heaps
     }
 }
 
 func rewind(src Iterator) *pqItem {
-    if rec, err := src.Prev(); err == nil && !isTombstoned(rec) && isNewest(rec) {
+    if rec, err := src.Prev(); err == nil {
         return &pqItem{rec: rec, src: src}
     }
     return nil
@@ -58,6 +57,6 @@ func rewind(src Iterator) *pqItem {
 ```
 
 Concerns:
-- Rewind helpers must reapply tombstone filtering and sequence-number suppression so deleted or stale keys stay hidden.
+- `RangeIterator` must perform tombstone filtering and sequence-number suppression so deleted or stale keys stay hidden before records reach the merger.
 - Dual heaps require rebalancing when sources are exhausted, otherwise `HasPrev` may leak duplicates.
 - Edge tests should exhaust a source, alternate `Next`/`Prev`, and traverse across memtables and SSTables to verify correctness.


### PR DESCRIPTION
## Summary
- clarify that only the forward heap is seeded in MergingIterator
- note RangeIterator handles tombstone/duplicate suppression

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c592ec8ef483259cdd2e1c11bdb6e7