### PR TITLE
docs: outline diffharness iterator test plan

### DIFF
--- a/docs/dev/00/diffharness_iterator/overall_plan.md
+++ b/docs/dev/00/diffharness_iterator/overall_plan.md
@@ -43,7 +43,10 @@ Ensure iterator walk reverses to the original sequence through a dedicated test.
 func TestHarness_RangeIteratorPrev(t *testing.T) {
     ctx := context.Background()
     h := newTestHarness(t)
-    it, _ := h.My.(*RinDBEngine).IterRange(ctx, []byte("a"), []byte("z"), 0)
+    it, err := h.My.(*RinDBEngine).IterRange(ctx, []byte("a"), []byte("z"), 0)
+    if err != nil {
+        t.Fatal(err)
+    }
     // collect forward then backward results and compare
 }
 ```

--- a/docs/dev/00/diffharness_iterator/overall_plan.md
+++ b/docs/dev/00/diffharness_iterator/overall_plan.md
@@ -22,8 +22,14 @@ func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg C
     if !ok || h.Ref == nil { return nil }
     lo, hi := randKey(r, cfg.KeyLen), randKey(r, cfg.KeyLen)
     snap := pickSnapshot(r, h.Seq, h.Snapshots, cfg.SnapshotReuseEvery)
-    want, _ := h.Ref.RangeWithSeq(lo, hi, snap, cfg.RangeMax)
-    it, _ := re.IterRange(ctx, lo, hi, snap)
+    want, err := h.Ref.RangeWithSeq(lo, hi, snap, cfg.RangeMax)
+    if err != nil {
+        return err
+    }
+    it, err := re.IterRange(ctx, lo, hi, snap)
+    if err != nil {
+        return err
+    }
     defer it.Close()
     // randomly call it.Next() or it.Prev() and compare with `want`
     return nil

--- a/docs/dev/00/diffharness_iterator/overall_plan.md
+++ b/docs/dev/00/diffharness_iterator/overall_plan.md
@@ -1,0 +1,50 @@
+# Diffharness iterator tests plan
+
+## 1. Expose iterator helper in `RinDBEngine`
+Enable diffharness invariants to drive raw iterators by wrapping `IRange` in a helper.
+```go
+func (e *RinDBEngine) IterRange(ctx context.Context, lo, hi []byte, snap uint64) (*rindb.RangeIterator, error) {
+    return e.db.IRange(ctx, rindb.Bytes(lo), rindb.Bytes(hi), snap)
+}
+```
+
+## 2. Add invariant for alternating `Next`/`Prev`
+Validate bidirectional iteration by comparing a random walk against the oracle sequence.
+```go
+var defaultInvariants = []Invariant{
+    checkMonotonicReads,
+    checkRangeConcat,
+    checkRangeIterNextPrev,
+}
+
+func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg Cfg) error {
+    re, ok := h.My.(*RinDBEngine)
+    if !ok || h.Ref == nil { return nil }
+    lo, hi := randKey(r, cfg.KeyLen), randKey(r, cfg.KeyLen)
+    snap := pickSnapshot(r, h.Seq, h.Snapshots, cfg.SnapshotReuseEvery)
+    want, _ := h.Ref.RangeWithSeq(lo, hi, snap, cfg.RangeMax)
+    it, _ := re.IterRange(ctx, lo, hi, snap)
+    defer it.Close()
+    // randomly call it.Next() or it.Prev() and compare with `want`
+    return nil
+}
+```
+Detailed plan: see `step_2_range_iterator_invariant_plan.md`.
+
+## 3. Add harness test verifying reverse iteration
+Ensure iterator walk reverses to the original sequence through a dedicated test.
+```go
+func TestHarness_RangeIteratorPrev(t *testing.T) {
+    ctx := context.Background()
+    h := newTestHarness(t)
+    it, _ := h.My.(*RinDBEngine).IterRange(ctx, []byte("a"), []byte("z"), 0)
+    // collect forward then backward results and compare
+}
+```
+
+### Complexity & further planning
+| Step | Complexity (1-10) | Dedicated plan? |
+|------|-------------------|-----------------|
+| 1    | 3                 | No              |
+| 2    | 8                 | Yes             |
+| 3    | 5                 | No              |

--- a/docs/dev/00/diffharness_iterator/step_2_range_iterator_invariant_plan.md
+++ b/docs/dev/00/diffharness_iterator/step_2_range_iterator_invariant_plan.md
@@ -1,0 +1,77 @@
+# Step 2 plan: Range iterator Next/Prev invariant
+
+## Goal
+Validate bidirectional iteration by comparing a random walk of `Next`/`Prev` calls against an oracle sequence produced by SQLite.
+
+## Steps
+1. Gather the full key/value slice from SQLite via `RangeWithSeq` for `[lo, hi)` at a chosen snapshot.
+   - This provides the authoritative ordering for both forward and reverse walks.
+2. Acquire the `RangeIterator` using `IterRange` and ensure it is closed after the walk.
+   - The helper bypasses the Engine interface so invariants can drive raw iterators.
+3. Execute a bounded number of random `Next` or `Prev` calls, updating an index over the oracle slice.
+   - Mix directions to surface cursor state bugs and boundary handling.
+4. After each call, compare returned records and handle `EOI` when the index crosses slice boundaries.
+   - Report mismatches immediately to preserve debug context.
+5. Start the walk at index `0` to trigger edge cases such as `Prev` before any `Next` and direction changes at range limits.
+
+## Implementation sketch
+The invariant mirrors the index into the oracle slice and validates each iterator step.
+
+```go
+func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg Cfg) error {
+    re := h.My.(*RinDBEngine)
+    lo, hi := randKey(r, cfg.KeyLen), randKey(r, cfg.KeyLen)
+    snap := pickSnapshot(r, h.Seq, h.Snapshots, cfg.SnapshotReuseEvery)
+
+    want, err := h.Ref.RangeWithSeq(lo, hi, snap, cfg.RangeMax)
+    if err != nil {
+        return err
+    }
+
+    it, err := re.IterRange(ctx, lo, hi, snap)
+    if err != nil {
+        return err
+    }
+    defer it.Close()
+
+    idx := 0
+    for step := 0; step < cfg.IterWalk; step++ {
+        if r.Intn(2) == 0 {
+            rec, err := it.Next()
+            if idx >= len(want) {
+                if !errors.Is(err, EOI) {
+                    return fmt.Errorf("expected EOI")
+                }
+                continue
+            }
+            if err != nil {
+                return err
+            }
+            if !bytes.Equal(rec.GetKey(), want[idx].Key) {
+                return fmt.Errorf("key mismatch")
+            }
+            idx++
+        } else {
+            rec, err := it.Prev()
+            if idx <= 0 {
+                if !errors.Is(err, EOI) {
+                    return fmt.Errorf("expected EOI")
+                }
+                continue
+            }
+            idx--
+            if err != nil {
+                return err
+            }
+            if !bytes.Equal(rec.GetKey(), want[idx].Key) {
+                return fmt.Errorf("key mismatch")
+            }
+        }
+    }
+    return nil
+}
+```
+
+## Notes
+- `cfg.IterWalk` controls walk length and should be small to avoid lengthy invariant checks.
+- Using index arithmetic allows forward and reverse comparison without needing a reverse oracle iterator.

--- a/docs/dev/00/diffharness_iterator/step_2_range_iterator_invariant_plan.md
+++ b/docs/dev/00/diffharness_iterator/step_2_range_iterator_invariant_plan.md
@@ -62,10 +62,10 @@ func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg C
                 }
                 continue
             }
-            idx--
             if err != nil {
                 return err
             }
+            idx--
             if !bytes.Equal(rec.GetKey(), want[idx].Key) {
                 return fmt.Errorf("key mismatch")
             }

--- a/docs/dev/00/diffharness_iterator/step_2_range_iterator_invariant_plan.md
+++ b/docs/dev/00/diffharness_iterator/step_2_range_iterator_invariant_plan.md
@@ -19,7 +19,10 @@ The invariant mirrors the index into the oracle slice and validates each iterato
 
 ```go
 func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg Cfg) error {
-    re := h.My.(*RinDBEngine)
+    re, ok := h.My.(*RinDBEngine)
+    if !ok || h.Ref == nil {
+        return nil
+    }
     lo, hi := randKey(r, cfg.KeyLen), randKey(r, cfg.KeyLen)
     snap := pickSnapshot(r, h.Seq, h.Snapshots, cfg.SnapshotReuseEvery)
 


### PR DESCRIPTION
## Summary
- draft plan for diffharness iterator tests covering Next/Prev
- rate complexity and flag step needing deeper plan
- add detailed plan for range iterator invariant with random Next/Prev walk

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c6943c84f4832581d29984dc7c9bb0