### PR TITLE
docs: add detailed diffharness refactor plans

### DIFF
--- a/docs/dev/00/refactor_diffharness/overall_plan.md
+++ b/docs/dev/00/refactor_diffharness/overall_plan.md
@@ -1,0 +1,134 @@
+# Diffharness refactor plan
+
+## 1. Split core types and harness struct into `types.go`
+Consolidate `OpKind`, `Op`, `Phase`, `Cfg`, and a trimmed `Harness` struct in a dedicated file to separate domain data from logic.
+```go
+// types.go
+package diffharness
+
+type OpKind uint8
+const (
+    OpPut OpKind = iota
+    OpDel
+    OpGet
+    OpRange
+    OpSnap
+)
+
+type Op struct {
+    Kind    OpKind
+    K, V    []byte
+    Lo, Hi  []byte
+    SnapSeq uint64
+    Limit   int
+}
+
+type Phase string
+
+type Cfg struct {
+    KeyLen, ValLenMin, ValLenMax, RangeMax int
+    Weights                                 map[OpKind]int
+    CrashEvery, TelemetryEvery              int
+}
+
+type Harness struct {
+    Seed int64
+    My   Engine
+    Ref  *SQLiteOracle
+    Seq       uint64
+    Snapshots []uint64
+}
+```
+
+## 2. Introduce an `Operation` interface and handlers
+Replace `applyPut`, `applyDel`, etc. with structs implementing a common `Operation` interface. Centralize phase handling and logging inside `Operation.Apply`.
+```go
+// op.go
+package diffharness
+
+ type Operation interface {
+     Apply(ctx context.Context, h *Harness, log PhaseLogger) (committed bool, err error)
+ }
+
+ type PutOp struct { K, V []byte }
+ func (p PutOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+     // begin, mutate, commit, log phases
+     return true, nil
+ }
+
+ type DelOp struct { K []byte }
+ func (d DelOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+     return true, nil
+ }
+
+ // Additional ops: GetOp, RangeOp, SnapOp
+```
+Detailed plan: see `step_2_operation_interface_plan.md`.
+
+## 3. Extract randomness and key tracking into `generator.go`
+Isolate fuzzing helpers so the harness focuses on orchestration rather than random data generation.
+```go
+// generator.go
+package diffharness
+
+type KeyTracker struct {
+    keys   []string
+    keySet map[string]struct{}
+}
+func (kt *KeyTracker) Add(k []byte) { /* ... */ }
+func (kt *KeyTracker) Del(k []byte) { /* ... */ }
+func (kt *KeyTracker) Random(r *rand.Rand) []byte { /* ... */ }
+
+type RandOps struct { cfg Cfg }
+func (ro RandOps) Next(r *rand.Rand, kt *KeyTracker) Operation { /* ... */ }
+```
+
+## 4. Isolate logging, crash, and telemetry hooks
+Move `phaseLogger`, crash, and telemetry callbacks into a dedicated `logger.go`, allowing `Harness.Step` to delegate side effects.
+```go
+// logger.go
+package diffharness
+
+type PhaseLogger interface {
+    Log(op Op, seq uint64, phase Phase) error
+}
+
+ type HookSet struct {
+     Crash     func() error
+     Telemetry func(seq uint64, ops int)
+ }
+
+ func (h *Harness) Step(ctx context.Context, op Operation) error {
+    committed, err := op.Apply(ctx, h, h.logger)
+    if err != nil { return err }
+    if committed { h.Seq++ }
+    return nil
+}
+```
+Detailed plan: see `step_4_logging_hooks_plan.md`.
+
+## 5. Move invariant checks into `invariants.go`
+Create composable invariant functions and have `run` iterate over them, improving readability and testability.
+```go
+// invariants.go
+package diffharness
+
+type Invariant func(ctx context.Context, h *Harness) error
+
+func checkMonotonicReads(ctx context.Context, h *Harness) error { /* ... */ }
+func checkRangeConcat(ctx context.Context, h *Harness) error  { /* ... */ }
+
+var defaultInvariants = []Invariant{
+    checkMonotonicReads,
+    checkRangeConcat,
+}
+```
+
+### Complexity & further planning
+| Step | Complexity (1-10) | Dedicated plan? |
+|------|-------------------|-----------------|
+| 1    | 4                 | No              |
+| 2    | 8                 | Yes             |
+| 3    | 5                 | No              |
+| 4    | 7                 | Yes             |
+| 5    | 3                 | No              |

--- a/docs/dev/00/refactor_diffharness/overall_plan.md
+++ b/docs/dev/00/refactor_diffharness/overall_plan.md
@@ -46,7 +46,7 @@ Replace `applyPut`, `applyDel`, etc. with structs implementing a common `Operati
 // op.go
 package diffharness
 
- type Operation interface {
+type Operation interface {
      Apply(ctx context.Context, h *Harness, log PhaseLogger) (committed bool, err error)
  }
 

--- a/docs/dev/00/refactor_diffharness/step_2_operation_interface_plan.md
+++ b/docs/dev/00/refactor_diffharness/step_2_operation_interface_plan.md
@@ -1,0 +1,63 @@
+# Step 2: Operation interface and handlers
+
+## Plan
+- Define a small `Operation` interface with `Apply(ctx, *Harness, PhaseLogger)` returning `(bool, error)` to unify begin/mutate/commit logic.
+- Convert existing `applyPut`, `applyDel`, `applyGet`, `applyRange`, and `applySnap` helpers into structs implementing `Operation`.
+- Keep idempotence by letting each handler decide whether it "committed" and increment the harness sequence only on true.
+- Provide a factory to translate parsed `Op` structs into concrete `Operation` values so the fuzz generator can stay unchanged.
+- Update `Harness.Step` to accept an `Operation`, invoke `Apply`, and handle errors uniformly.
+- Make `Operation` implementations responsible for updating snapshot bookkeeping so `Harness` remains slim.
+- Return a concrete error type for mismatches to aid invariant debugging.
+- Expose a helper `wrapErr(op, phase, err)` to annotate errors with operation context.
+- Supply table-driven tests per `Operation` to verify error propagation and logging.
+- Document the concurrency assumption that operations run serially; guard shared state within `Harness` accordingly.
+- Provide future extension point via `OperationName() string` if tracing or metrics need explicit names.
+
+These changes isolate operational logic and simplify extensions like batch ops or tracing.
+The snippet below sketches primary types and a factory for constructing operations from parsed input.
+
+```go
+// op.go
+package diffharness
+
+type Operation interface {
+    Apply(ctx context.Context, h *Harness, log PhaseLogger) (committed bool, err error)
+}
+
+type PutOp struct{ K, V []byte }
+func (p PutOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+    log.Log(Op{Kind: OpPut, K: p.K, V: p.V}, h.Seq, Phase("Begin"))
+    if err := h.My.Put(ctx, p.K, p.V); err != nil {
+        return false, err
+    }
+    if err := h.Ref.Put(ctx, p.K, p.V); err != nil {
+        return false, err
+    }
+    log.Log(Op{Kind: OpPut, K: p.K, V: p.V}, h.Seq, Phase("Commit"))
+    return true, nil
+}
+
+type DelOp struct{ K []byte }
+func (d DelOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+    log.Log(Op{Kind: OpDel, K: d.K}, h.Seq, Phase("Begin"))
+    if err := h.My.Del(ctx, d.K); err != nil {
+        return false, err
+    }
+    if err := h.Ref.Del(ctx, d.K); err != nil {
+        return false, err
+    }
+    log.Log(Op{Kind: OpDel, K: d.K}, h.Seq, Phase("Commit"))
+    return true, nil
+}
+
+func opFrom(o Op) Operation {
+    switch o.Kind {
+    case OpPut:
+        return PutOp{K: o.K, V: o.V}
+    case OpDel:
+        return DelOp{K: o.K}
+    // case OpGet, OpRange, OpSnap ...
+    }
+    return nil
+}
+```

--- a/docs/dev/00/refactor_diffharness/step_2_operation_interface_plan.md
+++ b/docs/dev/00/refactor_diffharness/step_2_operation_interface_plan.md
@@ -59,7 +59,8 @@ func opFrom(o Op) Operation {
     case OpDel:
         return DelOp{K: o.K}
     // case OpGet, OpRange, OpSnap ...
+    default:
+        panic(fmt.Sprintf("unhandled op kind: %v", o.Kind))
     }
-    return nil
 }
 ```

--- a/docs/dev/00/refactor_diffharness/step_2_operation_interface_plan.md
+++ b/docs/dev/00/refactor_diffharness/step_2_operation_interface_plan.md
@@ -26,7 +26,9 @@ type Operation interface {
 
 type PutOp struct{ K, V []byte }
 func (p PutOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
-    log.Log(Op{Kind: OpPut, K: p.K, V: p.V}, h.Seq, Phase("Begin"))
+    if err := log.Log(Op{Kind: OpPut, K: p.K, V: p.V}, h.Seq, Phase("Begin")); err != nil {
+        return false, err
+    }
     if err := h.My.Put(ctx, p.K, p.V); err != nil {
         return false, err
     }

--- a/docs/dev/00/refactor_diffharness/step_4_logging_hooks_plan.md
+++ b/docs/dev/00/refactor_diffharness/step_4_logging_hooks_plan.md
@@ -1,0 +1,62 @@
+# Step 4: Logging, crash, and telemetry hooks
+
+## Plan
+- Introduce a `PhaseLogger` interface and move existing phase printouts into implementations; keep `Harness` agnostic of output medium.
+- Bundle crash and telemetry callbacks in a `HookSet`, allowing tests to inject failures or custom metrics collection.
+- Embed `PhaseLogger` and `HookSet` into `Harness` and rewrite `Step` to call the hooks while keeping sequencing logic centralized.
+- Provide a default no-op logger and hooks so basic fuzzing runs without extra wiring.
+- Expose helpers for composing hooks (e.g., `WithCrash`, `WithTelemetry`) to keep setup declarative.
+- Offer a `MultiLogger` helper so multiple loggers (e.g., console + JSON) can be chained.
+- Clarify that crash hooks run after telemetry so failing hooks don't skip metrics.
+- Supply `WithHooks(h HookSet)` to replace the entire hook set in tests.
+- Add table-driven tests verifying order and nil safety of hooks.
+- Document that hooks should return quickly to keep fuzzing throughput high.
+- Reserve room for future metrics by letting `Telemetry` receive total op count.
+- Show how to serialize logs in a stable format for regression triage.
+
+These additions decouple side effects from the harness and permit richer observability without cluttering core logic.
+The snippet outlines key interfaces, `Harness` fields, and a `Step` method invoking the hooks.
+
+```go
+// logger.go
+package diffharness
+
+type PhaseLogger interface {
+    Log(op Op, seq uint64, phase Phase) error
+}
+
+type HookSet struct {
+    Crash     func() error
+    Telemetry func(seq uint64, ops int)
+}
+
+type Harness struct {
+    // ... existing fields ...
+    logger PhaseLogger
+    hooks  HookSet
+}
+
+func (h *Harness) Step(ctx context.Context, op Operation) error {
+    committed, err := op.Apply(ctx, h, h.logger)
+    if err != nil {
+        return err
+    }
+    if committed {
+        h.Seq++
+        if h.hooks.Telemetry != nil {
+            h.hooks.Telemetry(h.Seq, 1)
+        }
+    }
+    if h.hooks.Crash != nil {
+        if err := h.hooks.Crash(); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+var nopLogger PhaseLogger = PhaseLoggerFunc(func(Op, uint64, Phase) error { return nil })
+
+type PhaseLoggerFunc func(Op, uint64, Phase) error
+func (f PhaseLoggerFunc) Log(op Op, seq uint64, phase Phase) error { return f(op, seq, phase) }
+```

--- a/docs/dev/00/refactor_diffharness/step_4_logging_hooks_plan.md
+++ b/docs/dev/00/refactor_diffharness/step_4_logging_hooks_plan.md
@@ -44,7 +44,7 @@ func (h *Harness) Step(ctx context.Context, op Operation) error {
     if committed {
         h.Seq++
         if h.hooks.Telemetry != nil {
-            h.hooks.Telemetry(h.Seq, 1)
+            h.hooks.Telemetry(h.Seq, h.ops)
         }
     }
     if h.hooks.Crash != nil {


### PR DESCRIPTION
## Summary
- document dedicated plans for Operation interface and logging/telemetry hooks in diffharness refactor
- link step entries in overall plan to their detailed documents

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c596686f1c832598da79525a136ba7