### PR TITLE
test: refactor unit tests for naming conventions

### DIFF
--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // errIterator injects an error at a specified index.
@@ -27,7 +28,7 @@ func (e *errIterator) Next() (Record, error) {
 	return rec, nil
 }
 
-func TestMergingIterator(t *testing.T) {
+func TestMergingIterator_MergesRecords(t *testing.T) {
 	rec := func(k, v string, seq uint64, typ RecordType) Record {
 		var nv Bytes = nil
 		if v != "" {
@@ -77,10 +78,35 @@ func TestMergingIterator(t *testing.T) {
 	}
 }
 
-func TestMergingIteratorInitialError(t *testing.T) {
-	r := newRecord(Bytes("a"), Bytes("1"), 1)
-	it := &errIterator{records: []Record{r}, failIdx: 0}
-	mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
-	assert.Nil(t, mi)
-	assert.EqualError(t, err, "boom")
+func TestMergingIterator_ErrorPropagation(t *testing.T) {
+	r1 := newRecord(Bytes("a"), Bytes("1"), 1)
+	r2 := newRecord(Bytes("b"), Bytes("2"), 2)
+	cases := []struct {
+		name       string
+		records    []Record
+		failIdx    int
+		expectInit bool
+	}{
+		{name: "initial error", records: []Record{r1}, failIdx: 0, expectInit: true},
+		{name: "error on next", records: []Record{r1, r2}, failIdx: 1, expectInit: false},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			it := &errIterator{records: tt.records, failIdx: tt.failIdx}
+			mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
+			if tt.expectInit {
+				assert.Nil(t, mi)
+				assert.EqualError(t, err, "boom")
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, mi)
+			_, err = mi.Next()
+			require.NoError(t, err)
+			_, err = mi.Next()
+			assert.EqualError(t, err, "boom")
+		})
+	}
 }

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -87,7 +87,7 @@ func TestSnapshot_MinSequenceUpdatesOnlyOnFirst(t *testing.T) {
 	assert.Equal(t, uint64(math.MaxUint64), rin.SSTableManager.minSnapshotSeq)
 }
 
-func TestTombstoneRemovedAfterSnapshotRelease(t *testing.T) {
+func TestSnapshot_TombstoneRemovedAfterRelease(t *testing.T) {
 	ctx := context.Background()
 	rin, cleanup := initRinDBWithCleanup(t, WithDatabaseDir(t.TempDir()), WithMaxMemtableSize(200), WithLevel0CompactionThreshold(1))
 	defer cleanup()


### PR DESCRIPTION
## Summary
- rename merging iterator and snapshot tests to follow `Test<Subject>_<Behavior>`
- convert merging iterator error cases to table-driven subtests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c6302092a88325bb19a406707e1525