### PR TITLE
test: refactor unit tests to table-driven style

### DIFF
--- a/internal_key_test.go
+++ b/internal_key_test.go
@@ -7,34 +7,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDecodeInternalKey(t *testing.T) {
-	t.Run("RegularKey", func(t *testing.T) {
-		userKey := []byte("mykey")
-		seq := uint64(123)
-		typ := TypeValue
+func TestInternalKey_Decode(t *testing.T) {
+	cases := []struct {
+		name    string
+		userKey Bytes
+		seq     uint64
+		typ     RecordType
+		wantKey Bytes
+	}{
+		{
+			name:    "regular key",
+			userKey: Bytes("mykey"),
+			seq:     123,
+			typ:     TypeValue,
+			wantKey: Bytes("mykey"),
+		},
+		{
+			name:    "nil user key",
+			userKey: nil,
+			seq:     456,
+			typ:     TypeDeletion,
+			wantKey: nil,
+		},
+	}
 
-		internalKey := EncodeInternalKey(userKey, seq, typ)
-		decodedUserKey, decodedSeq, decodedTyp, err := DecodeInternalKey(internalKey)
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			internalKey := EncodeInternalKey(tt.userKey, tt.seq, tt.typ)
+			decodedUserKey, decodedSeq, decodedTyp, err := DecodeInternalKey(internalKey)
 
-		require.NoError(t, err)
-		require.True(t, bytes.Equal(userKey, decodedUserKey))
-		require.Equal(t, seq, decodedSeq)
-		require.Equal(t, typ, decodedTyp)
-	})
-
-	t.Run("NilUserKey", func(t *testing.T) {
-		userKey := Bytes(nil)
-		seq := uint64(456)
-		typ := TypeDeletion
-
-		internalKey := EncodeInternalKey(userKey, seq, typ)
-		decodedUserKey, decodedSeq, decodedTyp, err := DecodeInternalKey(internalKey)
-
-		require.NoError(t, err)
-		require.Nil(t, decodedUserKey)
-		require.Equal(t, seq, decodedSeq)
-		require.Equal(t, typ, decodedTyp)
-	})
+			require.NoError(t, err)
+			if tt.wantKey == nil {
+				require.Nil(t, decodedUserKey)
+			} else {
+				require.True(t, bytes.Equal(tt.wantKey, decodedUserKey))
+			}
+			require.Equal(t, tt.seq, decodedSeq)
+			require.Equal(t, tt.typ, decodedTyp)
+		})
+	}
 }
 
 func BenchmarkDecodeInternalKey(b *testing.B) {

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMemtable_Basic(t *testing.T) {
+func TestMemtable_BasicOperations(t *testing.T) {
 	cfg := testConfig()
 	pairs := generateKeyValuePairs(1000, 10, 20)
 	mem := populateMemtable(cfg, pairs...)
@@ -21,85 +21,122 @@ func TestMemtable_Basic(t *testing.T) {
 	}
 }
 
-func TestGetMaxSequenceNumberFromMemtable(t *testing.T) {
+func TestMemtable_MaxSequenceNumber(t *testing.T) {
 	cfg := testConfig()
 
-	t.Run("Empty Memtable", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(0), maxSeqNum)
-	})
+	cases := []struct {
+		name    string
+		records []struct {
+			key   string
+			value string
+			seq   uint64
+		}
+		want uint64
+	}{
+		{name: "empty memtable", want: 0},
+		{
+			name: "single record",
+			records: []struct {
+				key   string
+				value string
+				seq   uint64
+			}{{"key1", "value1", 10}},
+			want: 10,
+		},
+		{
+			name: "increasing sequence numbers",
+			records: []struct {
+				key   string
+				value string
+				seq   uint64
+			}{
+				{"key1", "value1", 1},
+				{"key2", "value2", 5},
+				{"key3", "value3", 10},
+			},
+			want: 10,
+		},
+		{
+			name: "decreasing sequence numbers",
+			records: []struct {
+				key   string
+				value string
+				seq   uint64
+			}{
+				{"key1", "value1", 20},
+				{"key2", "value2", 15},
+				{"key3", "value3", 10},
+			},
+			want: 20,
+		},
+		{
+			name: "mixed sequence numbers",
+			records: []struct {
+				key   string
+				value string
+				seq   uint64
+			}{
+				{"key1", "value1", 5},
+				{"key2", "value2", 20},
+				{"key3", "value3", 10},
+				{"key4", "value4", 1},
+			},
+			want: 20,
+		},
+		{
+			name: "all zero sequence numbers",
+			records: []struct {
+				key   string
+				value string
+				seq   uint64
+			}{
+				{"key1", "value1", 0},
+				{"key2", "value2", 0},
+			},
+			want: 0,
+		},
+		{
+			name: "mixed including zero",
+			records: []struct {
+				key   string
+				value string
+				seq   uint64
+			}{
+				{"key1", "value1", 0},
+				{"key2", "value2", 5},
+				{"key3", "value3", 0},
+				{"key4", "value4", 10},
+			},
+			want: 10,
+		},
+		{
+			name: "duplicate max sequence numbers",
+			records: []struct {
+				key   string
+				value string
+				seq   uint64
+			}{
+				{"key1", "value1", 5},
+				{"key2", "value2", 20},
+				{"key3", "value3", 10},
+				{"key4", "value4", 20},
+			},
+			want: 20,
+		},
+	}
 
-	t.Run("Single Record", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		mem.Put(newRecord(Bytes("key1"), Bytes("value1"), 10))
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(10), maxSeqNum)
-	})
-
-	t.Run("Multiple Records - Increasing Sequence Numbers", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		mem.Put(newRecord(Bytes("key1"), Bytes("value1"), 1))
-		mem.Put(newRecord(Bytes("key2"), Bytes("value2"), 5))
-		mem.Put(newRecord(Bytes("key3"), Bytes("value3"), 10))
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(10), maxSeqNum)
-	})
-
-	t.Run("Multiple Records - Decreasing Sequence Numbers", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		mem.Put(newRecord(Bytes("key1"), Bytes("value1"), 20))
-		mem.Put(newRecord(Bytes("key2"), Bytes("value2"), 15))
-		mem.Put(newRecord(Bytes("key3"), Bytes("value3"), 10))
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(20), maxSeqNum)
-	})
-
-	t.Run("Multiple Records - Mixed Sequence Numbers", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		mem.Put(newRecord(Bytes("key1"), Bytes("value1"), 5))
-		mem.Put(newRecord(Bytes("key2"), Bytes("value2"), 20))
-		mem.Put(newRecord(Bytes("key3"), Bytes("value3"), 10))
-		mem.Put(newRecord(Bytes("key4"), Bytes("value4"), 1))
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(20), maxSeqNum)
-	})
-
-	t.Run("All Records Have Sequence Number 0", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		mem.Put(newRecord(Bytes("key1"), Bytes("value1"), 0))
-		mem.Put(newRecord(Bytes("key2"), Bytes("value2"), 0))
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(0), maxSeqNum)
-	})
-
-	t.Run("Mixed Sequence Numbers Including 0", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		mem.Put(newRecord(Bytes("key1"), Bytes("value1"), 0))
-		mem.Put(newRecord(Bytes("key2"), Bytes("value2"), 5))
-		mem.Put(newRecord(Bytes("key3"), Bytes("value3"), 0))
-		mem.Put(newRecord(Bytes("key4"), Bytes("value4"), 10))
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(10), maxSeqNum)
-	})
-
-	t.Run("Duplicate Maximum Sequence Numbers", func(t *testing.T) {
-		mem := InitMemtable(cfg)
-		mem.Put(newRecord(Bytes("key1"), Bytes("value1"), 5))
-		mem.Put(newRecord(Bytes("key2"), Bytes("value2"), 20))
-		mem.Put(newRecord(Bytes("key3"), Bytes("value3"), 10))
-		mem.Put(newRecord(Bytes("key4"), Bytes("value4"), 20))
-		maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
-		assert.NoError(t, err)
-		assert.Equal(t, uint64(20), maxSeqNum)
-	})
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			mem := InitMemtable(cfg)
+			for _, r := range tt.records {
+				mem.Put(newRecord(Bytes(r.key), Bytes(r.value), r.seq))
+			}
+			maxSeqNum, err := getMaxSequenceNumberFromMemtable(mem)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, maxSeqNum)
+		})
+	}
 }
 
 func TestMemtable_ByteSize(t *testing.T) {


### PR DESCRIPTION
## Summary
- rename memtable and internal key tests to follow `Test<Subject>_<Behavior>`
- convert decode and sequence number tests to table-driven structure

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c615f18d248325a584155e79d5a443