### PR TITLE
docs: define test naming and template, reference in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 
 ## Testing Guidelines
 - Frameworks: Standard `testing` with `testify` for assertions.
-- Naming: Top‑level tests follow `Test<Subject>_<Behavior>`; integration tests in `integration/` use the same pattern.
+- Naming: Top‑level tests follow `Test<Subject>_<Behavior>`; integration tests in `integration/` use the same pattern. See `docs/dev/00/testing_convention/test_naming_and_template.md` for examples and the table-driven template.
 - Structure: When covering multiple cases, use table‑driven tests with `t.Run(tt.name, ...)`; subtest names should be descriptive and human‑readable.
 - Data: Write temp files under `testdata/`. Tests clean this directory; do not commit generated artifacts.
 - Integration tests live in `integration/` and use build tags. Run quick tests with `make test-integration-smoke` and the full suite with `make test-integration-full`.

--- a/docs/dev/00/testing_convention/test_naming_and_template.md
+++ b/docs/dev/00/testing_convention/test_naming_and_template.md
@@ -1,0 +1,44 @@
+# Test Naming and Table-Driven Template
+
+This document defines the naming pattern and table-driven structure used across unit and integration tests.
+
+## Naming Format
+Tests follow the `Test<Subject>_<Behavior>` format. Subtests describe scenarios in natural language.
+
+```go
+// Unit test example
+func TestMemtable_Get(t *testing.T) {
+    t.Run("found", func(t *testing.T) {
+        // ...
+    })
+}
+
+// Integration test example
+//go:build integration
+func TestCompaction_PreservesTombstone(t *testing.T) {
+    // ...
+}
+```
+
+## Table-Driven Template
+When a test covers multiple cases, structure it using a table of test cases and `t.Run` for subtests.
+
+```go
+func TestRecord_Encode(t *testing.T) {
+    tests := []struct {
+        name string
+        rec  Record
+        want []byte
+    }{
+        {"value record", newRecord(Bytes("k"), Bytes("v"), 1), []byte{0x01}},
+        {"tombstone", newDeletion(Bytes("k"), 2), []byte{0x00}},
+    }
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T) {
+            got := Encode(tt.rec)
+            assert.Equal(t, tt.want, got)
+        })
+    }
+}
+```


### PR DESCRIPTION
## Summary
- document `Test<Subject>_<Behavior>` naming pattern
- add standard table-driven test template
- reference the new testing convention doc from AGENTS guidelines

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c6076af0c083259d089f553528cc3c