### PR TITLE
test: refactor record tests to table-driven

### DIFF
--- a/io_test.go
+++ b/io_test.go
@@ -67,6 +67,7 @@ func TestRecord_WriteRead(t *testing.T) {
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tx, cleanup := newFileTx(t)
 			defer cleanup()
 			path := tx.log.Path()
@@ -176,6 +177,7 @@ func TestReadRecord_Errors(t *testing.T) {
 	for _, tt := range cases {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			r := tt.setup()
 			_, err := readRecord(r)
 			for _, msg := range tt.errContains {

--- a/io_test.go
+++ b/io_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/iotest"
 
@@ -42,153 +43,149 @@ func writeNumberBuf(buf *bytes.Buffer, n uint64) {
 	buf.Write(b[:])
 }
 
-func Test_rw(t *testing.T) {
-	t.Run("Write key with size = 0", func(t *testing.T) {
-		tx, cleanup := newFileTx(t)
-		defer cleanup()
-		path := tx.log.Path()
-		testKey := Bytes(nil)
-		testValue := Bytes("value")
-
-		err := writeRecord(tx, newRecord(testKey, testValue, 0))
-		assert.NoError(t, err)
-
-		data, err := os.ReadFile(path)
-		assert.NoError(t, err)
-		record, err := readRecord(bytes.NewReader(data))
-		assert.NoError(t, err)
-		assert.Equal(t, Bytes(nil), record.GetKey())
-		assert.Equal(t, testValue, record.GetValue())
-	})
-
-	t.Run("Write key and value with size = 0", func(t *testing.T) {
-		tx, cleanup := newFileTx(t)
-		defer cleanup()
-		path := tx.log.Path()
-		testKey := Bytes(nil)
-		testValue := Bytes(nil)
-
-		err := writeRecord(tx, newRecord(testKey, testValue, 0))
-		assert.NoError(t, err)
-
-		data, err := os.ReadFile(path)
-		assert.NoError(t, err)
-		record, err := readRecord(bytes.NewReader(data))
-		assert.NoError(t, err)
-		assert.Equal(t, testKey, record.GetKey())
-		assert.Equal(t, testValue, record.GetValue())
-	})
-
-	t.Run("Write key and value with size > 255", func(t *testing.T) {
-		tx, cleanup := newFileTx(t)
-		defer cleanup()
-		path := tx.log.Path()
-		testKey := ""
-		testValue := ""
+func TestRecord_WriteRead(t *testing.T) {
+	largeKey, largeValue := func() (Bytes, Bytes) {
+		var k strings.Builder
+		var v strings.Builder
 		for i := 0; i < 500; i++ {
-			testKey += fmt.Sprintf("test key %d ", i)
-			testValue += fmt.Sprintf("test value %d ", i)
+			fmt.Fprintf(&k, "test key %d ", i)
+			fmt.Fprintf(&v, "test value %d ", i)
 		}
+		return Bytes(k.String()), Bytes(v.String())
+	}()
 
-		err := writeRecord(tx, newRecord(Bytes(testKey), Bytes(testValue), 0))
-		assert.NoError(t, err)
+	cases := []struct {
+		name       string
+		key, value Bytes
+	}{
+		{"Write key with size = 0", nil, Bytes("value")},
+		{"Write key and value with size = 0", nil, nil},
+		{"Write key and value with size > 255", largeKey, largeValue},
+		{"Write key and value with size < 255", Bytes("key"), Bytes("value")},
+	}
 
-		data, err := os.ReadFile(path)
-		assert.NoError(t, err)
-		record, err := readRecord(bytes.NewReader(data))
-		assert.NoError(t, err)
-		assert.Equal(t, testKey, string(record.GetKey()))
-		assert.Equal(t, testValue, string(record.GetValue()))
-	})
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tx, cleanup := newFileTx(t)
+			defer cleanup()
+			path := tx.log.Path()
 
-	t.Run("Write key and value with size < 255", func(t *testing.T) {
-		tx, cleanup := newFileTx(t)
-		defer cleanup()
-		path := tx.log.Path()
-		err := writeRecord(tx, newRecord(Bytes("key"), Bytes("value"), 0))
-		assert.NoError(t, err)
+			err := writeRecord(tx, newRecord(tt.key, tt.value, 0))
+			assert.NoError(t, err)
 
-		data, err := os.ReadFile(path)
-		assert.NoError(t, err)
-		record, err := readRecord(bytes.NewReader(data))
-		assert.NoError(t, err)
-		assert.Equal(t, "key", string(record.GetKey()))
-		assert.Equal(t, "value", string(record.GetValue()))
-	})
+			data, err := os.ReadFile(path)
+			assert.NoError(t, err)
+			record, err := readRecord(bytes.NewReader(data))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.key, record.GetKey())
+			assert.Equal(t, tt.value, record.GetValue())
+		})
+	}
 }
 
 func TestReadRecord_Errors(t *testing.T) {
-	t.Run("Error reading internal key length", func(t *testing.T) {
-		reader := &errorReader{err: errors.New("read internal key length failed")}
-		_, err := readRecord(reader)
-		assert.ErrorContains(t, err, "failed to read internal key length")
-		assert.ErrorContains(t, err, "read internal key length failed")
-	})
+	cases := []struct {
+		name        string
+		setup       func() io.Reader
+		errIs       error
+		errContains []string
+	}{
+		{
+			name: "Error reading internal key length",
+			setup: func() io.Reader {
+				return &errorReader{err: errors.New("read internal key length failed")}
+			},
+			errContains: []string{"failed to read internal key length", "read internal key length failed"},
+		},
+		{
+			name: "Error reading value length",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				writeNumberBuf(&buf, 5)
+				return io.MultiReader(&buf, &errorReader{err: errors.New("read value length failed")})
+			},
+			errContains: []string{"failed to read value length", "read value length failed"},
+		},
+		{
+			name: "Error reading internal key bytes",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				writeNumberBuf(&buf, 5)
+				writeNumberBuf(&buf, 5)
+				buf.Write([]byte("key"))
+				return &buf
+			},
+			errContains: []string{"failed to read internal key bytes"},
+			errIs:       io.ErrUnexpectedEOF,
+		},
+		{
+			name: "Error reading value bytes (EOF)",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				writeNumberBuf(&buf, 3+internalKeySuffixLen)
+				writeNumberBuf(&buf, 5)
+				buf.Write(EncodeInternalKey(Bytes("key"), 0, TypeValue))
+				buf.Write([]byte("val"))
+				return &buf
+			},
+			errContains: []string{"failed to read value bytes"},
+			errIs:       io.ErrUnexpectedEOF,
+		},
+		{
+			name: "Error reading value bytes (iotest)",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				writeNumberBuf(&buf, 3+internalKeySuffixLen)
+				writeNumberBuf(&buf, 5)
+				buf.Write(EncodeInternalKey(Bytes("key"), 0, TypeValue))
+				return io.MultiReader(&buf, iotest.ErrReader(errors.New("read value bytes failed")))
+			},
+			errContains: []string{"failed to read value bytes", "read value bytes failed"},
+		},
+		{
+			name: "Error reading checksum",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
+				writeNumberBuf(&buf, uint64(len(ikey)))
+				writeNumberBuf(&buf, 5)
+				buf.Write(ikey)
+				buf.Write([]byte("value"))
+				return &buf
+			},
+			errContains: []string{"failed to read checksum"},
+			errIs:       io.EOF,
+		},
+		{
+			name: "Checksum mismatch",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
+				writeNumberBuf(&buf, uint64(len(ikey)))
+				writeNumberBuf(&buf, 5)
+				buf.Write(ikey)
+				buf.Write([]byte("value"))
+				buf.Write([]byte{0, 0, 0, 0})
+				return &buf
+			},
+			errIs: ErrChecksumMismatch,
+		},
+	}
 
-	t.Run("Error reading value length", func(t *testing.T) {
-		var buf bytes.Buffer
-		writeNumberBuf(&buf, 5)
-		reader := io.MultiReader(&buf, &errorReader{err: errors.New("read value length failed")})
-		_, err := readRecord(reader)
-		assert.ErrorContains(t, err, "failed to read value length")
-		assert.ErrorContains(t, err, "read value length failed")
-	})
-
-	t.Run("Error reading internal key bytes", func(t *testing.T) {
-		var buf bytes.Buffer
-		writeNumberBuf(&buf, 5)
-		writeNumberBuf(&buf, 5)
-		buf.Write([]byte("key"))
-		_, err := readRecord(&buf)
-		assert.ErrorContains(t, err, "failed to read internal key bytes")
-		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
-	})
-
-	t.Run("Error reading value bytes (EOF)", func(t *testing.T) {
-		var buf bytes.Buffer
-		writeNumberBuf(&buf, 3+internalKeySuffixLen)
-		writeNumberBuf(&buf, 5)
-		buf.Write(EncodeInternalKey(Bytes("key"), 0, TypeValue))
-		buf.Write([]byte("val"))
-		_, err := readRecord(&buf)
-		assert.ErrorContains(t, err, "failed to read value bytes")
-		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
-	})
-
-	t.Run("Error reading value bytes (iotest)", func(t *testing.T) {
-		var buf bytes.Buffer
-		writeNumberBuf(&buf, 3+internalKeySuffixLen)
-		writeNumberBuf(&buf, 5)
-		buf.Write(EncodeInternalKey(Bytes("key"), 0, TypeValue))
-		reader := io.MultiReader(&buf, iotest.ErrReader(errors.New("read value bytes failed")))
-		_, err := readRecord(reader)
-		assert.ErrorContains(t, err, "failed to read value bytes")
-		assert.ErrorContains(t, err, "read value bytes failed")
-	})
-
-	t.Run("Error reading checksum", func(t *testing.T) {
-		var buf bytes.Buffer
-		ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
-		writeNumberBuf(&buf, uint64(len(ikey)))
-		writeNumberBuf(&buf, 5)
-		buf.Write(ikey)
-		buf.Write([]byte("value"))
-		_, err := readRecord(&buf)
-		assert.ErrorContains(t, err, "failed to read checksum")
-		assert.ErrorIs(t, err, io.EOF)
-	})
-
-	t.Run("Checksum mismatch", func(t *testing.T) {
-		var buf bytes.Buffer
-		ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
-		writeNumberBuf(&buf, uint64(len(ikey)))
-		writeNumberBuf(&buf, 5)
-		buf.Write(ikey)
-		buf.Write([]byte("value"))
-		buf.Write([]byte{0, 0, 0, 0})
-		_, err := readRecord(&buf)
-		assert.ErrorIs(t, err, ErrChecksumMismatch)
-	})
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.setup()
+			_, err := readRecord(r)
+			for _, msg := range tt.errContains {
+				assert.ErrorContains(t, err, msg)
+			}
+			if tt.errIs != nil {
+				assert.ErrorIs(t, err, tt.errIs)
+			}
+		})
+	}
 }
 
 func BenchmarkReadRecord(b *testing.B) {


### PR DESCRIPTION
## Summary
- rename write/read test to `TestRecord_WriteRead` and apply table-driven subtests
- consolidate `TestReadRecord_Errors` into a table-driven suite

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c615f18d248325a584155e79d5a443