### PR TITLE
docs: refine diffharness iterator plan

### DIFF
--- a/docs/dev/00/diffharness_iterator/overall_plan.md
+++ b/docs/dev/00/diffharness_iterator/overall_plan.md
@@ -18,8 +18,11 @@ type Cfg struct {
 ```
 
 ## 3. Implement `checkRangeIterNextPrev` invariant
-Alternate `Next`/`Prev` calls against an oracle slice.
-Detailed plan: `step_3_range_iterator_invariant_plan.md`.
+Randomly alternate `Next`/`Prev` against an oracle slice while
+respecting iterator bounds. Skip when `h.Ref == nil`, `cfg.RangeMax <= 0`,
+or `cfg.IterWalk <= 0`. Resample `hi` until `lo < hi` (exclusive) and use
+`max(cfg.RangeMax, cfg.IterWalk)` to cap the oracle slice. Detailed plan:
+`step_3_range_iterator_invariant_plan.md`.
 
 ## 4. Add `TestHarness_RangeIteratorPrev`
 Ensure walking forward then backward yields the original sequence.
@@ -27,9 +30,30 @@ Ensure walking forward then backward yields the original sequence.
 func TestHarness_RangeIteratorPrev(t *testing.T) {
     it, err := h.My.IterRange(ctx, []byte("a"), []byte("z"), h.Snap)
     require.NoError(t, err)
-    forward := collectNext(it, 100)
-    reverse := walkPrev(it, len(forward))
-    require.Equal(t, reverseSlice(forward), reverse)
+
+    var forward [][]byte
+    for step := 0; step < 100; step++ {
+        rec, err := it.Next()
+        if errors.Is(err, rindb.EOI) {
+            break
+        }
+        require.NoError(t, err)
+        forward = append(forward, slices.Clone(rec.GetKey()))
+    }
+
+    var backward [][]byte
+    for step := 0; step < len(forward); step++ {
+        rec, err := it.Prev()
+        if errors.Is(err, rindb.EOI) {
+            break
+        }
+        require.NoError(t, err)
+        backward = append(backward, slices.Clone(rec.GetKey()))
+    }
+
+    slices.Reverse(forward)
+    require.Equal(t, forward, backward)
+    require.NoError(t, it.Close())
 }
 ```
 

--- a/docs/dev/00/diffharness_iterator/step_3_range_iterator_invariant_plan.md
+++ b/docs/dev/00/diffharness_iterator/step_3_range_iterator_invariant_plan.md
@@ -2,14 +2,15 @@
 
 ## Goal
 Validate bidirectional iteration by comparing a random walk of `Next`/`Prev` calls against an oracle slice from SQLite.
+Skip when `h.Ref == nil`, `cfg.RangeMax <= 0`, or `cfg.IterWalk <= 0`.
 
 ## Steps
-1. Sample `lo` and `hi`; resample `hi` until `lo < hi` to avoid empty ranges.
-2. Collect the authoritative slice via `RangeWithSeq(lo, hi, snap, cfg.RangeMax)`.
-3. Acquire the `RangeIterator` through the `IterRange` helper and ensure it is closed.
-4. Walk the iterator up to `cfg.IterWalk` steps, randomly choosing `Next` or `Prev`.
+1. Sample `lo`/`hi`; resample `hi` until `lo < hi`. `hi` is exclusive.
+2. Fetch an oracle slice with limit `max(cfg.RangeMax, cfg.IterWalk)` to avoid early `EOI`.
+3. Acquire the `RangeIterator` through `IterRange` and ensure it is closed.
+4. Walk up to `cfg.IterWalk` steps, randomly choosing `Next` or `Prev`.
 5. Mirror the position within the oracle slice and compare keys/values after each move.
-6. Handle boundary conditions by expecting `EOI` when stepping past the slice edges.
+6. Break after two consecutive `EOI` responses to avoid spinning at the edges.
 
 ## Implementation sketch
 The invariant uses the `IteratorEngine` interface to obtain the raw iterator and mirrors an index into the oracle slice.
@@ -17,16 +18,18 @@ The invariant uses the `IteratorEngine` interface to obtain the raw iterator and
 ```go
 func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg Cfg) error {
     eng, ok := h.My.(IteratorEngine)
-    if !ok || h.Ref == nil {
+    if !ok || h.Ref == nil || cfg.RangeMax <= 0 || cfg.IterWalk <= 0 {
         return nil
     }
+
     lo, hi := randKey(r, cfg.KeyLen), randKey(r, cfg.KeyLen)
     for bytes.Compare(hi, lo) <= 0 {
         hi = randKey(r, cfg.KeyLen)
     }
     snap := pickSnapshot(r, h.Seq, h.Snapshots, cfg.SnapshotReuseEvery)
 
-    want, err := h.Ref.RangeWithSeq(lo, hi, snap, cfg.RangeMax)
+    limit := max(cfg.RangeMax, cfg.IterWalk)
+    want, err := h.Ref.RangeWithSeq(lo, hi, snap, limit)
     if err != nil {
         return err
     }
@@ -37,30 +40,34 @@ func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg C
     }
     defer it.Close()
 
-    idx := 0
-    for step := 0; step < cfg.IterWalk; step++ {
+    idx, eoi := 0, 0
+    for step := 0; step < cfg.IterWalk && eoi < 2; step++ {
         if r.Intn(2) == 0 {
             rec, err := it.Next()
             if idx >= len(want) {
-                if !errors.Is(err, EOI) { return fmt.Errorf("expected EOI") }
+                if !errors.Is(err, rindb.EOI) { return fmt.Errorf("expected EOI") }
+                eoi++
                 continue
             }
             if err != nil { return err }
-if !bytes.Equal(rec.GetKey(), want[idx].K) || !bytes.Equal(rec.GetValue(), want[idx].V) {
-    return fmt.Errorf("Next() mismatch at index %d: got K=%q, want K=%q", idx, rec.GetKey(), want[idx].K)
-}
+            if !bytes.Equal(rec.GetKey(), want[idx].K) || !bytes.Equal(rec.GetValue(), want[idx].V) {
+                return fmt.Errorf("Next mismatch at %d", idx)
+            }
             idx++
+            eoi = 0
         } else {
             rec, err := it.Prev()
             if idx <= 0 {
-                if !errors.Is(err, EOI) { return fmt.Errorf("expected EOI") }
+                if !errors.Is(err, rindb.EOI) { return fmt.Errorf("expected EOI") }
+                eoi++
                 continue
             }
             if err != nil { return err }
             idx--
-if !bytes.Equal(rec.GetKey(), want[idx].K) || !bytes.Equal(rec.GetValue(), want[idx].V) {
-    return fmt.Errorf("Prev() mismatch at index %d: got K=%q, want K=%q", idx, rec.GetKey(), want[idx].K)
-}
+            if !bytes.Equal(rec.GetKey(), want[idx].K) || !bytes.Equal(rec.GetValue(), want[idx].V) {
+                return fmt.Errorf("Prev mismatch at %d", idx)
+            }
+            eoi = 0
         }
     }
     return nil

--- a/docs/dev/00/diffharness_iterator/step_6_iterator_engine_interface_plan.md
+++ b/docs/dev/00/diffharness_iterator/step_6_iterator_engine_interface_plan.md
@@ -6,9 +6,9 @@ Decouple invariants from the concrete `RinDBEngine` by introducing an `IteratorE
 ## Steps
 1. Define `IteratorEngine` in `diffharness/engine.go` with an `IterRange` method.
 2. Implement the interface in `RinDBEngine` by forwarding to `IRange`.
-3. Update invariants to assert `h.My` satisfies `IteratorEngine` instead of casting to `*RinDBEngine`.
-4. Adjust tests or helpers that rely on iterator access to use the interface.
-5. Document the interface to clarify it bypasses the top-level `Engine` abstraction.
+3. Update invariants and harness tests to type-assert `h.My` to `IteratorEngine`.
+4. Adjust any helpers to accept the interface and close iterators after use.
+5. Document that the interface bypasses the higher-level `Engine` abstraction.
 
 ## Implementation sketch
 
@@ -26,8 +26,13 @@ func (e *RinDBEngine) IterRange(ctx context.Context, lo, hi []byte, snap uint64)
 // diffharness/invariants.go
 eng, ok := h.My.(IteratorEngine)
 if !ok {
-    return nil // Skip invariant if not supported
+    return nil // skip if engine lacks IterRange
 }
+
+// diffharness/harness_test.go
+it, err := h.My.IterRange(ctx, []byte("a"), []byte("z"), snap)
+require.NoError(t, err)
+defer it.Close()
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary
- clarify skip conditions and range handling for the iterator invariant
- expand harness test sketch with explicit Next/Prev loops and iterator cleanup
- document IteratorEngine usage across invariants and tests

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c6d73b68448325a037f404de091ec8