### PR TITLE
feat: expose iterator helper, config limit, and iterator interface

### DIFF
--- a/diffharness/engine.go
+++ b/diffharness/engine.go
@@ -1,6 +1,10 @@
 package diffharness
 
-import "context"
+import (
+	"context"
+
+	rindb "github.com/metailurini/rindb"
+)
 
 // KV represents a key/value pair used by range operations.
 type KV struct{ K, V []byte }
@@ -17,4 +21,11 @@ type Engine interface {
 	NewSnapshot(ctx context.Context) (uint64, error)
 	ReleaseSnapshot(ctx context.Context, seq uint64) error
 	Close() error
+}
+
+// IteratorEngine exposes raw range iterators, bypassing the higher-level
+// Engine abstraction. Engines implementing this interface allow invariants to
+// drive iterators directly.
+type IteratorEngine interface {
+	IterRange(ctx context.Context, lo, hi []byte, snap uint64) (*rindb.RangeIterator, error)
 }

--- a/diffharness/harness_test.go
+++ b/diffharness/harness_test.go
@@ -3,10 +3,12 @@ package diffharness
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -52,6 +54,54 @@ func TestHarnessLogsAndSnapshots(t *testing.T) {
 	require.Equal(t, uint64(0), first.Seq)
 	require.Equal(t, OpPut, first.Op.Kind)
 	require.Equal(t, PhasePrepared, first.Phase)
+}
+
+func TestHarness_RangeIteratorPrev(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(filepath.Join(dir, "db")))
+	require.NoError(t, err)
+	eng := NewRinDBEngine(db)
+	logPath := filepath.Join(dir, "log.jsonl")
+	h, err := NewHarness(eng, nil, 1, logPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close(); _ = eng.Close() })
+
+	_, err = h.Step(ctx, PutOp{K: []byte("a"), V: []byte("1")})
+	require.NoError(t, err)
+	_, err = h.Step(ctx, PutOp{K: []byte("b"), V: []byte("2")})
+	require.NoError(t, err)
+	_, err = h.Step(ctx, PutOp{K: []byte("c"), V: []byte("3")})
+	require.NoError(t, err)
+
+	iterEng, ok := h.My.(IteratorEngine)
+	require.True(t, ok)
+	it, err := iterEng.IterRange(ctx, []byte("a"), []byte("z"), h.Seq)
+	require.NoError(t, err)
+	defer it.Close()
+
+	var forward [][]byte
+	for {
+		rec, err := it.Next()
+		if errors.Is(err, rindb.EOI) {
+			break
+		}
+		require.NoError(t, err)
+		forward = append(forward, slices.Clone(rec.GetKey()))
+	}
+
+	var backward [][]byte
+	for range forward {
+		rec, err := it.Prev()
+		if errors.Is(err, rindb.EOI) {
+			break
+		}
+		require.NoError(t, err)
+		backward = append(backward, slices.Clone(rec.GetKey()))
+	}
+
+	slices.Reverse(forward)
+	require.Equal(t, forward, backward)
 }
 
 // sqliteEngine adapts SQLiteOracle to the Engine interface for testing.

--- a/diffharness/invariants.go
+++ b/diffharness/invariants.go
@@ -192,10 +192,3 @@ func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg C
 	}
 	return nil
 }
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/diffharness/invariants.go
+++ b/diffharness/invariants.go
@@ -3,8 +3,11 @@ package diffharness
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
+
+	rindb "github.com/metailurini/rindb"
 )
 
 // Invariant checks harness state after each operation.
@@ -17,6 +20,7 @@ func (h *Harness) WithInvariants(invs []Invariant) { h.invariants = invs }
 var defaultInvariants = []Invariant{
 	checkMonotonicReads,
 	checkRangeConcat,
+	checkRangeIterNextPrev,
 }
 
 func compareKVLists(a, b []KV) error {
@@ -121,4 +125,77 @@ func checkRangeConcat(ctx context.Context, h *Harness, r *rand.Rand, cfg Cfg) er
 		return fmt.Errorf("range right mismatch: mid=%q hi=%q snap=%d: %w", mid, hi, snap, err)
 	}
 	return nil
+}
+
+func checkRangeIterNextPrev(ctx context.Context, h *Harness, r *rand.Rand, cfg Cfg) error {
+	eng, ok := h.My.(IteratorEngine)
+	if !ok || h.Ref == nil || cfg.RangeMax <= 0 || cfg.IterWalk <= 0 {
+		return nil
+	}
+
+	lo := randKey(r, cfg.KeyLen)
+	hi := randKey(r, cfg.KeyLen)
+	for bytes.Compare(hi, lo) <= 0 {
+		hi = randKey(r, cfg.KeyLen)
+	}
+	snap := pickSnapshot(r, h.Seq, h.Snapshots, cfg.SnapshotReuseEvery)
+
+	limit := max(cfg.RangeMax, cfg.IterWalk)
+	want, err := h.Ref.RangeWithSeq(lo, hi, snap, limit)
+	if err != nil {
+		return err
+	}
+
+	it, err := eng.IterRange(ctx, lo, hi, snap)
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+
+	idx, eoi := 0, 0
+	for step := 0; step < cfg.IterWalk && eoi < 2; step++ {
+		if r.Intn(2) == 0 {
+			rec, err := it.Next()
+			if idx >= len(want) {
+				if !errors.Is(err, rindb.EOI) {
+					return fmt.Errorf("expected EOI")
+				}
+				eoi++
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if !bytes.Equal(rec.GetKey(), want[idx].K) || !bytes.Equal(rec.GetValue(), want[idx].V) {
+				return fmt.Errorf("Next mismatch at %d", idx)
+			}
+			idx++
+			eoi = 0
+		} else {
+			rec, err := it.Prev()
+			if idx <= 0 {
+				if !errors.Is(err, rindb.EOI) {
+					return fmt.Errorf("expected EOI")
+				}
+				eoi++
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			idx--
+			if !bytes.Equal(rec.GetKey(), want[idx].K) || !bytes.Equal(rec.GetValue(), want[idx].V) {
+				return fmt.Errorf("Prev mismatch at %d", idx)
+			}
+			eoi = 0
+		}
+	}
+	return nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/diffharness/invariants_test.go
+++ b/diffharness/invariants_test.go
@@ -1,0 +1,37 @@
+package diffharness
+
+import (
+	"context"
+	"math/rand"
+	"path/filepath"
+	"testing"
+
+	rindb "github.com/metailurini/rindb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRangeIterNextPrev(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	ref, err := OpenSQLiteOracle(filepath.Join(dir, "ref.db"))
+	require.NoError(t, err)
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(filepath.Join(dir, "db")))
+	require.NoError(t, err)
+	eng := NewRinDBEngine(db)
+	logPath := filepath.Join(dir, "log.jsonl")
+	h, err := NewHarness(eng, ref, 1, logPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close(); _ = eng.Close(); _ = ref.Close() })
+
+	r := rand.New(rand.NewSource(1))
+	for i := 0; i < 5; i++ {
+		k := randKey(r, 8)
+		v := randValue(r, 8)
+		_, err = h.Step(ctx, PutOp{K: k, V: v})
+		require.NoError(t, err)
+	}
+
+	cfg := Cfg{KeyLen: 8, RangeMax: 10, IterWalk: 10}
+	r2 := rand.New(rand.NewSource(2))
+	require.NoError(t, checkRangeIterNextPrev(ctx, h, r2, cfg))
+}

--- a/diffharness/rindb_engine.go
+++ b/diffharness/rindb_engine.go
@@ -13,6 +13,9 @@ type RinDBEngine struct {
 	snaps map[uint64]*rindb.Snapshot
 }
 
+var _ Engine = (*RinDBEngine)(nil)
+var _ IteratorEngine = (*RinDBEngine)(nil)
+
 // NewRinDBEngine wraps a RinDB instance as an Engine.
 func NewRinDBEngine(db *rindb.Rindb) *RinDBEngine {
 	return &RinDBEngine{db: db, snaps: make(map[uint64]*rindb.Snapshot)}
@@ -59,6 +62,11 @@ func (e *RinDBEngine) Range(ctx context.Context, lo, hi []byte, snapshot uint64,
 		res = append(res, KV{K: append([]byte(nil), []byte(rec.GetKey())...), V: append([]byte(nil), []byte(rec.GetValue())...)})
 	}
 	return res, nil
+}
+
+// IterRange exposes the raw RangeIterator without additional filtering.
+func (e *RinDBEngine) IterRange(ctx context.Context, lo, hi []byte, snap uint64) (*rindb.RangeIterator, error) {
+	return e.db.IRange(ctx, rindb.Bytes(lo), rindb.Bytes(hi), snap)
 }
 
 func (e *RinDBEngine) NewSnapshot(ctx context.Context) (uint64, error) {

--- a/diffharness/rindb_engine_test.go
+++ b/diffharness/rindb_engine_test.go
@@ -1,0 +1,39 @@
+package diffharness
+
+import (
+	"context"
+	"testing"
+
+	rindb "github.com/metailurini/rindb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRinDBEngine_IterRange(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := rindb.InitRinDB(ctx, rindb.WithDatabaseDir(dir))
+	require.NoError(t, err)
+	eng := NewRinDBEngine(db)
+	t.Cleanup(func() { _ = eng.Close() })
+
+	require.NoError(t, eng.Put(ctx, []byte("a"), []byte("1")))
+	require.NoError(t, eng.Put(ctx, []byte("b"), []byte("2")))
+	require.NoError(t, eng.Put(ctx, []byte("c"), []byte("3")))
+
+	snap, err := eng.NewSnapshot(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = eng.ReleaseSnapshot(ctx, snap) })
+
+	it, err := eng.IterRange(ctx, []byte("a"), []byte("d"), snap)
+	require.NoError(t, err)
+	defer it.Close()
+
+	var got [][]byte
+	for it.HasNext() {
+		rec, err := it.Next()
+		require.NoError(t, err)
+		got = append(got, append([]byte(nil), []byte(rec.GetKey())...))
+	}
+
+	require.Equal(t, [][]byte{[]byte("a"), []byte("b"), []byte("c")}, got)
+}

--- a/diffharness/rindb_engine_test.go
+++ b/diffharness/rindb_engine_test.go
@@ -2,6 +2,7 @@ package diffharness
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	rindb "github.com/metailurini/rindb"
@@ -32,7 +33,7 @@ func TestRinDBEngine_IterRange(t *testing.T) {
 	for it.HasNext() {
 		rec, err := it.Next()
 		require.NoError(t, err)
-		got = append(got, append([]byte(nil), []byte(rec.GetKey())...))
+		got = append(got, slices.Clone([]byte(rec.GetKey())))
 	}
 
 	require.Equal(t, [][]byte{[]byte("a"), []byte("b"), []byte("c")}, got)

--- a/diffharness/types.go
+++ b/diffharness/types.go
@@ -56,6 +56,7 @@ type Cfg struct {
 	ValLenMin int
 	ValLenMax int
 	RangeMax  int
+	IterWalk  int // max elements to walk when testing iterators
 	Weights   map[OpKind]int
 
 	CrashEvery         int


### PR DESCRIPTION
## Summary
- expose `IterRange` on RinDBEngine for raw iterator access
- add `IterWalk` field to diffharness config
- implement `checkRangeIterNextPrev` invariant with `hi` resampling and random walks
- cover iterator helper and invariant with tests
- add harness test to verify reversing iterators yields the original sequence
- introduce `IteratorEngine` interface and adjust invariants and tests to type-assert it

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`
- `cd diffharness && go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c6db6d08a48325aacc95c249ddf751