### PR TITLE
test: adopt table-driven unit tests

### DIFF
--- a/comparable_test.go
+++ b/comparable_test.go
@@ -22,7 +22,7 @@ func (c customCmpType) Compare(other any) int {
 }
 
 //nolint:gocognit,funlen,gocyclo
-func TestComparable(t *testing.T) {
+func TestComparable_Compare(t *testing.T) {
 	t.Run("Int", func(t *testing.T) {
 		tests := []struct {
 			a, b     int

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -27,14 +27,23 @@ func TestRindb_Init(t *testing.T) {
 func TestRindb_Put(t *testing.T) {
 	rin, cleanup := initRinDBWithCleanup(t, testOptions()...)
 	defer cleanup()
-	t.Run("BasicPut", func(t *testing.T) {
-		err := rin.Put(context.Background(), Bytes("key"), Bytes("value"))
-		assert.NoError(t, err)
-	})
-	t.Run("Tombstone", func(t *testing.T) {
-		err := rin.Put(context.Background(), Bytes("rm-key"), nil)
-		assert.NoError(t, err)
-	})
+
+	cases := []struct {
+		name  string
+		key   Bytes
+		value Bytes
+	}{
+		{name: "stores value", key: Bytes("key"), value: Bytes("value")},
+		{name: "stores tombstone", key: Bytes("rm-key"), value: nil},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := rin.Put(context.Background(), tt.key, tt.value)
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestNoDeadlockConcurrentPutAndCompaction(t *testing.T) {

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSStable tests the SStable functionality.
-func TestSStable(t *testing.T) {
+// TestSSTable_BasicOperations tests the SStable functionality.
+func TestSSTable_BasicOperations(t *testing.T) {
 	cfg := testConfig()
 	t.Run("FlushEmptyMemtable", func(t *testing.T) {
 		defer func() {


### PR DESCRIPTION
## Summary
- rename Comparable and SSTable tests to follow `Test<Subject>_<Behavior>`
- refactor Rindb Put test into table-driven subtests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c659c1f9b4832590c659d353943d18