### PR TITLE
test: refine range and cache test structure

### DIFF
--- a/range_test.go
+++ b/range_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRangeIterator(t *testing.T) {
+func TestRangeIterator_Next(t *testing.T) {
 	rec := func(k, v string, seq uint64, typ RecordType) Record {
 		var nv Bytes = nil
 		if v != "" {
@@ -79,7 +79,7 @@ func TestRangeIterator(t *testing.T) {
 	}
 }
 
-func TestIRangeCloseReleasesSSTables(t *testing.T) {
+func TestIRange_CloseReleasesSSTables(t *testing.T) {
 	cfg := testConfig()
 	ctx := context.Background()
 	ts := newTestRindbSetup(t, ctx, &cfg)
@@ -112,7 +112,7 @@ func TestIRangeCloseReleasesSSTables(t *testing.T) {
 	assert.Equal(t, int32(0), h.refs.Load())
 }
 
-func TestRangeIteratorPrepare(t *testing.T) {
+func TestRangeIterator_Prepare(t *testing.T) {
 	rec := func(k, v string, seq uint64) Record {
 		var nv Bytes = nil
 		if v != "" {
@@ -121,50 +121,57 @@ func TestRangeIteratorPrepare(t *testing.T) {
 		return newRecord(Bytes(k), nv, seq)
 	}
 
-	t.Run("skips duplicates in same iterator", func(t *testing.T) {
-		it := &errIterator{
-			records: []Record{
-				rec("a", "v2", 2),
-				rec("a", "v1", 1),
-				rec("b", "vb", 1),
-			},
-			failIdx: -1,
-		}
-		mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
-		assert.NoError(t, err)
+	type testCase struct {
+		name         string
+		records      []Record
+		failIdx      int
+		wantPrepared bool
+		wantKey      string
+		wantValue    string
+		wantErr      string
+	}
 
-		iter := NewRangeIterator(mi)
-		iter.prepare()
-		_, err = iter.Next()
-		assert.NoError(t, err)
+	tests := []testCase{
+		{
+			name:         "skips duplicates in same iterator",
+			records:      []Record{rec("a", "v2", 2), rec("a", "v1", 1), rec("b", "vb", 1)},
+			failIdx:      -1,
+			wantPrepared: true,
+			wantKey:      "b",
+			wantValue:    "vb",
+		},
+		{
+			name:         "propagates iterator error",
+			records:      []Record{rec("a", "v2", 2), rec("a", "v1", 1)},
+			failIdx:      1,
+			wantPrepared: false,
+			wantErr:      "boom",
+		},
+	}
 
-		iter.prepare()
-		assert.True(t, iter.prepared)
-		assert.Equal(t, "b", string(iter.next.GetKey()))
-		assert.Equal(t, "vb", string(iter.next.GetValue()))
-	})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			it := &errIterator{records: tt.records, failIdx: tt.failIdx}
+			mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
+			assert.NoError(t, err)
 
-	t.Run("propagates iterator error", func(t *testing.T) {
-		it := &errIterator{
-			records: []Record{
-				rec("a", "v2", 2),
-				rec("a", "v1", 1),
-			},
-			failIdx: 1,
-		}
-		mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
-		assert.NoError(t, err)
+			iter := NewRangeIterator(mi)
+			iter.prepare()
+			_, err = iter.Next()
+			assert.NoError(t, err)
 
-		iter := NewRangeIterator(mi)
-		iter.prepare()
-		_, err = iter.Next()
-		assert.NoError(t, err)
-
-		iter.prepare()
-		assert.EqualError(t, iter.err, "boom")
-
-		iter.prepared = false
-		iter.prepare()
-		assert.False(t, iter.prepared)
-	})
+			iter.prepare()
+			if tt.wantErr != "" {
+				assert.EqualError(t, iter.err, tt.wantErr)
+				iter.prepared = false
+				iter.prepare()
+				assert.False(t, iter.prepared)
+			} else {
+				assert.Equal(t, tt.wantPrepared, iter.prepared)
+				assert.Equal(t, tt.wantKey, string(iter.next.GetKey()))
+				assert.Equal(t, tt.wantValue, string(iter.next.GetValue()))
+			}
+		})
+	}
 }

--- a/tablecache_slru_test.go
+++ b/tablecache_slru_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestShardGetEntryLockedRemovesClosedEntry covers the branch where a closed entry is pruned.
-func TestShardGetEntryLockedRemovesClosedEntry(t *testing.T) {
+// TestShardGetEntryLocked_RemovesClosedEntry covers the branch where a closed entry is pruned.
+func TestShardGetEntryLocked_RemovesClosedEntry(t *testing.T) {
 	parent := &tableCache{}
 	s := &shard{
 		items:  make(map[tableKey]*entry),
@@ -42,8 +42,8 @@ func TestShardGetEntryLockedRemovesClosedEntry(t *testing.T) {
 	require.False(t, ok)
 }
 
-// TestPromoteOnHitDemoteAndBreak ensures demotion and the break path when protected list is empty.
-func TestPromoteOnHitDemoteAndBreak(t *testing.T) {
+// TestPromoteOnHit_DemoteAndBreak ensures demotion and the break path when protected list is empty.
+func TestPromoteOnHit_DemoteAndBreak(t *testing.T) {
 	s := &shard{
 		items:        make(map[tableKey]*entry),
 		protCapBytes: 0,
@@ -68,8 +68,8 @@ func TestPromoteOnHitDemoteAndBreak(t *testing.T) {
 	require.EqualValues(t, 1, s.protBytes)
 }
 
-// TestChooseVictimFromProtectedSkipsPinned covers iteration over protected list.
-func TestChooseVictimFromProtectedSkipsPinned(t *testing.T) {
+// TestChooseVictimFromProtected_SkipsPinned covers iteration over protected list.
+func TestChooseVictimFromProtected_SkipsPinned(t *testing.T) {
 	s := &shard{}
 	eUnpinned := &entry{key: tableKey{FileNum: 1}, entry: &tableCacheEntry{}, seg: segProtected}
 	eUnpinned.elem = s.prot.PushBack(eUnpinned)
@@ -80,8 +80,8 @@ func TestChooseVictimFromProtectedSkipsPinned(t *testing.T) {
 	require.Equal(t, eUnpinned, victim)
 }
 
-// TestEvictOrDemoteLockedDemotesTail verifies demotion when protected exceeds cap.
-func TestEvictOrDemoteLockedDemotesTail(t *testing.T) {
+// TestEvictOrDemoteLocked_DemotesTail verifies demotion when protected exceeds cap.
+func TestEvictOrDemoteLocked_DemotesTail(t *testing.T) {
 	parent := &tableCache{}
 	s := &shard{
 		items:        make(map[tableKey]*entry),
@@ -111,8 +111,8 @@ func TestEvictOrDemoteLockedDemotesTail(t *testing.T) {
 	require.EqualValues(t, e2.entry.actualBytes, s.probBytes)
 }
 
-// TestEvictOrDemoteLockedBreakOnEmptyProtected exercises the break when protected list is empty.
-func TestEvictOrDemoteLockedBreakOnEmptyProtected(t *testing.T) {
+// TestEvictOrDemoteLocked_BreakOnEmptyProtected exercises the break when protected list is empty.
+func TestEvictOrDemoteLocked_BreakOnEmptyProtected(t *testing.T) {
 	s := &shard{
 		protCapBytes: 0,
 		protBytes:    1,
@@ -128,8 +128,8 @@ func TestEvictOrDemoteLockedBreakOnEmptyProtected(t *testing.T) {
 	require.Equal(t, 0, s.prot.Len())
 }
 
-// TestEvictOrDemoteLockedDropsRecentWhenNoVictim ensures recent entry is dropped when all are pinned.
-func TestEvictOrDemoteLockedDropsRecentWhenNoVictim(t *testing.T) {
+// TestEvictOrDemoteLocked_DropsRecentWhenNoVictim ensures recent entry is dropped when all are pinned.
+func TestEvictOrDemoteLocked_DropsRecentWhenNoVictim(t *testing.T) {
 	parent := &tableCache{}
 	recentEntry := &tableCacheEntry{
 		Table:       &SStable{},


### PR DESCRIPTION
## Summary
- rename range iterator and table cache tests to follow Test<Subject>_<Behavior> convention
- convert RangeIterator.Prepare checks into table-driven subtests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c63b1aa9208325a4769c4f8c5ea848