### PR TITLE
test: refactor table cache tests

### DIFF
--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -28,64 +28,89 @@ func newTestCache(t *testing.T, opt tableCacheOptions) *tableCache {
 	return newTableCache(opt)
 }
 
-func TestTableCacheHitMiss(t *testing.T) {
+func TestTableCache_HitMiss(t *testing.T) {
 	ctx := context.Background()
-	var opens atomic.Int32
-	cache := newTestCache(t, tableCacheOptions{
-		Open: func(ctx context.Context, k tableKey) (*SStable, error) {
-			opens.Add(1)
-			return &SStable{}, nil
-		},
-	})
+	cases := []struct {
+		name       string
+		getCalls   int
+		wantMisses int64
+		wantHits   int64
+		wantOpens  int32
+	}{
+		{"miss", 1, 1, 0, 1},
+		{"hit", 2, 1, 1, 1},
+	}
 
-	// tests use default DBID 0; override when multi-DB is supported
-	key := tableKey{FileNum: 1}
-	h, err := cache.get(ctx, key)
-	require.NoError(t, err)
-	h.unref()
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var opens atomic.Int32
+			cache := newTestCache(t, tableCacheOptions{
+				Open: func(ctx context.Context, k tableKey) (*SStable, error) {
+					opens.Add(1)
+					return &SStable{}, nil
+				},
+			})
 
-	require.True(t, cache.tryRef(key))
-	st := cache.stats()
-	require.EqualValues(t, 1, st.Misses)
-	require.EqualValues(t, 0, st.Hits)
+			key := tableKey{FileNum: 1}
+			for i := 0; i < tt.getCalls; i++ {
+				h, err := cache.get(ctx, key)
+				require.NoError(t, err)
+				h.unref()
+				if i == 0 {
+					require.True(t, cache.tryRef(key))
+				}
+			}
 
-	h, err = cache.get(ctx, key)
-	require.NoError(t, err)
-	h.unref()
-
-	require.EqualValues(t, 1, opens.Load())
-	st = cache.stats()
-	require.EqualValues(t, 1, st.Misses)
-	require.EqualValues(t, 1, st.Hits)
+			require.EqualValues(t, tt.wantOpens, opens.Load())
+			st := cache.stats()
+			require.EqualValues(t, tt.wantMisses, st.Misses)
+			require.EqualValues(t, tt.wantHits, st.Hits)
+		})
+	}
 }
 
-func TestTableCacheTryGetStats(t *testing.T) {
-	ctx := context.Background()
-	cache := newTestCache(t, tableCacheOptions{})
+func TestTableCache_TryGetStats(t *testing.T) {
+	cases := []struct {
+		name       string
+		tryKey     tableKey
+		wantOK     bool
+		wantMisses int64
+		wantHits   int64
+	}{
+		{"hit", tableKey{FileNum: 1}, true, 1, 1},
+		{"miss", tableKey{FileNum: 2}, false, 2, 1},
+	}
 
-	k1 := tableKey{FileNum: 1}
-	h, err := cache.get(ctx, k1)
-	require.NoError(t, err)
-	h.unref()
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			cache := newTestCache(t, tableCacheOptions{})
 
-	st := cache.stats()
-	require.EqualValues(t, 1, st.Misses)
-	require.EqualValues(t, 0, st.Hits)
+			k1 := tableKey{FileNum: 1}
+			h, err := cache.get(ctx, k1)
+			require.NoError(t, err)
+			h.unref()
 
-	h, ok := cache.tryGet(ctx, k1)
-	require.True(t, ok)
-	h.unref()
+			if tt.wantOK {
+				h, ok := cache.tryGet(ctx, tt.tryKey)
+				require.True(t, ok)
+				h.unref()
+			} else {
+				h, ok := cache.tryGet(ctx, k1)
+				require.True(t, ok)
+				h.unref()
 
-	st = cache.stats()
-	require.EqualValues(t, 1, st.Misses)
-	require.EqualValues(t, 1, st.Hits)
+				_, ok = cache.tryGet(ctx, tt.tryKey)
+				require.False(t, ok)
+			}
 
-	_, ok = cache.tryGet(ctx, tableKey{FileNum: 2})
-	require.False(t, ok)
-
-	st = cache.stats()
-	require.EqualValues(t, 2, st.Misses)
-	require.EqualValues(t, 1, st.Hits)
+			st := cache.stats()
+			require.EqualValues(t, tt.wantMisses, st.Misses)
+			require.EqualValues(t, tt.wantHits, st.Hits)
+		})
+	}
 }
 
 func TestTableCacheEviction(t *testing.T) {

--- a/tablecache_test.go
+++ b/tablecache_test.go
@@ -73,13 +73,32 @@ func TestTableCache_HitMiss(t *testing.T) {
 func TestTableCache_TryGetStats(t *testing.T) {
 	cases := []struct {
 		name       string
-		tryKey     tableKey
-		wantOK     bool
+		tryKeys    []tableKey
+		wantOKs    []bool
 		wantMisses int64
 		wantHits   int64
 	}{
-		{"hit", tableKey{FileNum: 1}, true, 1, 1},
-		{"miss", tableKey{FileNum: 2}, false, 2, 1},
+		{
+			name:       "hit",
+			tryKeys:    []tableKey{{FileNum: 1}},
+			wantOKs:    []bool{true},
+			wantMisses: 1,
+			wantHits:   1,
+		},
+		{
+			name:       "miss",
+			tryKeys:    []tableKey{{FileNum: 2}},
+			wantOKs:    []bool{false},
+			wantMisses: 2,
+			wantHits:   0,
+		},
+		{
+			name:       "hit then miss",
+			tryKeys:    []tableKey{{FileNum: 1}, {FileNum: 2}},
+			wantOKs:    []bool{true, false},
+			wantMisses: 2,
+			wantHits:   1,
+		},
 	}
 
 	for _, tt := range cases {
@@ -88,22 +107,20 @@ func TestTableCache_TryGetStats(t *testing.T) {
 			ctx := context.Background()
 			cache := newTestCache(t, tableCacheOptions{})
 
+			// Common setup: one item in cache.
+			// This results in 1 miss, 0 hits.
 			k1 := tableKey{FileNum: 1}
 			h, err := cache.get(ctx, k1)
 			require.NoError(t, err)
 			h.unref()
 
-			if tt.wantOK {
-				h, ok := cache.tryGet(ctx, tt.tryKey)
-				require.True(t, ok)
-				h.unref()
-			} else {
-				h, ok := cache.tryGet(ctx, k1)
-				require.True(t, ok)
-				h.unref()
-
-				_, ok = cache.tryGet(ctx, tt.tryKey)
-				require.False(t, ok)
+			require.Len(t, tt.tryKeys, len(tt.wantOKs))
+			for i, key := range tt.tryKeys {
+				h, ok := cache.tryGet(ctx, key)
+				require.Equal(t, tt.wantOKs[i], ok, "tryGet for key %v", key)
+				if ok {
+					h.unref()
+				}
 			}
 
 			st := cache.stats()


### PR DESCRIPTION
## Summary
- refactor TableCache hit/miss logic into table-driven tests
- convert TableCache tryGet stats test to table-driven structure

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c61c5d7474832587505ea67314fe88