### PR TITLE
refactor: isolate diffharness randomness

### DIFF
--- a/diffharness/generator.go
+++ b/diffharness/generator.go
@@ -3,6 +3,7 @@ package diffharness
 import (
 	"bytes"
 	"math/rand"
+	"sort"
 )
 
 const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -42,7 +43,9 @@ func (kt *KeyTracker) Add(k []byte) {
 	}
 	if len(kt.keys) >= maxKnownKeys {
 		oldest := kt.keys[0]
-		kt.keys = kt.keys[1:]
+		copy(kt.keys, kt.keys[1:])
+		kt.keys[len(kt.keys)-1] = ""
+		kt.keys = kt.keys[:len(kt.keys)-1]
 		delete(kt.keySet, oldest)
 	}
 	kt.keys = append(kt.keys, s)
@@ -60,7 +63,9 @@ func (kt *KeyTracker) Del(k []byte) {
 	delete(kt.keySet, s)
 	for i, v := range kt.keys {
 		if v == s {
-			kt.keys = append(kt.keys[:i], kt.keys[i+1:]...)
+			copy(kt.keys[i:], kt.keys[i+1:])
+			kt.keys[len(kt.keys)-1] = ""
+			kt.keys = kt.keys[:len(kt.keys)-1]
 			break
 		}
 	}
@@ -94,12 +99,16 @@ func pickSnapshot(r *rand.Rand, seq uint64, snaps []uint64) uint64 {
 
 func (ro RandOps) Next(r *rand.Rand, kt *KeyTracker, seq uint64, snaps []uint64) Operation {
 	sum := 0
-	for _, w := range ro.cfg.Weights {
+	var kinds []OpKind
+	for op, w := range ro.cfg.Weights {
 		sum += w
+		kinds = append(kinds, op)
 	}
+	sort.Slice(kinds, func(i, j int) bool { return kinds[i] < kinds[j] })
 	x := r.Intn(sum)
 	var kind OpKind
-	for op, w := range ro.cfg.Weights {
+	for _, op := range kinds {
+		w := ro.cfg.Weights[op]
 		if x < w {
 			kind = op
 			break

--- a/diffharness/generator.go
+++ b/diffharness/generator.go
@@ -1,0 +1,134 @@
+package diffharness
+
+import (
+	"bytes"
+	"math/rand"
+)
+
+const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func randPrefixedBytes(r *rand.Rand, n int, prefix, suffix string) []byte {
+	minLen := len(prefix) + len(suffix)
+	if n < minLen {
+		n = minLen
+	}
+	b := make([]byte, n)
+	copy(b, prefix)
+	for i := len(prefix); i < n-len(suffix); i++ {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	copy(b[n-len(suffix):], suffix)
+	return b
+}
+
+func randKey(r *rand.Rand, n int) []byte { return randPrefixedBytes(r, n, "sk", "ek") }
+
+func randValue(r *rand.Rand, n int) []byte { return randPrefixedBytes(r, n, "sv", "ev") }
+
+const maxKnownKeys = 100
+
+type KeyTracker struct {
+	keys   []string
+	keySet map[string]struct{}
+}
+
+func (kt *KeyTracker) Add(k []byte) {
+	if kt.keySet == nil {
+		kt.keySet = make(map[string]struct{})
+	}
+	s := string(k)
+	if _, ok := kt.keySet[s]; ok {
+		return
+	}
+	if len(kt.keys) >= maxKnownKeys {
+		oldest := kt.keys[0]
+		kt.keys = kt.keys[1:]
+		delete(kt.keySet, oldest)
+	}
+	kt.keys = append(kt.keys, s)
+	kt.keySet[s] = struct{}{}
+}
+
+func (kt *KeyTracker) Del(k []byte) {
+	if kt.keySet == nil {
+		return
+	}
+	s := string(k)
+	if _, ok := kt.keySet[s]; !ok {
+		return
+	}
+	delete(kt.keySet, s)
+	for i, v := range kt.keys {
+		if v == s {
+			kt.keys = append(kt.keys[:i], kt.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+func (kt *KeyTracker) Random(r *rand.Rand) []byte {
+	if len(kt.keys) == 0 {
+		return nil
+	}
+	return []byte(kt.keys[r.Intn(len(kt.keys))])
+}
+
+type RandOps struct{ cfg Cfg }
+
+func (ro RandOps) genKey(r *rand.Rand, kt *KeyTracker) []byte {
+	k := randKey(r, ro.cfg.KeyLen)
+	if kt != nil {
+		if ex := kt.Random(r); ex != nil && r.Intn(2) == 0 {
+			k = ex
+		}
+	}
+	return k
+}
+
+func pickSnapshot(r *rand.Rand, seq uint64, snaps []uint64) uint64 {
+	if len(snaps) == 0 || r.Intn(10) == 0 {
+		return seq
+	}
+	return snaps[r.Intn(len(snaps))]
+}
+
+func (ro RandOps) Next(r *rand.Rand, kt *KeyTracker, seq uint64, snaps []uint64) Operation {
+	sum := 0
+	for _, w := range ro.cfg.Weights {
+		sum += w
+	}
+	x := r.Intn(sum)
+	var kind OpKind
+	for op, w := range ro.cfg.Weights {
+		if x < w {
+			kind = op
+			break
+		}
+		x -= w
+	}
+	switch kind {
+	case OpPut:
+		vlen := ro.cfg.ValLenMin + r.Intn(ro.cfg.ValLenMax-ro.cfg.ValLenMin+1)
+		key := ro.genKey(r, kt)
+		return PutOp{K: key, V: randValue(r, vlen)}
+	case OpDel:
+		key := ro.genKey(r, kt)
+		return DelOp{K: key}
+	case OpGet:
+		key := ro.genKey(r, kt)
+		s := pickSnapshot(r, seq, snaps)
+		return GetOp{K: key, SnapSeq: s}
+	case OpRange:
+		lo := randKey(r, ro.cfg.KeyLen)
+		hi := randKey(r, ro.cfg.KeyLen)
+		for bytes.Compare(hi, lo) <= 0 {
+			hi = randKey(r, ro.cfg.KeyLen)
+		}
+		s := pickSnapshot(r, seq, snaps)
+		return RangeOp{Lo: lo, Hi: hi, SnapSeq: s, Limit: ro.cfg.RangeMax}
+	case OpSnap:
+		return SnapOp{}
+	default:
+		panic("unknown op kind")
+	}
+}

--- a/diffharness/harness.go
+++ b/diffharness/harness.go
@@ -26,128 +26,7 @@ func (h *Harness) Close() error {
 	return h.log.Close()
 }
 
-const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-func randPrefixedBytes(r *rand.Rand, n int, prefix, suffix string) []byte {
-	minLen := len(prefix) + len(suffix)
-	if n < minLen {
-		n = minLen
-	}
-	b := make([]byte, n)
-	copy(b, prefix)
-	for i := len(prefix); i < n-len(suffix); i++ {
-		b[i] = letters[r.Intn(len(letters))]
-	}
-	copy(b[n-len(suffix):], suffix)
-	return b
-}
-
-func randKey(r *rand.Rand, n int) []byte {
-	return randPrefixedBytes(r, n, "sk", "ek")
-}
-
-func randValue(r *rand.Rand, n int) []byte {
-	return randPrefixedBytes(r, n, "sv", "ev")
-}
-
-const maxKnownKeys = 100
-
-func (h *Harness) addKey(k []byte) {
-	if h.keySet == nil {
-		h.keySet = make(map[string]struct{})
-	}
-	s := string(k)
-	if _, ok := h.keySet[s]; ok {
-		return
-	}
-	if len(h.keys) >= maxKnownKeys {
-		oldest := h.keys[0]
-		h.keys = h.keys[1:]
-		delete(h.keySet, oldest)
-	}
-	h.keys = append(h.keys, s)
-	h.keySet[s] = struct{}{}
-}
-
-func (h *Harness) delKey(k []byte) {
-	if h.keySet == nil {
-		return
-	}
-	s := string(k)
-	if _, ok := h.keySet[s]; !ok {
-		return
-	}
-	delete(h.keySet, s)
-	for i, v := range h.keys {
-		if v == s {
-			h.keys = append(h.keys[:i], h.keys[i+1:]...)
-			break
-		}
-	}
-}
-
-func (h *Harness) pickKnownKey(r *rand.Rand) []byte {
-	if len(h.keys) == 0 {
-		return nil
-	}
-	return []byte(h.keys[r.Intn(len(h.keys))])
-}
-
-func (h *Harness) genKey(r *rand.Rand, n int) []byte {
-	k := randKey(r, n)
-	if ex := h.pickKnownKey(r); ex != nil && r.Intn(2) == 0 {
-		k = ex
-	}
-	return k
-}
-
-func (h *Harness) genOp(r *rand.Rand, cfg Cfg) Op {
-	sum := 0
-	for _, w := range cfg.Weights {
-		sum += w
-	}
-	x := r.Intn(sum)
-	var kind OpKind
-	for op, w := range cfg.Weights {
-		if x < w {
-			kind = op
-			break
-		}
-		x -= w
-	}
-	switch kind {
-	case OpPut:
-		vlen := cfg.ValLenMin + r.Intn(cfg.ValLenMax-cfg.ValLenMin+1)
-		key := h.genKey(r, cfg.KeyLen)
-		return Op{Kind: OpPut, K: key, V: randValue(r, vlen)}
-	case OpDel:
-		key := h.genKey(r, cfg.KeyLen)
-		return Op{Kind: OpDel, K: key}
-	case OpGet:
-		key := h.genKey(r, cfg.KeyLen)
-		s := h.pickSnapshot(r)
-		return Op{Kind: OpGet, K: key, SnapSeq: s}
-	case OpRange:
-		lo := randKey(r, cfg.KeyLen)
-		hi := randKey(r, cfg.KeyLen)
-		for bytes.Compare(hi, lo) <= 0 {
-			hi = randKey(r, cfg.KeyLen)
-		}
-		s := h.pickSnapshot(r)
-		return Op{Kind: OpRange, Lo: lo, Hi: hi, SnapSeq: s, Limit: cfg.RangeMax}
-	case OpSnap:
-		return Op{Kind: OpSnap}
-	default:
-		panic("unknown op kind")
-	}
-}
-
-func (h *Harness) pickSnapshot(r *rand.Rand) uint64 {
-	if len(h.Snapshots) == 0 || r.Intn(10) == 0 {
-		return h.Seq
-	}
-	return h.Snapshots[r.Intn(len(h.Snapshots))]
-}
+// randomness helpers moved to generator.go
 
 // SetCrashHook registers a callback invoked after CrashEvery operations.
 // The callback should close and reopen both engines to simulate recovery.
@@ -158,7 +37,7 @@ func (h *Harness) SetCrashHook(fn func() error) { h.crash = fn }
 func (h *Harness) SetTelemetryHook(fn func(seq uint64, ops int)) { h.telemetry = fn }
 
 // Step applies a single operation, logging it before execution.
-func (h *Harness) Step(ctx context.Context, op Operation) error {
+func (h *Harness) Step(ctx context.Context, op Operation) (bool, error) {
 	i := h.ops
 	logger := phaseLoggerFunc(func(o Op, seq uint64, p Phase) error {
 		if err := h.enc.Encode(struct {
@@ -173,13 +52,13 @@ func (h *Harness) Step(ctx context.Context, op Operation) error {
 	})
 	committed, err := op.Apply(ctx, h, logger)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if committed {
 		h.Seq++
 	}
 	h.ops++
-	return nil
+	return committed, nil
 }
 
 func (h *Harness) releaseSnapshots(ctx context.Context, logErrors bool) error {
@@ -210,10 +89,21 @@ func (h *Harness) releaseSnapshots(ctx context.Context, logErrors bool) error {
 
 func (h *Harness) run(ctx context.Context, r *rand.Rand, cfg Cfg, n int) error {
 	h.Snapshots = append(h.Snapshots, h.Seq)
+	kt := KeyTracker{}
+	ro := RandOps{cfg: cfg}
 	for i := 0; n < 0 || i < n; i++ {
-		op := h.genOp(r, cfg)
-		if err := h.Step(ctx, opFrom(op, "")); err != nil {
+		op := ro.Next(r, &kt, h.Seq, h.Snapshots)
+		committed, err := h.Step(ctx, op)
+		if err != nil {
 			return err
+		}
+		if committed {
+			switch t := op.(type) {
+			case PutOp:
+				kt.Add(t.K)
+			case DelOp:
+				kt.Del(t.K)
+			}
 		}
 		if err := h.checkInvariants(ctx, r, cfg); err != nil {
 			return h.fail(h.ops, Op{Kind: OpInvariantCheck}, err)
@@ -319,7 +209,7 @@ func (h *Harness) checkInvariants(ctx context.Context, r *rand.Rand, cfg Cfg) er
 		for bytes.Compare(mid, lo) <= 0 || bytes.Compare(mid, hi) >= 0 {
 			mid = randKey(r, cfg.KeyLen)
 		}
-		snap := h.pickSnapshot(r)
+		snap := pickSnapshot(r, h.Seq, h.Snapshots)
 		left, err := h.My.Range(ctx, lo, mid, snap, cfg.RangeMax)
 		if err != nil {
 			return err

--- a/diffharness/harness_test.go
+++ b/diffharness/harness_test.go
@@ -26,10 +26,12 @@ func TestHarnessLogsAndSnapshots(t *testing.T) {
 	h.Snapshots = append(h.Snapshots, h.Seq)
 	t.Cleanup(func() { _ = h.Close(); _ = eng.Close() })
 
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("a"), V: []byte("b")}))
+	_, err = h.Step(ctx, PutOp{K: []byte("a"), V: []byte("b")})
+	require.NoError(t, err)
 	require.Equal(t, uint64(1), h.Seq)
 
-	require.NoError(t, h.Step(ctx, SnapOp{}))
+	_, err = h.Step(ctx, SnapOp{})
+	require.NoError(t, err)
 	require.Len(t, h.Snapshots, 2)
 	require.Equal(t, uint64(1), h.Snapshots[1])
 
@@ -105,10 +107,13 @@ func TestHistoricalReads(t *testing.T) {
 
 	ctx := context.Background()
 	h.Snapshots = append(h.Snapshots, h.Seq)
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v1")}))
+	_, err = h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v1")})
+	require.NoError(t, err)
 	snap := h.Seq
-	require.NoError(t, h.Step(ctx, SnapOp{}))
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v2")}))
+	_, err = h.Step(ctx, SnapOp{})
+	require.NoError(t, err)
+	_, err = h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v2")})
+	require.NoError(t, err)
 
 	v, ok, err := h.My.Get(ctx, []byte("k"), snap)
 	require.NoError(t, err)
@@ -139,14 +144,20 @@ func TestRangeHistoricalSnapshot(t *testing.T) {
 
 	ctx := context.Background()
 	h.Snapshots = append(h.Snapshots, h.Seq)
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("a"), V: []byte("1")}))
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("b"), V: []byte("2")}))
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("c"), V: []byte("3")}))
+	_, err = h.Step(ctx, PutOp{K: []byte("a"), V: []byte("1")})
+	require.NoError(t, err)
+	_, err = h.Step(ctx, PutOp{K: []byte("b"), V: []byte("2")})
+	require.NoError(t, err)
+	_, err = h.Step(ctx, PutOp{K: []byte("c"), V: []byte("3")})
+	require.NoError(t, err)
 	snap := h.Seq
-	require.NoError(t, h.Step(ctx, SnapOp{}))
+	_, err = h.Step(ctx, SnapOp{})
+	require.NoError(t, err)
 
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("b"), V: []byte("2'")}))
-	require.NoError(t, h.Step(ctx, DelOp{K: []byte("c")}))
+	_, err = h.Step(ctx, PutOp{K: []byte("b"), V: []byte("2'")})
+	require.NoError(t, err)
+	_, err = h.Step(ctx, DelOp{K: []byte("c")})
+	require.NoError(t, err)
 
 	res, err := h.My.Range(ctx, []byte("a"), []byte("z"), snap, 10)
 	require.NoError(t, err)
@@ -222,9 +233,11 @@ func TestHarnessCrashAndTelemetryHooks(t *testing.T) {
 
 	ctx := context.Background()
 	h.Snapshots = append(h.Snapshots, h.Seq)
-	require.NoError(t, h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v")}))
+	_, err = h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v")})
+	require.NoError(t, err)
 	snap := h.Seq
-	require.NoError(t, h.Step(ctx, SnapOp{}))
+	_, err = h.Step(ctx, SnapOp{})
+	require.NoError(t, err)
 	require.NoError(t, h.crash())
 	v, ok, err := h.My.Get(ctx, []byte("k"), h.Seq)
 	require.NoError(t, err)
@@ -280,7 +293,7 @@ func TestReplayRecoversAfterCrash(t *testing.T) {
 		return nil
 	})
 
-	err = h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v")})
+	_, err = h.Step(ctx, PutOp{K: []byte("k"), V: []byte("v")})
 	require.Error(t, err)
 	require.Equal(t, 2, calls)
 	_ = h.Close()

--- a/diffharness/op.go
+++ b/diffharness/op.go
@@ -106,7 +106,6 @@ func (p PutOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, er
 		if err := log.Log(op, h.Seq, PhaseCommitted); err != nil {
 			return false, wrapErr(op, PhaseCommitted, err)
 		}
-		h.addKey(p.K)
 		return true, nil
 	default:
 		return false, nil
@@ -179,7 +178,6 @@ func (d DelOp) Apply(ctx context.Context, h *Harness, log PhaseLogger) (bool, er
 		if err := log.Log(op, h.Seq, PhaseCommitted); err != nil {
 			return false, wrapErr(op, PhaseCommitted, err)
 		}
-		h.delKey(d.K)
 		return true, nil
 	default:
 		return false, nil

--- a/diffharness/types.go
+++ b/diffharness/types.go
@@ -48,9 +48,6 @@ type Harness struct {
 	Seq       uint64
 	Snapshots []uint64
 
-	keys   []string
-	keySet map[string]struct{}
-
 	log *os.File
 	enc *json.Encoder
 	ops int


### PR DESCRIPTION
## Summary
- add generator with KeyTracker and RandOps for fuzzing
- move random op selection and key tracking out of Harness

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c61597cce88325935a858075fb3043