### PR TITLE
test: enforce unit test naming and structure

### DIFF
--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -13,69 +13,86 @@ import (
 
 //nolint:funlen
 func TestFileSystem_BasicOperations(t *testing.T) {
-	t.Run("Check file must be opened before doing other actions", func(t *testing.T) {
-		fss, closer := initTempFileSystems(t, 1, nil)
-		defer closer()
+	cases := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{
+			name: "Check file must be opened before doing other actions",
+			test: func(t *testing.T) {
+				fss, closer := initTempFileSystems(t, 1, nil)
+				defer closer()
 
-		fs := fss[0]
-		emptyFs := FileSystem{filePath: ":path:"}
+				fs := fss[0]
+				emptyFs := FileSystem{filePath: ":path:"}
 
-		assert.NoError(t, fs.Sync())
-		assert.ErrorIs(t, emptyFs.Sync(), ErrFileNotOpened)
+				assert.NoError(t, fs.Sync())
+				assert.ErrorIs(t, emptyFs.Sync(), ErrFileNotOpened)
 
-		assert.NoError(t, fs.Clean())
-		assert.ErrorIs(t, emptyFs.Clean(), ErrFileNotOpened)
+				assert.NoError(t, fs.Clean())
+				assert.ErrorIs(t, emptyFs.Clean(), ErrFileNotOpened)
 
-		_, err := fs.CursorPos()
-		assert.NoError(t, err)
-		_, err = emptyFs.CursorPos()
-		assert.ErrorIs(t, err, ErrFileNotOpened)
+				_, err := fs.CursorPos()
+				assert.NoError(t, err)
+				_, err = emptyFs.CursorPos()
+				assert.ErrorIs(t, err, ErrFileNotOpened)
 
-		_, err = fs.Read(nil)
-		assert.NoError(t, err)
-		_, err = emptyFs.Read(nil)
-		assert.ErrorIs(t, err, ErrFileNotOpened)
+				_, err = fs.Read(nil)
+				assert.NoError(t, err)
+				_, err = emptyFs.Read(nil)
+				assert.ErrorIs(t, err, ErrFileNotOpened)
 
-		_, err = fs.Write(nil)
-		assert.NoError(t, err)
-		_, err = emptyFs.Write(nil)
-		assert.ErrorIs(t, err, ErrFileNotOpened)
+				_, err = fs.Write(nil)
+				assert.NoError(t, err)
+				_, err = emptyFs.Write(nil)
+				assert.ErrorIs(t, err, ErrFileNotOpened)
 
-		assert.NoError(t, fs.Close())
-		assert.NoError(t, emptyFs.Close())
-	})
+				assert.NoError(t, fs.Close())
+				assert.NoError(t, emptyFs.Close())
+			},
+		},
+		{
+			name: "Rename file",
+			test: func(t *testing.T) {
+				fss, closer := initTempFileSystems(t, 1, nil)
+				defer closer()
 
-	t.Run("Rename file", func(t *testing.T) {
-		fss, closer := initTempFileSystems(t, 1, nil)
-		defer closer()
+				fs := fss[0]
+				newPath := fs.Path() + "-renamed"
 
-		fs := fss[0]
-		newPath := fs.Path() + "-renamed"
+				assert.NoError(t, fs.Rename(newPath))
+				assert.Equal(t, newPath, fs.Path())
+			},
+		},
+		{
+			name: "Rename and append content",
+			test: func(t *testing.T) {
+				fss, closer := initTempFileSystems(t, 1, nil)
+				defer closer()
+				fs := fss[0]
+				ctx := context.Background()
 
-		assert.NoError(t, fs.Rename(newPath))
-		assert.Equal(t, newPath, fs.Path())
-	})
+				_, err := fs.Write([]byte("A"))
+				require.NoError(t, err)
+				newPath := filepath.Join(filepath.Dir(fs.Path()), "file")
+				require.NoError(t, fs.Rename(newPath))
+				require.NoError(t, fs.Open(ctx))
+				_, err = fs.Seek(0, io.SeekEnd)
+				require.NoError(t, err)
+				_, err = fs.Write([]byte("B"))
+				require.NoError(t, err)
+				require.NoError(t, fs.Close())
+				data, err := os.ReadFile(newPath)
+				require.NoError(t, err)
+				require.Equal(t, []byte("AB"), data)
+			},
+		},
+	}
 
-	t.Run("Rename and append content", func(t *testing.T) {
-		fss, closer := initTempFileSystems(t, 1, nil)
-		defer closer()
-		fs := fss[0]
-		ctx := context.Background()
-
-		_, err := fs.Write([]byte("A"))
-		require.NoError(t, err)
-		newPath := filepath.Join(filepath.Dir(fs.Path()), "file")
-		require.NoError(t, fs.Rename(newPath))
-		require.NoError(t, fs.Open(ctx))
-		_, err = fs.Seek(0, io.SeekEnd)
-		require.NoError(t, err)
-		_, err = fs.Write([]byte("B"))
-		require.NoError(t, err)
-		require.NoError(t, fs.Close())
-		data, err := os.ReadFile(newPath)
-		require.NoError(t, err)
-		require.Equal(t, []byte("AB"), data)
-	})
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, tt.test)
+	}
 }
 
 func TestFileSystem_Errors(t *testing.T) {

--- a/tablecache_slru_test.go
+++ b/tablecache_slru_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestShardGetEntryLockedRemovesClosedEntry covers the branch where a closed entry is pruned.
-func TestShardGetEntryLockedRemovesClosedEntry(t *testing.T) {
+// TestShardGetEntryLocked_RemovesClosedEntry covers the branch where a closed entry is pruned.
+func TestShardGetEntryLocked_RemovesClosedEntry(t *testing.T) {
 	parent := &tableCache{}
 	s := &shard{
 		items:  make(map[tableKey]*entry),
@@ -42,8 +42,8 @@ func TestShardGetEntryLockedRemovesClosedEntry(t *testing.T) {
 	require.False(t, ok)
 }
 
-// TestPromoteOnHitDemoteAndBreak ensures demotion and the break path when protected list is empty.
-func TestPromoteOnHitDemoteAndBreak(t *testing.T) {
+// TestPromoteOnHit_DemoteAndBreak ensures demotion and the break path when protected list is empty.
+func TestPromoteOnHit_DemoteAndBreak(t *testing.T) {
 	s := &shard{
 		items:        make(map[tableKey]*entry),
 		protCapBytes: 0,
@@ -68,8 +68,8 @@ func TestPromoteOnHitDemoteAndBreak(t *testing.T) {
 	require.EqualValues(t, 1, s.protBytes)
 }
 
-// TestChooseVictimFromProtectedSkipsPinned covers iteration over protected list.
-func TestChooseVictimFromProtectedSkipsPinned(t *testing.T) {
+// TestChooseVictimFromProtected_SkipsPinned covers iteration over protected list.
+func TestChooseVictimFromProtected_SkipsPinned(t *testing.T) {
 	s := &shard{}
 	eUnpinned := &entry{key: tableKey{FileNum: 1}, entry: &tableCacheEntry{}, seg: segProtected}
 	eUnpinned.elem = s.prot.PushBack(eUnpinned)
@@ -80,8 +80,8 @@ func TestChooseVictimFromProtectedSkipsPinned(t *testing.T) {
 	require.Equal(t, eUnpinned, victim)
 }
 
-// TestEvictOrDemoteLockedDemotesTail verifies demotion when protected exceeds cap.
-func TestEvictOrDemoteLockedDemotesTail(t *testing.T) {
+// TestEvictOrDemoteLocked_DemotesTail verifies demotion when protected exceeds cap.
+func TestEvictOrDemoteLocked_DemotesTail(t *testing.T) {
 	parent := &tableCache{}
 	s := &shard{
 		items:        make(map[tableKey]*entry),
@@ -111,8 +111,8 @@ func TestEvictOrDemoteLockedDemotesTail(t *testing.T) {
 	require.EqualValues(t, e2.entry.actualBytes, s.probBytes)
 }
 
-// TestEvictOrDemoteLockedBreakOnEmptyProtected exercises the break when protected list is empty.
-func TestEvictOrDemoteLockedBreakOnEmptyProtected(t *testing.T) {
+// TestEvictOrDemoteLocked_BreakOnEmptyProtected exercises the break when protected list is empty.
+func TestEvictOrDemoteLocked_BreakOnEmptyProtected(t *testing.T) {
 	s := &shard{
 		protCapBytes: 0,
 		protBytes:    1,
@@ -128,8 +128,8 @@ func TestEvictOrDemoteLockedBreakOnEmptyProtected(t *testing.T) {
 	require.Equal(t, 0, s.prot.Len())
 }
 
-// TestEvictOrDemoteLockedDropsRecentWhenNoVictim ensures recent entry is dropped when all are pinned.
-func TestEvictOrDemoteLockedDropsRecentWhenNoVictim(t *testing.T) {
+// TestEvictOrDemoteLocked_DropsRecentWhenNoVictim ensures recent entry is dropped when all are pinned.
+func TestEvictOrDemoteLocked_DropsRecentWhenNoVictim(t *testing.T) {
 	parent := &tableCache{}
 	recentEntry := &tableCacheEntry{
 		Table:       &SStable{},


### PR DESCRIPTION
## Summary
- rename shard and eviction tests to `Test<Subject>_<Behavior>` style
- refactor filesystem basic operations into table-driven subtests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c63b1aa9208325a4769c4f8c5ea848