### PR TITLE
docs: add testing convention plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@
 
 ## Testing Guidelines
 - Frameworks: Standard `testing` with `testify` for assertions.
-- Style: Prefer table‑driven tests; name tests `TestXxx` in `*_test.go`.
+- Naming: Top‑level tests follow `Test<Subject>_<Behavior>`; integration tests in `integration/` use the same pattern.
+- Structure: When covering multiple cases, use table‑driven tests with `t.Run(tt.name, ...)`; subtest names should be descriptive and human‑readable.
 - Data: Write temp files under `testdata/`. Tests clean this directory; do not commit generated artifacts.
 - Integration tests live in `integration/` and use build tags. Run quick tests with `make test-integration-smoke` and the full suite with `make test-integration-full`.
 - Run: `make test` locally; use `t.Helper()` for helpers and avoid global state between tests.

--- a/docs/dev/00/testing_convention/integration_tests_refactor_plan.md
+++ b/docs/dev/00/testing_convention/integration_tests_refactor_plan.md
@@ -1,0 +1,69 @@
+# Integration Tests Refactor Plan
+
+1. **Rename integration tests**
+   - Plan: Apply `Test<Subject>_<Behavior>` and include `//go:build integration` tags.
+   ```go
+   //go:build integration
+   // old
+   func TestTableCacheMissAfterGetFollowingCompaction(t *testing.T) {}
+   // new
+   func TestTableCache_GetAfterCompactionMiss(t *testing.T) {}
+   ```
+   - Complexity: 6/10
+
+2. **Normalize setup/teardown**
+   - Plan: Introduce helper constructors to reduce duplicated environment setup.
+   ```go
+   func newIntegrationDB(t *testing.T) *DB {
+       t.Helper()
+       dir := t.TempDir()
+       db, err := Open(dir, WithWAL(), WithMemTableSize(1024))
+       require.NoError(t, err)
+       return db
+   }
+   ```
+   - Complexity: 4/10
+
+3. **Adopt table-driven subtests**
+   - Plan: Restructure tests that cover multiple scenarios into table-driven format.
+   ```go
+   func TestRangeQuery_ReturnsOrderedKeys(t *testing.T) {
+       cases := []struct{
+           name string
+           keys []string
+       }{
+           {"ascending", []string{"a","b"}},
+           {"descending", []string{"b","a"}},
+       }
+       for _, tt := range cases {
+           tt := tt
+           t.Run(tt.name, func(t *testing.T) {
+               // ...
+           })
+       }
+   }
+   ```
+   - Complexity: 7/10
+
+4. **Add naming enforcement test**
+   - Plan: Implement a test that fails when functions don't match regex `^Test[A-Za-z0-9]+_[A-Za-z0-9]+$`.
+   ```go
+   var testNameRe = regexp.MustCompile(`^Test[A-Za-z0-9]+_[A-Za-z0-9]+$`)
+
+   func TestNamingConventions(t *testing.T) {
+       for _, name := range testNamesFromPackage(t) {
+           if !testNameRe.MatchString(name) {
+               t.Errorf("%s does not follow Test<Subject>_<Behavior>", name)
+           }
+       }
+   }
+   ```
+   - Complexity: 8/10
+
+5. **Run smoke and full suites**
+   - Plan: Execute `make test` and `make test-integration-smoke` to validate changes.
+   ```sh
+   make test
+   make test-integration-smoke
+   ```
+   - Complexity: 5/10

--- a/docs/dev/00/testing_convention/overall_plan.md
+++ b/docs/dev/00/testing_convention/overall_plan.md
@@ -1,0 +1,85 @@
+# Testing Convention Overhaul Plan
+
+1. **Define naming format**
+   - Plan: Document a consistent `Test<Subject>_<Behavior>` pattern for unit and integration tests; subtests should describe scenarios in natural language.
+   ```go
+   // Unit test example
+   func TestMemtable_Get(t *testing.T) {
+       t.Run("found", func(t *testing.T) {
+           // ...
+       })
+   }
+
+   // Integration test example
+   //go:build integration
+   func TestCompaction_PreservesTombstone(t *testing.T) {
+       // ...
+   }
+   ```
+   - Complexity: 2/10
+   - Dedicated plan file: No
+
+2. **Establish table-driven template**
+   - Plan: Provide a standard table-driven template to cover multiple cases with `t.Run`.
+   ```go
+   func TestRecord_Encode(t *testing.T) {
+       tests := []struct {
+           name string
+           rec  Record
+           want []byte
+       }{
+           {"value record", newRecord(Bytes("k"), Bytes("v"), 1), []byte{0x01}},
+           {"tombstone", newDeletion(Bytes("k"), 2), []byte{0x00}},
+       }
+       for _, tt := range tests {
+           tt := tt
+           t.Run(tt.name, func(t *testing.T) {
+               got := Encode(tt.rec)
+               assert.Equal(t, tt.want, got)
+           })
+       }
+   }
+   ```
+   - Complexity: 4/10
+   - Dedicated plan file: No
+
+3. **Refactor unit tests**
+   - Plan: Rename existing unit test functions and convert ad-hoc checks into table-driven subtests.
+   ```go
+   // before
+   func TestMemtable_Basic(t *testing.T) {
+       // ...
+   }
+
+   // after
+   func TestMemtable_BasicOperations(t *testing.T) {
+       cases := []struct{name, key, val string}{{"put/get", "k1", "v1"}}
+       for _, tt := range cases {
+           t.Run(tt.name, func(t *testing.T) {
+               // ...
+           })
+       }
+   }
+   ```
+   - Complexity: 8/10
+   - Dedicated plan file: Yes (unit_tests_refactor_plan.md)
+
+4. **Refactor integration tests and enforce naming check**
+   - Plan: Align integration test names with the same pattern and add a lightweight check to flag misnamed tests.
+   ```go
+   //go:build integration
+   func TestRangeQuery_ReturnsOrderedKeys(t *testing.T) {
+       // ...
+   }
+
+   var testNameRe = regexp.MustCompile(`^Test[A-Za-z0-9]+_[A-Za-z0-9]+$`)
+   func TestNameConventions(t *testing.T) {
+       for _, name := range testNamesFromPackage() {
+           if !testNameRe.MatchString(name) {
+               t.Errorf("%s does not follow Test<Subject>_<Behavior>", name)
+           }
+       }
+   }
+   ```
+   - Complexity: 7/10
+   - Dedicated plan file: Yes (integration_tests_refactor_plan.md)

--- a/docs/dev/00/testing_convention/unit_tests_refactor_plan.md
+++ b/docs/dev/00/testing_convention/unit_tests_refactor_plan.md
@@ -1,0 +1,55 @@
+# Unit Tests Refactor Plan
+
+1. **Inventory and rename tests**
+   - Plan: List all unit test functions, rename to `Test<Subject>_<Behavior>`.
+   ```go
+   // old
+   func TestMemtable_Basic(t *testing.T) {}
+   // new
+   func TestMemtable_BasicOperations(t *testing.T) {}
+   ```
+   - Complexity: 5/10
+
+2. **Adopt table-driven structure**
+   - Plan: Convert ad-hoc checks to table-driven subtests using `t.Run`.
+   ```go
+   func TestTableCache_Load(t *testing.T) {
+       cases := []struct{
+           name string
+           key  string
+           want bool
+       }{
+           {"hit", "k1", true},
+           {"miss", "k2", false},
+       }
+       for _, tt := range cases {
+           tt := tt
+           t.Run(tt.name, func(t *testing.T) {
+               got := cache.Load(tt.key)
+               require.Equal(t, tt.want, got)
+           })
+       }
+   }
+   ```
+   - Complexity: 8/10
+
+3. **Extract shared helpers**
+   - Plan: Move repeated setup/teardown into helper functions with `t.Helper()`.
+   ```go
+   func newTestDB(t *testing.T) *DB {
+       t.Helper()
+       dir := t.TempDir()
+       db, err := Open(dir)
+       require.NoError(t, err)
+       return db
+   }
+   ```
+   - Complexity: 4/10
+
+4. **Enforce linting and run tests**
+   - Plan: Ensure `make check` and `make test` pass after refactors.
+   ```sh
+   make check
+   make test
+   ```
+   - Complexity: 3/10


### PR DESCRIPTION
## Summary
- add dedicated plan for unit test refactors
- outline integration test refactors with naming enforcement

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c5976ba3448325873defa76b28d1b4