### PR TITLE
test: refactor bloom filter and offset reader tests

### DIFF
--- a/bloomfilter_test.go
+++ b/bloomfilter_test.go
@@ -110,7 +110,7 @@ func TestBloomFilter_Options(t *testing.T) {
 				assert.Equal(t, tt.wantK, b.config.k)
 			}
 			if tt.checkFP {
-				assert.LessOrEqual(t, b.FalsePositive(), .1, "False positive rate too hight")
+                                assert.LessOrEqual(t, b.FalsePositive(), .1, "False positive rate too high")
 			}
 		})
 	}

--- a/bloomfilter_test.go
+++ b/bloomfilter_test.go
@@ -1,14 +1,12 @@
 package rindb
 
 import (
-	"context"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBloomFilter(t *testing.T) {
+func TestBloomFilter_BasicOperations(t *testing.T) {
 	wordPresent := []string{
 		"abound", "abounds", "abundance", "abundant", "accessible",
 		"bloom", "blossom", "bolster", "bonny", "bonus", "bonuses",
@@ -26,7 +24,6 @@ func TestBloomFilter(t *testing.T) {
 		SetN(l),
 		SetP(10e-100),
 		WithCalculatedM(),
-		// WithCalculatedK(),
 		SetK(4),
 	)
 
@@ -37,56 +34,84 @@ func TestBloomFilter(t *testing.T) {
 		b.Insert(Bytes(word))
 	}
 
-	for _, word := range wordAbsent {
-		if !b.Lookup(Bytes(word)) {
-			debug(context.Background(), "word: %v\n", word)
-			assert.False(t, slices.Contains(wordPresent, word))
-		}
+	cases := []struct {
+		name  string
+		words []string
+		want  bool
+	}{
+		{"lookup present words", wordPresent, true},
+		{"lookup absent words", wordAbsent, false},
 	}
-
-	for _, word := range wordPresent {
-		assert.True(t, b.Lookup(Bytes(word)))
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			for _, w := range tt.words {
+				assert.Equal(t, tt.want, b.Lookup(Bytes(w)))
+			}
+		})
 	}
 }
 
-func TestBloomFilterOpts(t *testing.T) {
-	t.Run("Set all params manually", func(t *testing.T) {
-		b := NewBloomFilter(
-			SetN(100),
-			SetP(10e-100),
-			SetM(1000),
-			SetK(4),
-		)
-		assert.Equal(t, uint64(100), b.config.n)
-		assert.Equal(t, float64(10e-100), b.config.p)
-		assert.Equal(t, uint32(1000), b.config.m)
-		assert.Equal(t, uint32(4), b.config.k)
-	})
+func TestBloomFilter_Options(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    []BloomFilterOpt
+		wantN   uint64
+		wantP   float64
+		wantM   uint32
+		wantK   uint32
+		checkM  bool
+		checkK  bool
+		checkFP bool
+	}{
+		{
+			name:  "set all params manually",
+			opts:  []BloomFilterOpt{SetN(100), SetP(10e-100), SetM(1000), SetK(4)},
+			wantN: 100,
+			wantP: 10e-100,
+			wantM: 1000,
+			wantK: 4,
+		},
+		{
+			name:    "with calculated m",
+			opts:    []BloomFilterOpt{SetN(100), SetP(10e-100), WithCalculatedM(), SetK(4)},
+			wantN:   100,
+			wantP:   10e-100,
+			wantK:   4,
+			checkM:  true,
+			checkFP: true,
+		},
+		{
+			name:    "with calculated k",
+			opts:    []BloomFilterOpt{SetN(100), SetP(10e-100), SetM(1000), WithCalculatedK()},
+			wantN:   100,
+			wantP:   10e-100,
+			wantM:   1000,
+			checkK:  true,
+			checkFP: true,
+		},
+	}
 
-	t.Run("With calculated m", func(t *testing.T) {
-		b := NewBloomFilter(
-			SetN(100),
-			SetP(10e-100),
-			WithCalculatedM(),
-			SetK(4),
-		)
-		assert.Equal(t, uint64(100), b.config.n)
-		assert.Equal(t, float64(10e-100), b.config.p)
-		assert.False(t, isEmpty(b.config.m))
-		assert.LessOrEqual(t, b.FalsePositive(), .1, "False positive rate too hight")
-	})
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBloomFilter(tt.opts...)
 
-	t.Run("With calculated k", func(t *testing.T) {
-		b := NewBloomFilter(
-			SetN(100),
-			SetP(10e-100),
-			SetM(1000),
-			WithCalculatedK(),
-		)
-		assert.Equal(t, uint64(100), b.config.n)
-		assert.Equal(t, float64(10e-100), b.config.p)
-		assert.Equal(t, uint32(1000), b.config.m)
-		assert.False(t, isEmpty(b.config.k))
-		assert.LessOrEqual(t, b.FalsePositive(), .1, "False positive rate too hight")
-	})
+			assert.Equal(t, tt.wantN, b.config.n)
+			assert.Equal(t, tt.wantP, b.config.p)
+			if tt.checkM {
+				assert.False(t, isEmpty(b.config.m))
+			} else {
+				assert.Equal(t, tt.wantM, b.config.m)
+			}
+			if tt.checkK {
+				assert.False(t, isEmpty(b.config.k))
+			} else {
+				assert.Equal(t, tt.wantK, b.config.k)
+			}
+			if tt.checkFP {
+				assert.LessOrEqual(t, b.FalsePositive(), .1, "False positive rate too hight")
+			}
+		})
+	}
 }

--- a/offset_reader_test.go
+++ b/offset_reader_test.go
@@ -33,6 +33,8 @@ func TestOffsetReader_Read(t *testing.T) {
 		{
 			name:    "read error leaves offset unchanged",
 			bufSize: 5,
+			wantN:   0,
+			wantOff: 0,
 			wantErr: ErrFileNotOpened,
 			setupFunc: func(fs *FileSystem) {
 				require.NoError(t, fs.Close())

--- a/offset_reader_test.go
+++ b/offset_reader_test.go
@@ -9,41 +9,58 @@ import (
 )
 
 func TestOffsetReader_Read(t *testing.T) {
-	t.Run("advances offset on full read", func(t *testing.T) {
-		fss, closer := initTempFileSystems(t, 1, [][]byte{[]byte("hello")})
-		defer closer()
+	cases := []struct {
+		name      string
+		bufSize   int
+		wantN     int
+		wantOff   int64
+		wantErr   error
+		setupFunc func(fs *FileSystem)
+	}{
+		{
+			name:    "advances offset on full read",
+			bufSize: 5,
+			wantN:   5,
+			wantOff: 5,
+		},
+		{
+			name:    "partial read advances offset",
+			bufSize: 10,
+			wantN:   5,
+			wantOff: 5,
+			wantErr: io.EOF,
+		},
+		{
+			name:    "read error leaves offset unchanged",
+			bufSize: 5,
+			wantErr: ErrFileNotOpened,
+			setupFunc: func(fs *FileSystem) {
+				require.NoError(t, fs.Close())
+			},
+		},
+	}
 
-		r := newOffsetReader(fss[0], 0)
-		buf := make([]byte, 5)
-		n, err := r.Read(buf)
-		require.NoError(t, err)
-		assert.Equal(t, 5, n)
-		assert.Equal(t, int64(5), r.Offset())
-	})
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fss, closer := initTempFileSystems(t, 1, [][]byte{[]byte("hello")})
+			defer closer()
 
-	t.Run("partial read advances offset", func(t *testing.T) {
-		fss, closer := initTempFileSystems(t, 1, [][]byte{[]byte("hello")})
-		defer closer()
+			fs := fss[0]
+			r := newOffsetReader(fs, 0)
+			if tt.setupFunc != nil {
+				tt.setupFunc(fs)
+			}
 
-		r := newOffsetReader(fss[0], 0)
-		buf := make([]byte, 10)
-		n, err := r.Read(buf)
-		assert.ErrorIs(t, err, io.EOF)
-		assert.Equal(t, 5, n)
-		assert.Equal(t, int64(5), r.Offset())
-	})
-
-	t.Run("read error leaves offset unchanged", func(t *testing.T) {
-		fss, closer := initTempFileSystems(t, 1, [][]byte{[]byte("hello")})
-		defer closer()
-
-		fs := fss[0]
-		r := newOffsetReader(fs, 0)
-		require.NoError(t, fs.Close())
-
-		n, err := r.Read(make([]byte, 5))
-		assert.ErrorIs(t, err, ErrFileNotOpened)
-		assert.Zero(t, n)
-		assert.Equal(t, int64(0), r.Offset())
-	})
+			buf := make([]byte, tt.bufSize)
+			n, err := r.Read(buf)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantN, n)
+			assert.Equal(t, tt.wantOff, r.Offset())
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- rename bloom filter tests and restructure them with table-driven subtests
- refactor offset reader tests to table-driven style

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c62a16eeac8325bd9ab295d78cdd59