### PR TITLE
refactor: introduce diffharness operation interface

### DIFF
--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -11,72 +11,6 @@ import (
 	"os"
 )
 
-// OpKind enumerates supported operation types.
-type OpKind uint8
-
-const (
-	OpPut OpKind = iota
-	OpDel
-	OpGet
-	OpRange
-	OpSnap
-)
-
-const OpInvariantCheck OpKind = 255
-
-// Op models a single diffharness operation.
-type Op struct {
-	Kind    OpKind
-	K       []byte
-	V       []byte
-	Lo      []byte
-	Hi      []byte
-	SnapSeq uint64
-	Limit   int
-}
-
-type Phase string
-
-const (
-	PhasePrepared  Phase = "prepared"
-	PhaseMyDone    Phase = "my_done"
-	PhaseRefDone   Phase = "ref_done"
-	PhaseCommitted Phase = "committed"
-)
-
-// Harness coordinates both engines and records every executed operation.
-type Harness struct {
-	Seed int64
-
-	My  Engine
-	Ref *SQLiteOracle
-
-	Seq       uint64
-	Snapshots []uint64
-
-	keys   []string
-	keySet map[string]struct{}
-
-	log *os.File
-	enc *json.Encoder
-	ops int
-
-	crash     func() error
-	telemetry func(seq uint64, ops int)
-}
-
-// Cfg controls random operation generation.
-type Cfg struct {
-	KeyLen    int
-	ValLenMin int
-	ValLenMax int
-	RangeMax  int
-	Weights   map[OpKind]int
-
-	CrashEvery     int
-	TelemetryEvery int
-}
-
 // NewHarness creates a harness with the given engines and log file path.
 func NewHarness(my Engine, ref *SQLiteOracle, seed int64, logPath string) (*Harness, error) {
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
@@ -223,274 +157,28 @@ func (h *Harness) SetCrashHook(fn func() error) { h.crash = fn }
 // It receives the current sequence and op count.
 func (h *Harness) SetTelemetryHook(fn func(seq uint64, ops int)) { h.telemetry = fn }
 
-type phaseLogger func(Phase) error
-type phaseHook func() error
-
-func applyPut(ctx context.Context, my Engine, ref *SQLiteOracle, op Op, seq uint64, start Phase, log phaseLogger, hook phaseHook) (uint64, error) {
-	finalSeq := seq + 1
-	switch start {
-	case PhasePrepared:
-		if err := my.Begin(ctx); err != nil {
-			return 0, err
-		}
-		if err := my.Put(ctx, op.K, op.V); err != nil {
-			_ = my.Rollback(ctx)
-			return 0, err
-		}
-		if err := my.Commit(ctx); err != nil {
-			return 0, err
-		}
-		if err := log(PhaseMyDone); err != nil {
-			return 0, err
-		}
-		if hook != nil {
-			if err := hook(); err != nil {
-				return 0, err
-			}
-		}
-		fallthrough
-	case PhaseMyDone:
-		if ref != nil {
-			if err := ref.Begin(ctx); err != nil {
-				return 0, err
-			}
-			if err := ref.PutWithSeq(op.K, op.V, finalSeq); err != nil {
-				_ = ref.Rollback(ctx)
-				return 0, err
-			}
-			if err := ref.Commit(ctx); err != nil {
-				return 0, err
-			}
-		}
-		if err := log(PhaseRefDone); err != nil {
-			return 0, err
-		}
-		if hook != nil {
-			if err := hook(); err != nil {
-				return 0, err
-			}
-		}
-		fallthrough
-	case PhaseRefDone:
-		if err := log(PhaseCommitted); err != nil {
-			return 0, err
-		}
-	}
-	return finalSeq, nil
-}
-
-func applyDel(ctx context.Context, my Engine, ref *SQLiteOracle, op Op, seq uint64, start Phase, log phaseLogger, hook phaseHook) (uint64, error) {
-	finalSeq := seq + 1
-	switch start {
-	case PhasePrepared:
-		if err := my.Begin(ctx); err != nil {
-			return 0, err
-		}
-		if err := my.Delete(ctx, op.K); err != nil {
-			_ = my.Rollback(ctx)
-			return 0, err
-		}
-		if err := my.Commit(ctx); err != nil {
-			return 0, err
-		}
-		if err := log(PhaseMyDone); err != nil {
-			return 0, err
-		}
-		if hook != nil {
-			if err := hook(); err != nil {
-				return 0, err
-			}
-		}
-		fallthrough
-	case PhaseMyDone:
-		if ref != nil {
-			if err := ref.Begin(ctx); err != nil {
-				return 0, err
-			}
-			if err := ref.DelWithSeq(op.K, finalSeq); err != nil {
-				_ = ref.Rollback(ctx)
-				return 0, err
-			}
-			if err := ref.Commit(ctx); err != nil {
-				return 0, err
-			}
-		}
-		if err := log(PhaseRefDone); err != nil {
-			return 0, err
-		}
-		if hook != nil {
-			if err := hook(); err != nil {
-				return 0, err
-			}
-		}
-		fallthrough
-	case PhaseRefDone:
-		if err := log(PhaseCommitted); err != nil {
-			return 0, err
-		}
-	}
-	return finalSeq, nil
-}
-
-func applySnap(ctx context.Context, my Engine, ref *SQLiteOracle, seq uint64, start Phase, log phaseLogger, hook phaseHook) (uint64, error) {
-	switch start {
-	case PhasePrepared:
-		s, err := my.NewSnapshot(ctx)
-		if err != nil {
-			return 0, err
-		}
-		if s != seq {
-			return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, have=%d", seq, s)
-		}
-		if err := log(PhaseMyDone); err != nil {
-			return 0, err
-		}
-		if hook != nil {
-			if err := hook(); err != nil {
-				return 0, err
-			}
-		}
-		fallthrough
-	case PhaseMyDone:
-		if ref != nil {
-			refSeq, err := ref.NewSnapshot(ctx)
-			if err != nil {
-				return 0, err
-			}
-			if refSeq != seq {
-				return 0, fmt.Errorf("snapshot sequence mismatch: my=%d, ref=%d", seq, refSeq)
-			}
-		}
-		if err := log(PhaseRefDone); err != nil {
-			return 0, err
-		}
-		if hook != nil {
-			if err := hook(); err != nil {
-				return 0, err
-			}
-		}
-		fallthrough
-	case PhaseRefDone:
-		if err := log(PhaseCommitted); err != nil {
-			return 0, err
-		}
-	}
-	return seq, nil
-}
-
 // Step applies a single operation, logging it before execution.
-func (h *Harness) Step(ctx context.Context, op Op) error {
+func (h *Harness) Step(ctx context.Context, op Operation) error {
 	i := h.ops
-	seq := h.Seq
-	logPhase := func(p Phase) error {
+	logger := phaseLoggerFunc(func(o Op, seq uint64, p Phase) error {
 		if err := h.enc.Encode(struct {
 			I     int    `json:"i"`
 			Seq   uint64 `json:"seq"`
 			Op    Op     `json:"op"`
 			Phase Phase  `json:"phase"`
-		}{i, seq, op, p}); err != nil {
+		}{i, seq, o, p}); err != nil {
 			return err
 		}
 		return h.log.Sync()
-	}
-	if err := logPhase(PhasePrepared); err != nil {
+	})
+	committed, err := op.Apply(ctx, h, logger)
+	if err != nil {
 		return err
 	}
-	if h.crash != nil {
-		if err := h.crash(); err != nil {
-			return err
-		}
+	if committed {
+		h.Seq++
 	}
 	h.ops++
-	committed := false
-	switch op.Kind {
-	case OpPut:
-		h.Seq++
-		if _, err := applyPut(ctx, h.My, h.Ref, op, seq, PhasePrepared, logPhase, h.crash); err != nil {
-			return h.fail(i, op, err)
-		}
-		h.addKey(op.K)
-		committed = true
-	case OpDel:
-		h.Seq++
-		if _, err := applyDel(ctx, h.My, h.Ref, op, seq, PhasePrepared, logPhase, h.crash); err != nil {
-			return h.fail(i, op, err)
-		}
-		h.delKey(op.K)
-		committed = true
-	case OpGet:
-		mv, mok, me := h.My.Get(ctx, op.K, op.SnapSeq)
-		if me != nil {
-			return h.fail(i, op, me)
-		}
-		if err := logPhase(PhaseMyDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-		if h.Ref != nil {
-			sv, sok, se := h.Ref.GetWithSeq(op.K, op.SnapSeq)
-			if se != nil {
-				return h.fail(i, op, se)
-			}
-			if mok != sok || !bytes.Equal(mv, sv) {
-				return h.mismatch(i, op, mv, mok, sv, sok)
-			}
-		}
-		if err := logPhase(PhaseRefDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-	case OpRange:
-		mres, me := h.My.Range(ctx, op.Lo, op.Hi, op.SnapSeq, op.Limit)
-		if me != nil {
-			return h.fail(i, op, me)
-		}
-		if err := logPhase(PhaseMyDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-		if h.Ref != nil {
-			sres, se := h.Ref.RangeWithSeq(op.Lo, op.Hi, op.SnapSeq, op.Limit)
-			if se != nil {
-				return h.fail(i, op, se)
-			}
-			if err := compareKVLists(mres, sres); err != nil {
-				return h.fail(i, op, err)
-			}
-		}
-		if err := logPhase(PhaseRefDone); err != nil {
-			return err
-		}
-		if h.crash != nil {
-			if err := h.crash(); err != nil {
-				return err
-			}
-		}
-	case OpSnap:
-		seqSnap := h.Seq
-		if _, err := applySnap(ctx, h.My, h.Ref, seqSnap, PhasePrepared, logPhase, h.crash); err != nil {
-			return h.fail(i, op, err)
-		}
-		h.Snapshots = append(h.Snapshots, seqSnap)
-		committed = true
-	}
-	if !committed {
-		if err := logPhase(PhaseCommitted); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -524,7 +212,7 @@ func (h *Harness) run(ctx context.Context, r *rand.Rand, cfg Cfg, n int) error {
 	h.Snapshots = append(h.Snapshots, h.Seq)
 	for i := 0; n < 0 || i < n; i++ {
 		op := h.genOp(r, cfg)
-		if err := h.Step(ctx, op); err != nil {
+		if err := h.Step(ctx, opFrom(op, "")); err != nil {
 			return err
 		}
 		if err := h.checkInvariants(ctx, r, cfg); err != nil {
@@ -567,10 +255,6 @@ func (h *Harness) RunForever(ctx context.Context, cfg Cfg) error { return h.Run(
 func (h *Harness) fail(i int, op Op, cause error) error {
 	_ = h.log.Sync()
 	return fmt.Errorf("fuzz fail at i=%d seq=%d kind=%d: %w", i, h.Seq, op.Kind, cause)
-}
-
-func (h *Harness) mismatch(i int, op Op, mv []byte, mok bool, sv []byte, sok bool) error {
-	return h.fail(i, op, fmt.Errorf("mismatch: my=(ok=%v, val=%q) ref=(ok=%v, val=%q)", mok, mv, sok, sv))
 }
 
 func compareKVLists(a, b []KV) error {
@@ -749,59 +433,38 @@ func Replay(ctx context.Context, my Engine, ref *SQLiteOracle, logPath string) (
 	}
 
 	finalize := func(entry logEntry) (uint64, error) {
-		logPhase := func(p Phase) error {
-			return write(logEntry{I: entry.I, Seq: entry.Seq, Op: entry.Op, Phase: p})
+		logger := phaseLoggerFunc(func(o Op, seq uint64, p Phase) error {
+			return write(logEntry{I: entry.I, Seq: seq, Op: o, Phase: p})
+		})
+		htemp := &Harness{My: my, Ref: ref, Seq: entry.Seq}
+		op := opFrom(entry.Op, entry.Phase)
+		committed, err := op.Apply(ctx, htemp, logger)
+		if err != nil {
+			return 0, err
 		}
-		switch entry.Op.Kind {
-		case OpPut:
-			return applyPut(ctx, my, ref, entry.Op, entry.Seq, entry.Phase, logPhase, nil)
-		case OpDel:
-			return applyDel(ctx, my, ref, entry.Op, entry.Seq, entry.Phase, logPhase, nil)
-		case OpSnap:
-			seq, err := applySnap(ctx, my, ref, entry.Seq, entry.Phase, logPhase, nil)
-			if err != nil {
-				return 0, err
-			}
-			// Replay doesn't retain snapshot handles, so release any
-			// snapshots created while finalizing the log entry.
+		if entry.Op.Kind == OpSnap {
 			switch entry.Phase {
 			case PhasePrepared:
-				if err := my.ReleaseSnapshot(ctx, seq); err != nil {
+				if err := my.ReleaseSnapshot(ctx, entry.Seq); err != nil {
 					return 0, err
 				}
 				if ref != nil {
-					if err := ref.ReleaseSnapshot(ctx, seq); err != nil {
+					if err := ref.ReleaseSnapshot(ctx, entry.Seq); err != nil {
 						return 0, err
 					}
 				}
 			case PhaseMyDone:
 				if ref != nil {
-					if err := ref.ReleaseSnapshot(ctx, seq); err != nil {
+					if err := ref.ReleaseSnapshot(ctx, entry.Seq); err != nil {
 						return 0, err
 					}
 				}
 			}
-			return seq, nil
-		default:
-			switch entry.Phase {
-			case PhasePrepared:
-				if err := logPhase(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseMyDone:
-				if err := logPhase(PhaseRefDone); err != nil {
-					return 0, err
-				}
-				if err := logPhase(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			case PhaseRefDone:
-				if err := logPhase(PhaseCommitted); err != nil {
-					return 0, err
-				}
-			}
-			return entry.Seq, nil
 		}
+		if committed {
+			return entry.Seq + 1, nil
+		}
+		return entry.Seq, nil
 	}
 	var finalSeq uint64
 	for _, e := range entries {

--- a/diffharness/harness_test.go
+++ b/diffharness/harness_test.go
@@ -26,10 +26,10 @@ func TestHarnessLogsAndSnapshots(t *testing.T) {
 	h.Snapshots = append(h.Snapshots, h.Seq)
 	t.Cleanup(func() { _ = h.Close(); _ = eng.Close() })
 
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("a"), V: []byte("b")}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("a"), V: []byte("b")}))
 	require.Equal(t, uint64(1), h.Seq)
 
-	require.NoError(t, h.Step(ctx, Op{Kind: OpSnap}))
+	require.NoError(t, h.Step(ctx, SnapOp{}))
 	require.Len(t, h.Snapshots, 2)
 	require.Equal(t, uint64(1), h.Snapshots[1])
 
@@ -105,10 +105,10 @@ func TestHistoricalReads(t *testing.T) {
 
 	ctx := context.Background()
 	h.Snapshots = append(h.Snapshots, h.Seq)
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v1")}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v1")}))
 	snap := h.Seq
-	require.NoError(t, h.Step(ctx, Op{Kind: OpSnap}))
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v2")}))
+	require.NoError(t, h.Step(ctx, SnapOp{}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v2")}))
 
 	v, ok, err := h.My.Get(ctx, []byte("k"), snap)
 	require.NoError(t, err)
@@ -139,14 +139,14 @@ func TestRangeHistoricalSnapshot(t *testing.T) {
 
 	ctx := context.Background()
 	h.Snapshots = append(h.Snapshots, h.Seq)
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("a"), V: []byte("1")}))
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("b"), V: []byte("2")}))
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("c"), V: []byte("3")}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("a"), V: []byte("1")}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("b"), V: []byte("2")}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("c"), V: []byte("3")}))
 	snap := h.Seq
-	require.NoError(t, h.Step(ctx, Op{Kind: OpSnap}))
+	require.NoError(t, h.Step(ctx, SnapOp{}))
 
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("b"), V: []byte("2'")}))
-	require.NoError(t, h.Step(ctx, Op{Kind: OpDel, K: []byte("c")}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("b"), V: []byte("2'")}))
+	require.NoError(t, h.Step(ctx, DelOp{K: []byte("c")}))
 
 	res, err := h.My.Range(ctx, []byte("a"), []byte("z"), snap, 10)
 	require.NoError(t, err)
@@ -222,9 +222,9 @@ func TestHarnessCrashAndTelemetryHooks(t *testing.T) {
 
 	ctx := context.Background()
 	h.Snapshots = append(h.Snapshots, h.Seq)
-	require.NoError(t, h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v")}))
+	require.NoError(t, h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v")}))
 	snap := h.Seq
-	require.NoError(t, h.Step(ctx, Op{Kind: OpSnap}))
+	require.NoError(t, h.Step(ctx, SnapOp{}))
 	require.NoError(t, h.crash())
 	v, ok, err := h.My.Get(ctx, []byte("k"), h.Seq)
 	require.NoError(t, err)
@@ -280,7 +280,7 @@ func TestReplayRecoversAfterCrash(t *testing.T) {
 		return nil
 	})
 
-	err = h.Step(ctx, Op{Kind: OpPut, K: []byte("k"), V: []byte("v")})
+	err = h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v")})
 	require.Error(t, err)
 	require.Equal(t, 2, calls)
 	_ = h.Close()

--- a/diffharness/op.go
+++ b/diffharness/op.go
@@ -1,0 +1,397 @@
+package diffharness
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+)
+
+// PhaseLogger records the phase transitions of an operation.
+type PhaseLogger interface {
+	Log(op Op, seq uint64, phase Phase) error
+}
+
+type phaseLoggerFunc func(op Op, seq uint64, phase Phase) error
+
+func (f phaseLoggerFunc) Log(op Op, seq uint64, phase Phase) error { return f(op, seq, phase) }
+
+// Operation defines a harness action.
+type Operation interface {
+	Apply(ctx context.Context, h *Harness, log PhaseLogger) (committed bool, err error)
+}
+
+// MismatchError reports a divergence between engines.
+type MismatchError struct {
+	Op    Op
+	MyV   []byte
+	MyOK  bool
+	RefV  []byte
+	RefOK bool
+}
+
+func (m *MismatchError) Error() string {
+	return fmt.Sprintf("mismatch: my=(ok=%v, val=%q) ref=(ok=%v, val=%q)", m.MyOK, m.MyV, m.RefOK, m.RefV)
+}
+
+func wrapErr(op Op, phase Phase, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("op %v phase %s: %w", op.Kind, phase, err)
+}
+
+// PutOp inserts or replaces a key/value pair.
+type PutOp struct {
+	K, V  []byte
+	start Phase
+}
+
+func (p PutOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+	op := Op{Kind: OpPut, K: p.K, V: p.V}
+	if p.start == "" {
+		if err := log.Log(op, h.Seq, PhasePrepared); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		p.start = PhasePrepared
+	}
+	switch p.start {
+	case PhasePrepared:
+		if err := h.My.Begin(ctx); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if err := h.My.Put(ctx, p.K, p.V); err != nil {
+			_ = h.My.Rollback(ctx)
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if err := h.My.Commit(ctx); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if err := log.Log(op, h.Seq, PhaseMyDone); err != nil {
+			return false, wrapErr(op, PhaseMyDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if h.Ref != nil {
+			if err := h.Ref.Begin(ctx); err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+			if err := h.Ref.PutWithSeq(p.K, p.V, h.Seq+1); err != nil {
+				_ = h.Ref.Rollback(ctx)
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+			if err := h.Ref.Commit(ctx); err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+		}
+		if err := log.Log(op, h.Seq, PhaseRefDone); err != nil {
+			return false, wrapErr(op, PhaseRefDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log.Log(op, h.Seq, PhaseCommitted); err != nil {
+			return false, wrapErr(op, PhaseCommitted, err)
+		}
+		h.addKey(p.K)
+		return true, nil
+	default:
+		return true, nil
+	}
+}
+
+// DelOp deletes a key.
+type DelOp struct {
+	K     []byte
+	start Phase
+}
+
+func (d DelOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+	op := Op{Kind: OpDel, K: d.K}
+	if d.start == "" {
+		if err := log.Log(op, h.Seq, PhasePrepared); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		d.start = PhasePrepared
+	}
+	switch d.start {
+	case PhasePrepared:
+		if err := h.My.Begin(ctx); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if err := h.My.Delete(ctx, d.K); err != nil {
+			_ = h.My.Rollback(ctx)
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if err := h.My.Commit(ctx); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if err := log.Log(op, h.Seq, PhaseMyDone); err != nil {
+			return false, wrapErr(op, PhaseMyDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if h.Ref != nil {
+			if err := h.Ref.Begin(ctx); err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+			if err := h.Ref.DelWithSeq(d.K, h.Seq+1); err != nil {
+				_ = h.Ref.Rollback(ctx)
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+			if err := h.Ref.Commit(ctx); err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+		}
+		if err := log.Log(op, h.Seq, PhaseRefDone); err != nil {
+			return false, wrapErr(op, PhaseRefDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log.Log(op, h.Seq, PhaseCommitted); err != nil {
+			return false, wrapErr(op, PhaseCommitted, err)
+		}
+		h.delKey(d.K)
+		return true, nil
+	default:
+		return true, nil
+	}
+}
+
+// GetOp retrieves a single key at a snapshot.
+type GetOp struct {
+	K       []byte
+	SnapSeq uint64
+	start   Phase
+}
+
+func (g GetOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+	op := Op{Kind: OpGet, K: g.K, SnapSeq: g.SnapSeq}
+	if g.start == "" {
+		if err := log.Log(op, h.Seq, PhasePrepared); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		g.start = PhasePrepared
+	}
+	var mv []byte
+	var mok bool
+	switch g.start {
+	case PhasePrepared:
+		v, ok, err := h.My.Get(ctx, g.K, g.SnapSeq)
+		if err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		mv, mok = v, ok
+		if err := log.Log(op, h.Seq, PhaseMyDone); err != nil {
+			return false, wrapErr(op, PhaseMyDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if h.Ref != nil {
+			sv, sok, err := h.Ref.GetWithSeq(g.K, g.SnapSeq)
+			if err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+			if mok != sok || !bytes.Equal(mv, sv) {
+				return false, &MismatchError{Op: op, MyV: mv, MyOK: mok, RefV: sv, RefOK: sok}
+			}
+		}
+		if err := log.Log(op, h.Seq, PhaseRefDone); err != nil {
+			return false, wrapErr(op, PhaseRefDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log.Log(op, h.Seq, PhaseCommitted); err != nil {
+			return false, wrapErr(op, PhaseCommitted, err)
+		}
+	}
+	return false, nil
+}
+
+// RangeOp scans keys in a range.
+type RangeOp struct {
+	Lo, Hi  []byte
+	SnapSeq uint64
+	Limit   int
+	start   Phase
+}
+
+func (r RangeOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+	op := Op{Kind: OpRange, Lo: r.Lo, Hi: r.Hi, SnapSeq: r.SnapSeq, Limit: r.Limit}
+	if r.start == "" {
+		if err := log.Log(op, h.Seq, PhasePrepared); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		r.start = PhasePrepared
+	}
+	var mres []KV
+	switch r.start {
+	case PhasePrepared:
+		res, err := h.My.Range(ctx, r.Lo, r.Hi, r.SnapSeq, r.Limit)
+		if err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		mres = res
+		if err := log.Log(op, h.Seq, PhaseMyDone); err != nil {
+			return false, wrapErr(op, PhaseMyDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if h.Ref != nil {
+			sres, err := h.Ref.RangeWithSeq(r.Lo, r.Hi, r.SnapSeq, r.Limit)
+			if err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+			if err := compareKVLists(mres, sres); err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+		}
+		if err := log.Log(op, h.Seq, PhaseRefDone); err != nil {
+			return false, wrapErr(op, PhaseRefDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log.Log(op, h.Seq, PhaseCommitted); err != nil {
+			return false, wrapErr(op, PhaseCommitted, err)
+		}
+	}
+	return false, nil
+}
+
+// SnapOp creates snapshots in both engines.
+type SnapOp struct{ start Phase }
+
+func (s SnapOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, error) {
+	op := Op{Kind: OpSnap}
+	if s.start == "" {
+		if err := log.Log(op, h.Seq, PhasePrepared); err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		s.start = PhasePrepared
+	}
+	switch s.start {
+	case PhasePrepared:
+		seq, err := h.My.NewSnapshot(ctx)
+		if err != nil {
+			return false, wrapErr(op, PhasePrepared, err)
+		}
+		if seq != h.Seq {
+			return false, wrapErr(op, PhasePrepared, fmt.Errorf("snapshot sequence mismatch: my=%d have=%d", h.Seq, seq))
+		}
+		if err := log.Log(op, h.Seq, PhaseMyDone); err != nil {
+			return false, wrapErr(op, PhaseMyDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseMyDone:
+		if h.Ref != nil {
+			refSeq, err := h.Ref.NewSnapshot(ctx)
+			if err != nil {
+				return false, wrapErr(op, PhaseMyDone, err)
+			}
+			if refSeq != h.Seq {
+				return false, wrapErr(op, PhaseMyDone, fmt.Errorf("snapshot sequence mismatch: my=%d ref=%d", h.Seq, refSeq))
+			}
+		}
+		if err := log.Log(op, h.Seq, PhaseRefDone); err != nil {
+			return false, wrapErr(op, PhaseRefDone, err)
+		}
+		if h.crash != nil {
+			if err := h.crash(); err != nil {
+				return false, err
+			}
+		}
+		fallthrough
+	case PhaseRefDone:
+		if err := log.Log(op, h.Seq, PhaseCommitted); err != nil {
+			return false, wrapErr(op, PhaseCommitted, err)
+		}
+		h.Snapshots = append(h.Snapshots, h.Seq)
+	}
+	return false, nil
+}
+
+// opFrom constructs an Operation from an Op and a starting phase.
+func opFrom(o Op, start Phase) Operation {
+	switch o.Kind {
+	case OpPut:
+		return PutOp{K: o.K, V: o.V, start: start}
+	case OpDel:
+		return DelOp{K: o.K, start: start}
+	case OpGet:
+		return GetOp{K: o.K, SnapSeq: o.SnapSeq, start: start}
+	case OpRange:
+		return RangeOp{Lo: o.Lo, Hi: o.Hi, SnapSeq: o.SnapSeq, Limit: o.Limit, start: start}
+	case OpSnap:
+		return SnapOp{start: start}
+	default:
+		panic(fmt.Sprintf("unhandled op kind: %v", o.Kind))
+	}
+}

--- a/diffharness/op_test.go
+++ b/diffharness/op_test.go
@@ -1,0 +1,77 @@
+package diffharness
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dummyEngine struct {
+	putErr error
+}
+
+func (d dummyEngine) Begin(context.Context) error               { return nil }
+func (d dummyEngine) Commit(context.Context) error              { return nil }
+func (d dummyEngine) Rollback(context.Context) error            { return nil }
+func (d dummyEngine) Put(context.Context, []byte, []byte) error { return d.putErr }
+func (d dummyEngine) Delete(context.Context, []byte) error      { return nil }
+func (d dummyEngine) Get(context.Context, []byte, uint64) ([]byte, bool, error) {
+	return nil, false, nil
+}
+func (d dummyEngine) Range(context.Context, []byte, []byte, uint64, int) ([]KV, error) {
+	return nil, nil
+}
+func (d dummyEngine) NewSnapshot(context.Context) (uint64, error)   { return 0, nil }
+func (d dummyEngine) ReleaseSnapshot(context.Context, uint64) error { return nil }
+func (d dummyEngine) Close() error                                  { return nil }
+
+func TestPutOpLoggingAndError(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name       string
+		eng        dummyEngine
+		wantErr    bool
+		wantPhases []Phase
+	}{
+		{"ok", dummyEngine{}, false, []Phase{PhasePrepared, PhaseMyDone, PhaseRefDone, PhaseCommitted}},
+		{"put-fail", dummyEngine{putErr: errors.New("boom")}, true, []Phase{PhasePrepared}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &Harness{My: tc.eng}
+			var phases []Phase
+			logger := phaseLoggerFunc(func(o Op, seq uint64, p Phase) error {
+				phases = append(phases, p)
+				return nil
+			})
+			op := PutOp{K: []byte("k"), V: []byte("v")}
+			_, err := op.Apply(ctx, h, logger)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.wantPhases, phases)
+		})
+	}
+}
+
+func TestGetOpMismatch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	ref, err := OpenSQLiteOracle(filepath.Join(dir, "ref.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ref.Close() })
+	require.NoError(t, ref.Begin(ctx))
+	require.NoError(t, ref.PutWithSeq([]byte("k"), []byte("v"), 1))
+	require.NoError(t, ref.Commit(ctx))
+	h := &Harness{My: dummyEngine{}, Ref: ref}
+	logger := phaseLoggerFunc(func(o Op, seq uint64, p Phase) error { return nil })
+	g := GetOp{K: []byte("k"), SnapSeq: 1}
+	_, err = g.Apply(ctx, h, logger)
+	var mm *MismatchError
+	require.ErrorAs(t, err, &mm)
+}

--- a/diffharness/types.go
+++ b/diffharness/types.go
@@ -1,0 +1,72 @@
+package diffharness
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// OpKind enumerates supported operation types.
+type OpKind uint8
+
+const (
+	OpPut OpKind = iota
+	OpDel
+	OpGet
+	OpRange
+	OpSnap
+)
+
+const OpInvariantCheck OpKind = 255
+
+// Op models a single diffharness operation.
+type Op struct {
+	Kind    OpKind
+	K       []byte
+	V       []byte
+	Lo      []byte
+	Hi      []byte
+	SnapSeq uint64
+	Limit   int
+}
+
+type Phase string
+
+const (
+	PhasePrepared  Phase = "prepared"
+	PhaseMyDone    Phase = "my_done"
+	PhaseRefDone   Phase = "ref_done"
+	PhaseCommitted Phase = "committed"
+)
+
+// Harness coordinates both engines and records every executed operation.
+type Harness struct {
+	Seed int64
+
+	My  Engine
+	Ref *SQLiteOracle
+
+	Seq       uint64
+	Snapshots []uint64
+
+	keys   []string
+	keySet map[string]struct{}
+
+	log *os.File
+	enc *json.Encoder
+	ops int
+
+	crash     func() error
+	telemetry func(seq uint64, ops int)
+}
+
+// Cfg controls random operation generation.
+type Cfg struct {
+	KeyLen    int
+	ValLenMin int
+	ValLenMax int
+	RangeMax  int
+	Weights   map[OpKind]int
+
+	CrashEvery     int
+	TelemetryEvery int
+}


### PR DESCRIPTION
## Summary
- introduce Operation interface with concrete handlers for diffharness ops
- refactor Harness.Step and log replay to use unified Operation API
- add focused tests covering operation logging and mismatch errors

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c607c8b7dc8325b44287523c682530