### PR TITLE
refactor transaction manager tests

### DIFF
--- a/transaction_manager_test.go
+++ b/transaction_manager_test.go
@@ -59,6 +59,7 @@ func TestTransactionManager_BeginErrors(t *testing.T) {
 		{
 			name: "copy open error",
 			setup: func(t *testing.T) (*FileSystem, func()) {
+				t.Helper()
 				fs := newTempFS(t)
 				require.NoError(t, fs.Close())
 				origOpen := osOpen
@@ -68,6 +69,7 @@ func TestTransactionManager_BeginErrors(t *testing.T) {
 			},
 			wantErr: wantOpenFail,
 			post: func(t *testing.T, fs *FileSystem) {
+				t.Helper()
 				entries, err := os.ReadDir(filepath.Dir(fs.Path()))
 				require.NoError(t, err)
 				require.Len(t, entries, 1)
@@ -76,6 +78,7 @@ func TestTransactionManager_BeginErrors(t *testing.T) {
 		{
 			name: "copy error",
 			setup: func(t *testing.T) (*FileSystem, func()) {
+				t.Helper()
 				fs := newTempFS(t)
 				origCopy := ioCopy
 				ioCopy = func(io.Writer, io.Reader) (int64, error) { return 0, wantCopyFail }
@@ -84,6 +87,7 @@ func TestTransactionManager_BeginErrors(t *testing.T) {
 			},
 			wantErr: wantCopyFail,
 			post: func(t *testing.T, fs *FileSystem) {
+				t.Helper()
 				entries, err := os.ReadDir(filepath.Dir(fs.Path()))
 				require.NoError(t, err)
 				require.Len(t, entries, 1)
@@ -92,6 +96,7 @@ func TestTransactionManager_BeginErrors(t *testing.T) {
 		{
 			name: "close error",
 			setup: func(t *testing.T) (*FileSystem, func()) {
+				t.Helper()
 				fs := newTempFS(t)
 				require.NoError(t, fs.file.Close())
 				return fs, nil
@@ -100,6 +105,7 @@ func TestTransactionManager_BeginErrors(t *testing.T) {
 		{
 			name: "shadow fs open error",
 			setup: func(t *testing.T) (*FileSystem, func()) {
+				t.Helper()
 				fs := newTempFS(t)
 				dir := filepath.Dir(fs.Path())
 				require.NoError(t, fs.Close())
@@ -110,6 +116,7 @@ func TestTransactionManager_BeginErrors(t *testing.T) {
 		{
 			name: "src close error",
 			setup: func(t *testing.T) (*FileSystem, func()) {
+				t.Helper()
 				fs := newTempFS(t)
 				tmp, err := os.CreateTemp("", "src")
 				require.NoError(t, err)

--- a/transaction_manager_test.go
+++ b/transaction_manager_test.go
@@ -22,7 +22,7 @@ func newTempFS(t *testing.T) *FileSystem {
 	return fs
 }
 
-func TestBeginCopiesExistingData(t *testing.T) {
+func TestTransactionManager_BeginCopiesExistingData(t *testing.T) {
 	fs := newTempFS(t)
 	_, err := fs.Write([]byte("old"))
 	require.NoError(t, err)
@@ -46,87 +46,107 @@ func TestBeginCopiesExistingData(t *testing.T) {
 	require.Equal(t, []byte("oldnew"), final)
 }
 
-func TestBeginCopyOpenError(t *testing.T) {
-	fs := newTempFS(t)
-	require.NoError(t, fs.Close())
-	tm := newTransactionManager()
+func TestTransactionManager_BeginErrors(t *testing.T) {
+	ctx := context.Background()
+	wantOpenFail := errors.New("open fail")
+	wantCopyFail := errors.New("copy fail")
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) (*FileSystem, func())
+		wantErr error
+		post    func(t *testing.T, fs *FileSystem)
+	}{
+		{
+			name: "copy open error",
+			setup: func(t *testing.T) (*FileSystem, func()) {
+				fs := newTempFS(t)
+				require.NoError(t, fs.Close())
+				origOpen := osOpen
+				osOpen = func(string) (*os.File, error) { return nil, wantOpenFail }
+				cleanup := func() { osOpen = origOpen }
+				return fs, cleanup
+			},
+			wantErr: wantOpenFail,
+			post: func(t *testing.T, fs *FileSystem) {
+				entries, err := os.ReadDir(filepath.Dir(fs.Path()))
+				require.NoError(t, err)
+				require.Len(t, entries, 1)
+			},
+		},
+		{
+			name: "copy error",
+			setup: func(t *testing.T) (*FileSystem, func()) {
+				fs := newTempFS(t)
+				origCopy := ioCopy
+				ioCopy = func(io.Writer, io.Reader) (int64, error) { return 0, wantCopyFail }
+				cleanup := func() { ioCopy = origCopy }
+				return fs, cleanup
+			},
+			wantErr: wantCopyFail,
+			post: func(t *testing.T, fs *FileSystem) {
+				entries, err := os.ReadDir(filepath.Dir(fs.Path()))
+				require.NoError(t, err)
+				require.Len(t, entries, 1)
+			},
+		},
+		{
+			name: "close error",
+			setup: func(t *testing.T) (*FileSystem, func()) {
+				fs := newTempFS(t)
+				require.NoError(t, fs.file.Close())
+				return fs, nil
+			},
+		},
+		{
+			name: "shadow fs open error",
+			setup: func(t *testing.T) (*FileSystem, func()) {
+				fs := newTempFS(t)
+				dir := filepath.Dir(fs.Path())
+				require.NoError(t, fs.Close())
+				require.NoError(t, os.RemoveAll(dir))
+				return fs, nil
+			},
+		},
+		{
+			name: "src close error",
+			setup: func(t *testing.T) (*FileSystem, func()) {
+				fs := newTempFS(t)
+				tmp, err := os.CreateTemp("", "src")
+				require.NoError(t, err)
+				require.NoError(t, tmp.Close())
+				origOpen := osOpen
+				origCopy := ioCopy
+				osOpen = func(string) (*os.File, error) { return tmp, nil }
+				ioCopy = func(io.Writer, io.Reader) (int64, error) { return 0, nil }
+				cleanup := func() { osOpen = origOpen; ioCopy = origCopy; os.Remove(tmp.Name()) }
+				return fs, cleanup
+			},
+		},
+	}
 
-	wantErr := errors.New("open fail")
-	origOpen := osOpen
-	osOpen = func(string) (*os.File, error) { return nil, wantErr }
-	defer func() { osOpen = origOpen }()
-
-	txn, err := tm.begin(context.Background(), fs)
-	require.ErrorIs(t, err, wantErr)
-	require.Nil(t, txn)
-
-	entries, err := os.ReadDir(filepath.Dir(fs.Path()))
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fs, cleanup := tt.setup(t)
+			if cleanup != nil {
+				defer cleanup()
+			}
+			tm := newTransactionManager()
+			txn, err := tm.begin(ctx, fs)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.Error(t, err)
+			}
+			require.Nil(t, txn)
+			if tt.post != nil {
+				tt.post(t, fs)
+			}
+		})
+	}
 }
 
-func TestBeginCopyCopyError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-
-	wantErr := errors.New("copy fail")
-	origCopy := ioCopy
-	ioCopy = func(io.Writer, io.Reader) (int64, error) { return 0, wantErr }
-	defer func() { ioCopy = origCopy }()
-
-	txn, err := tm.begin(context.Background(), fs)
-	require.ErrorIs(t, err, wantErr)
-	require.Nil(t, txn)
-
-	entries, err := os.ReadDir(filepath.Dir(fs.Path()))
-	require.NoError(t, err)
-	require.Len(t, entries, 1)
-}
-
-func TestBeginCloseError(t *testing.T) {
-	fs := newTempFS(t)
-	// Close underlying file without updating fs to simulate close error
-	require.NoError(t, fs.file.Close())
-
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.Error(t, err)
-	require.Nil(t, txn)
-}
-
-func TestBeginShadowFSOpenError(t *testing.T) {
-	fs := newTempFS(t)
-	dir := filepath.Dir(fs.Path())
-	require.NoError(t, fs.Close())
-	require.NoError(t, os.RemoveAll(dir))
-
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.Error(t, err)
-	require.Nil(t, txn)
-}
-
-func TestBeginSrcCloseError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-
-	tmp, err := os.CreateTemp("", "src")
-	require.NoError(t, err)
-	require.NoError(t, tmp.Close())
-	defer os.Remove(tmp.Name())
-
-	origOpen := osOpen
-	origCopy := ioCopy
-	osOpen = func(string) (*os.File, error) { return tmp, nil }
-	ioCopy = func(io.Writer, io.Reader) (int64, error) { return 0, nil }
-	defer func() { osOpen = origOpen; ioCopy = origCopy }()
-
-	txn, err := tm.begin(context.Background(), fs)
-	require.Error(t, err)
-	require.Nil(t, txn)
-}
-
-func TestWriteAndCommit(t *testing.T) {
+func TestTransactionManager_WriteAndCommit(t *testing.T) {
 	fs := newTempFS(t)
 	tm := newTransactionManager()
 	txn, err := tm.begin(context.Background(), fs)
@@ -141,7 +161,7 @@ func TestWriteAndCommit(t *testing.T) {
 	require.Equal(t, []byte("hello"), data)
 }
 
-func TestTransactionWritePartial(t *testing.T) {
+func TestTransactionManager_WritePartial(t *testing.T) {
 	fs := newTempFS(t)
 	tm := newTransactionManager()
 	txn, err := tm.begin(context.Background(), fs)
@@ -170,7 +190,7 @@ func TestTransactionWritePartial(t *testing.T) {
 	require.Equal(t, data, read)
 }
 
-func TestRollback(t *testing.T) {
+func TestTransactionManager_RollbackRestoresExistingData(t *testing.T) {
 	fs := newTempFS(t)
 	_, err := fs.Write([]byte("base"))
 	require.NoError(t, err)
@@ -189,7 +209,7 @@ func TestRollback(t *testing.T) {
 	require.Equal(t, []byte("base"), data)
 }
 
-func TestWriteAfterCommit(t *testing.T) {
+func TestTransactionManager_WriteAfterCommit(t *testing.T) {
 	fs := newTempFS(t)
 	tm := newTransactionManager()
 	txn, err := tm.begin(context.Background(), fs)
@@ -203,7 +223,7 @@ func TestWriteAfterCommit(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestConcurrentBegin(t *testing.T) {
+func TestTransactionManager_ConcurrentBegin(t *testing.T) {
 	tm := newTransactionManager()
 	const n = 10
 	var wg sync.WaitGroup
@@ -227,7 +247,7 @@ func TestConcurrentBegin(t *testing.T) {
 	}
 }
 
-func TestConcurrentWrite(t *testing.T) {
+func TestTransactionManager_ConcurrentWrite(t *testing.T) {
 	tm := newTransactionManager()
 	fs := newTempFS(t)
 	tx, err := tm.begin(context.Background(), fs)
@@ -247,7 +267,7 @@ func TestConcurrentWrite(t *testing.T) {
 	require.Equal(t, int64(numWrites), tx.size())
 }
 
-func TestTransactionCommitRollbackConcurrency(t *testing.T) {
+func TestTransactionManager_CommitRollbackConcurrency(t *testing.T) {
 	ctx := context.Background()
 	cfg := NewConfig(WithDatabaseDir(t.TempDir()))
 	w, err := DefaultNewWALFunc(ctx, cfg)
@@ -293,124 +313,132 @@ func TestTransactionCommitRollbackConcurrency(t *testing.T) {
 	require.Equal(t, Bytes("commit"), val)
 }
 
-func TestCommitSyncError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.NoError(t, err)
-
-	wantErr := errors.New("sync fail")
-	origSync := fsSync
-	fsSync = func(*FileSystem) error { return wantErr }
-	defer func() { fsSync = origSync }()
-
-	err = txn.commit(context.Background())
-	require.ErrorIs(t, err, wantErr)
-}
-
-func TestCommitLogCloseError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.NoError(t, err)
-
-	wantErr := errors.New("log close fail")
-	origSync := fsSync
-	origClose := fsClose
-	fsSync = func(*FileSystem) error { return nil }
-	fsClose = func(f *FileSystem) error {
-		if f == txn.log {
-			return wantErr
-		}
-		return origClose(f)
+func TestTransactionManager_CommitErrors(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		setup func(txn *transaction) (func(), error)
+	}{
+		{
+			name: "sync error",
+			setup: func(txn *transaction) (func(), error) {
+				wantErr := errors.New("sync fail")
+				origSync := fsSync
+				fsSync = func(*FileSystem) error { return wantErr }
+				return func() { fsSync = origSync }, wantErr
+			},
+		},
+		{
+			name: "log close error",
+			setup: func(txn *transaction) (func(), error) {
+				wantErr := errors.New("log close fail")
+				origSync := fsSync
+				origClose := fsClose
+				fsSync = func(*FileSystem) error { return nil }
+				fsClose = func(f *FileSystem) error {
+					if f == txn.log {
+						return wantErr
+					}
+					return origClose(f)
+				}
+				return func() { fsSync = origSync; fsClose = origClose }, wantErr
+			},
+		},
+		{
+			name: "rename error",
+			setup: func(txn *transaction) (func(), error) {
+				wantErr := errors.New("rename fail")
+				origRename := osRename
+				osRename = func(_, _ string) error { return wantErr }
+				return func() { osRename = origRename }, wantErr
+			},
+		},
+		{
+			name: "target close error",
+			setup: func(txn *transaction) (func(), error) {
+				wantErr := errors.New("target close fail")
+				origClose := fsClose
+				fsClose = func(f *FileSystem) error {
+					if f == txn.target {
+						return wantErr
+					}
+					return origClose(f)
+				}
+				return func() { fsClose = origClose }, wantErr
+			},
+		},
+		{
+			name: "open existing error",
+			setup: func(txn *transaction) (func(), error) {
+				wantErr := errors.New("open existing fail")
+				origOpenExisting := fsOpenExisting
+				fsOpenExisting = func(*FileSystem, context.Context) error { return wantErr }
+				return func() { fsOpenExisting = origOpenExisting }, wantErr
+			},
+		},
 	}
-	defer func() { fsSync = origSync; fsClose = origClose }()
 
-	err = txn.commit(context.Background())
-	require.ErrorIs(t, err, wantErr)
-}
-
-func TestCommitRenameError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.NoError(t, err)
-
-	wantErr := errors.New("rename fail")
-	origRename := osRename
-	osRename = func(_, _ string) error { return wantErr }
-	defer func() { osRename = origRename }()
-
-	err = txn.commit(context.Background())
-	require.ErrorIs(t, err, wantErr)
-}
-
-func TestCommitTargetCloseError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.NoError(t, err)
-
-	wantErr := errors.New("target close fail")
-	origClose := fsClose
-	fsClose = func(f *FileSystem) error {
-		if f == txn.target {
-			return wantErr
-		}
-		return origClose(f)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fs := newTempFS(t)
+			tm := newTransactionManager()
+			txn, err := tm.begin(ctx, fs)
+			require.NoError(t, err)
+			cleanup, wantErr := tt.setup(txn)
+			if cleanup != nil {
+				defer cleanup()
+			}
+			err = txn.commit(ctx)
+			require.ErrorIs(t, err, wantErr)
+		})
 	}
-	defer func() { fsClose = origClose }()
-
-	err = txn.commit(context.Background())
-	require.ErrorIs(t, err, wantErr)
 }
 
-func TestCommitOpenExistingError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.NoError(t, err)
-
-	wantErr := errors.New("open existing fail")
-	origOpenExisting := fsOpenExisting
-	fsOpenExisting = func(*FileSystem, context.Context) error { return wantErr }
-	defer func() { fsOpenExisting = origOpenExisting }()
-
-	err = txn.commit(context.Background())
-	require.ErrorIs(t, err, wantErr)
-}
-
-func TestRollbackCloseError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.NoError(t, err)
-
-	wantErr := errors.New("log close fail")
-	origClose := fsClose
-	fsClose = func(f *FileSystem) error {
-		if f == txn.log {
-			return wantErr
-		}
-		return origClose(f)
+func TestTransactionManager_RollbackErrors(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		setup func(txn *transaction) (func(), error)
+	}{
+		{
+			name: "log close error",
+			setup: func(txn *transaction) (func(), error) {
+				wantErr := errors.New("log close fail")
+				origClose := fsClose
+				fsClose = func(f *FileSystem) error {
+					if f == txn.log {
+						return wantErr
+					}
+					return origClose(f)
+				}
+				return func() { fsClose = origClose }, wantErr
+			},
+		},
+		{
+			name: "remove error",
+			setup: func(txn *transaction) (func(), error) {
+				wantErr := errors.New("remove fail")
+				origRemove := osRemove
+				osRemove = func(string) error { return wantErr }
+				return func() { osRemove = origRemove }, wantErr
+			},
+		},
 	}
-	defer func() { fsClose = origClose }()
 
-	err = txn.rollback(context.Background())
-	require.ErrorIs(t, err, wantErr)
-}
-
-func TestRollbackRemoveError(t *testing.T) {
-	fs := newTempFS(t)
-	tm := newTransactionManager()
-	txn, err := tm.begin(context.Background(), fs)
-	require.NoError(t, err)
-
-	wantErr := errors.New("remove fail")
-	origRemove := osRemove
-	osRemove = func(string) error { return wantErr }
-	defer func() { osRemove = origRemove }()
-
-	err = txn.rollback(context.Background())
-	require.ErrorIs(t, err, wantErr)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fs := newTempFS(t)
+			tm := newTransactionManager()
+			txn, err := tm.begin(ctx, fs)
+			require.NoError(t, err)
+			cleanup, wantErr := tt.setup(txn)
+			if cleanup != nil {
+				defer cleanup()
+			}
+			err = txn.rollback(ctx)
+			require.ErrorIs(t, err, wantErr)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- rename transaction manager tests to follow Test<Subject>_<Behavior>
- consolidate begin error cases into table-driven subtests
- group commit and rollback error scenarios with shared setup helpers

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c61c5d7474832587505ea67314fe88