### PR TITLE
test: align unit tests with naming convention

### DIFF
--- a/bloomfilter_test.go
+++ b/bloomfilter_test.go
@@ -110,7 +110,7 @@ func TestBloomFilter_Options(t *testing.T) {
 				assert.Equal(t, tt.wantK, b.config.k)
 			}
 			if tt.checkFP {
-                                assert.LessOrEqual(t, b.FalsePositive(), .1, "False positive rate too high")
+				assert.LessOrEqual(t, b.FalsePositive(), .1, "False positive rate too high")
 			}
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestDefaultConfig verifies that DefaultConfig returns the expected default values.
-func TestDefaultConfig(t *testing.T) {
+// TestConfig_Default verifies that DefaultConfig returns the expected default values.
+func TestConfig_Default(t *testing.T) {
 	cfg := DefaultConfig()
 
 	tests := []struct {
@@ -37,6 +37,7 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.got != tt.want {
 				t.Errorf("DefaultConfig() %s = %v, want %v", tt.name, tt.got, tt.want)
@@ -45,8 +46,8 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
-// TestNewConfigWithOptions tests that NewConfig applies options correctly.
-func TestNewConfigWithOptions(t *testing.T) {
+// TestConfig_NewWithOptions tests that NewConfig applies options correctly.
+func TestConfig_NewWithOptions(t *testing.T) {
 	tests := []struct {
 		name   string
 		opts   []Option
@@ -239,6 +240,7 @@ func TestNewConfigWithOptions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := NewConfig(tt.opts...)
 			tt.verify(t, cfg)
@@ -246,7 +248,7 @@ func TestNewConfigWithOptions(t *testing.T) {
 	}
 }
 
-func TestConfigValidatePanics(t *testing.T) {
+func TestConfig_ValidatePanics(t *testing.T) {
 	base := DefaultConfig()
 	tests := []struct {
 		name   string
@@ -282,6 +284,7 @@ func TestConfigValidatePanics(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := base
 			tt.mutate(&cfg)

--- a/fd_limiter_test.go
+++ b/fd_limiter_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSemaphoreFDLimiterConcurrentGet(t *testing.T) {
+func TestSemaphoreFDLimiter_ConcurrentGet(t *testing.T) {
 	ctx := context.Background()
 	limiter := NewSemaphoreFDLimiter(1)
 
@@ -48,16 +48,39 @@ func TestSemaphoreFDLimiterConcurrentGet(t *testing.T) {
 	require.EqualValues(t, 1, max.Load(), "concurrent opens should be limited to 1")
 }
 
-func TestSemaphoreFDLimiterAcquireCancelled(t *testing.T) {
-	limiter := NewSemaphoreFDLimiter(1)
+func TestSemaphoreFDLimiter_Acquire(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     func() context.Context
+		wantErr error
+	}{
+		{
+			name:    "success",
+			ctx:     func() context.Context { return context.Background() },
+			wantErr: nil,
+		},
+		{
+			name: "canceled",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantErr: context.Canceled,
+		},
+	}
 
-	require.NoError(t, limiter.Acquire(context.Background()))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := limiter.Acquire(ctx)
-	require.ErrorIs(t, err, context.Canceled)
-
-	limiter.Release()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			limiter := NewSemaphoreFDLimiter(1)
+			err := limiter.Acquire(tt.ctx())
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				limiter.Release()
+			}
+		})
+	}
 }

--- a/fd_limiter_test.go
+++ b/fd_limiter_test.go
@@ -52,12 +52,16 @@ func TestSemaphoreFDLimiter_Acquire(t *testing.T) {
 	tests := []struct {
 		name    string
 		ctx     func() context.Context
+		setup   func(t *testing.T, l *SemaphoreFDLimiter)
+		cleanup func(t *testing.T, l *SemaphoreFDLimiter)
 		wantErr error
 	}{
 		{
-			name:    "success",
-			ctx:     func() context.Context { return context.Background() },
-			wantErr: nil,
+			name: "success",
+			ctx:  func() context.Context { return context.Background() },
+			cleanup: func(t *testing.T, l *SemaphoreFDLimiter) {
+				l.Release()
+			},
 		},
 		{
 			name: "canceled",
@@ -65,6 +69,12 @@ func TestSemaphoreFDLimiter_Acquire(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				return ctx
+			},
+			setup: func(t *testing.T, l *SemaphoreFDLimiter) {
+				require.NoError(t, l.Acquire(context.Background()))
+			},
+			cleanup: func(t *testing.T, l *SemaphoreFDLimiter) {
+				l.Release()
 			},
 			wantErr: context.Canceled,
 		},
@@ -74,12 +84,17 @@ func TestSemaphoreFDLimiter_Acquire(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			limiter := NewSemaphoreFDLimiter(1)
+			if tt.setup != nil {
+				tt.setup(t, limiter)
+			}
 			err := limiter.Acquire(tt.ctx())
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
-				limiter.Release()
+			}
+			if tt.cleanup != nil {
+				tt.cleanup(t, limiter)
 			}
 		})
 	}

--- a/file_number_allocator_test.go
+++ b/file_number_allocator_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFileNumberAllocatorApply(t *testing.T) {
+func TestFileNumberAllocator_Apply(t *testing.T) {
 	tests := []struct {
 		name     string
 		start    uint64
@@ -27,11 +27,12 @@ func TestFileNumberAllocatorApply(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			a := newFileNumberAllocator(tc.start)
-			a.apply(tc.edit)
-			require.Equal(t, tc.expected, a.peek())
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			a := newFileNumberAllocator(tt.start)
+			a.apply(tt.edit)
+			require.Equal(t, tt.expected, a.peek())
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- rename config tests and capture loop vars to follow Test<Subject>_<Behavior>
- refactor semaphore FD limiter tests with table-driven cases
- align file number allocator test with naming convention

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c6302092a88325bb19a406707e1525