### PR TITLE
feat: add iter walk flag to diffharness

### DIFF
--- a/diffharness/cmd/main.go
+++ b/diffharness/cmd/main.go
@@ -29,6 +29,7 @@ func main() {
 	seed := flag.Int64("seed", time.Now().UnixNano(), "PRNG seed")
 	n := flag.Int("n", -1, "number of operations (-1 for infinite)")
 	logPath := flag.String("log", "repro.jsonl", "log file path")
+	iterWalk := flag.Int("iter-walk", 64, "max elements to walk when testing iterators")
 	crashEvery := flag.Int("crash-every", 0, "crash/recover every N ops")
 	telemetryEvery := flag.Int("telemetry-every", 0, "emit telemetry every N ops")
 	jaeger := flag.String("jaeger", "", "Jaeger OTLP gRPC endpoint (e.g., localhost:4317)")
@@ -62,7 +63,7 @@ func main() {
 				if runDir != "" {
 					runDir = filepath.Join(runDir, c.label)
 				}
-				if err := runOne(ctx, runDir, *seed, *n, *logPath+"-"+c.label, *crashEvery, *telemetryEvery, *jaeger, c.opts); err != nil {
+				if err := runOne(ctx, runDir, *seed, *n, *logPath+"-"+c.label, *iterWalk, *crashEvery, *telemetryEvery, *jaeger, c.opts); err != nil {
 					errCh <- fmt.Errorf("%s run failed: %w", c.label, err)
 				}
 			}()
@@ -82,13 +83,13 @@ func main() {
 		if runDir != "" {
 			runDir = filepath.Join(runDir, c.label)
 		}
-		if err := runOne(ctx, runDir, *seed, *n, *logPath+"-"+c.label, *crashEvery, *telemetryEvery, *jaeger, c.opts); err != nil {
+		if err := runOne(ctx, runDir, *seed, *n, *logPath+"-"+c.label, *iterWalk, *crashEvery, *telemetryEvery, *jaeger, c.opts); err != nil {
 			log.Fatalf("%s run failed: %v", c.label, err)
 		}
 	}
 }
 
-func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, crashEvery, telemetryEvery int, jaeger string, opts []rindb.Option) error {
+func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, iterWalk, crashEvery, telemetryEvery int, jaeger string, opts []rindb.Option) error {
 	cleanup := false
 	existed := false
 	if dir == "" {
@@ -160,6 +161,7 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 		ValLenMin: 10,
 		ValLenMax: 100,
 		RangeMax:  64,
+		IterWalk:  iterWalk,
 		Weights: map[diffharness.OpKind]int{
 			diffharness.OpPut:   5,
 			diffharness.OpDel:   1,

--- a/diffharness/cmd/main.go
+++ b/diffharness/cmd/main.go
@@ -16,6 +16,17 @@ import (
 	"github.com/metailurini/rindb/diffharness"
 )
 
+type runConfig struct {
+	seed           int64
+	n              int
+	logPath        string
+	iterWalk       int
+	crashEvery     int
+	telemetryEvery int
+	jaeger         string
+	opts           []rindb.Option
+}
+
 func main() {
 	go func() {
 		err := http.ListenAndServe("0.0.0.0:6060", nil)
@@ -63,7 +74,17 @@ func main() {
 				if runDir != "" {
 					runDir = filepath.Join(runDir, c.label)
 				}
-				if err := runOne(ctx, runDir, *seed, *n, *logPath+"-"+c.label, *iterWalk, *crashEvery, *telemetryEvery, *jaeger, c.opts); err != nil {
+				cfg := runConfig{
+					seed:           *seed,
+					n:              *n,
+					logPath:        *logPath + "-" + c.label,
+					iterWalk:       *iterWalk,
+					crashEvery:     *crashEvery,
+					telemetryEvery: *telemetryEvery,
+					jaeger:         *jaeger,
+					opts:           c.opts,
+				}
+				if err := runOne(ctx, runDir, cfg); err != nil {
 					errCh <- fmt.Errorf("%s run failed: %w", c.label, err)
 				}
 			}()
@@ -78,18 +99,30 @@ func main() {
 		return
 	}
 
+	baseCfg := runConfig{
+		seed:           *seed,
+		n:              *n,
+		logPath:        *logPath,
+		iterWalk:       *iterWalk,
+		crashEvery:     *crashEvery,
+		telemetryEvery: *telemetryEvery,
+		jaeger:         *jaeger,
+	}
 	for _, c := range configs {
 		runDir := *dir
 		if runDir != "" {
 			runDir = filepath.Join(runDir, c.label)
 		}
-		if err := runOne(ctx, runDir, *seed, *n, *logPath+"-"+c.label, *iterWalk, *crashEvery, *telemetryEvery, *jaeger, c.opts); err != nil {
+		cfg := baseCfg
+		cfg.logPath = baseCfg.logPath + "-" + c.label
+		cfg.opts = c.opts
+		if err := runOne(ctx, runDir, cfg); err != nil {
 			log.Fatalf("%s run failed: %v", c.label, err)
 		}
 	}
 }
 
-func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, iterWalk, crashEvery, telemetryEvery int, jaeger string, opts []rindb.Option) error {
+func runOne(ctx context.Context, dir string, runCfg runConfig) error {
 	cleanup := false
 	existed := false
 	if dir == "" {
@@ -112,6 +145,7 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 	if cleanup {
 		defer os.RemoveAll(dir)
 	}
+	logPath := runCfg.logPath
 	if dir != "" {
 		logPath = filepath.Join(dir, logPath)
 	}
@@ -121,14 +155,14 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 		rindb.WithDatabaseDir(dbDir),
 		rindb.WithCacheBytes(32 << 20), // 32MiB table cache budget
 	}
-	if jaeger != "" {
+	if runCfg.jaeger != "" {
 		baseOpts = append(baseOpts,
 			rindb.WithEnableTelemetry(true),
-			rindb.WithExporterEndpoint(jaeger),
+			rindb.WithExporterEndpoint(runCfg.jaeger),
 			rindb.WithExporterInsecure(true),
 		)
 	}
-	db, err := rindb.InitRinDB(ctx, append(baseOpts, opts...)...)
+	db, err := rindb.InitRinDB(ctx, append(baseOpts, runCfg.opts...)...)
 	if err != nil {
 		return err
 	}
@@ -145,7 +179,7 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 			}
 		}
 	}
-	h, err := diffharness.NewHarness(eng, ref, seed, logPath)
+	h, err := diffharness.NewHarness(eng, ref, runCfg.seed, logPath)
 	if err != nil {
 		return err
 	}
@@ -161,7 +195,7 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 		ValLenMin: 10,
 		ValLenMax: 100,
 		RangeMax:  64,
-		IterWalk:  iterWalk,
+		IterWalk:  runCfg.iterWalk,
 		Weights: map[diffharness.OpKind]int{
 			diffharness.OpPut:   5,
 			diffharness.OpDel:   1,
@@ -169,13 +203,13 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 			diffharness.OpRange: 1,
 			diffharness.OpSnap:  1,
 		},
-		CrashEvery:         crashEvery,
-		TelemetryEvery:     telemetryEvery,
+		CrashEvery:         runCfg.crashEvery,
+		TelemetryEvery:     runCfg.telemetryEvery,
 		MaxKnownKeys:       100,
 		SnapshotReuseEvery: 10,
 	}
 
-	if crashEvery > 0 {
+	if runCfg.crashEvery > 0 {
 		h.WithCrash(func(ops int) error {
 			if err := eng.Close(); err != nil {
 				return err
@@ -183,7 +217,7 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 			if err := ref.Close(); err != nil {
 				return err
 			}
-			db, err := rindb.InitRinDB(ctx, append(baseOpts, opts...)...)
+			db, err := rindb.InitRinDB(ctx, append(baseOpts, runCfg.opts...)...)
 			if err != nil {
 				return err
 			}
@@ -200,7 +234,7 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 		})
 	}
 
-	if telemetryEvery > 0 {
+	if runCfg.telemetryEvery > 0 {
 		start := time.Now()
 		lastOps := 0
 		h.WithTelemetry(func(seq uint64, ops int) {
@@ -212,8 +246,8 @@ func runOne(ctx context.Context, dir string, seed int64, n int, logPath string, 
 		})
 	}
 
-	if n < 0 {
+	if runCfg.n < 0 {
 		return h.RunForever(ctx, cfg)
 	}
-	return h.Run(ctx, cfg, n)
+	return h.Run(ctx, cfg, runCfg.n)
 }

--- a/diffharness/harness_test.go
+++ b/diffharness/harness_test.go
@@ -78,7 +78,6 @@ func TestHarness_RangeIteratorPrev(t *testing.T) {
 	require.True(t, ok)
 	it, err := iterEng.IterRange(ctx, []byte("a"), []byte("z"), h.Seq)
 	require.NoError(t, err)
-	defer it.Close()
 
 	var forward [][]byte
 	for {
@@ -102,6 +101,7 @@ func TestHarness_RangeIteratorPrev(t *testing.T) {
 
 	slices.Reverse(forward)
 	require.Equal(t, forward, backward)
+	require.NoError(t, it.Close())
 }
 
 // sqliteEngine adapts SQLiteOracle to the Engine interface for testing.

--- a/docs/dev/00/diffharness_iterator/overall_plan.md
+++ b/docs/dev/00/diffharness_iterator/overall_plan.md
@@ -9,7 +9,7 @@ func (e *RinDBEngine) IterRange(ctx context.Context, lo, hi []byte, snap uint64)
 ```
 
 ## 2. Extend `Cfg` with `IterWalk`
-Limit the number of iterator steps during invariants.
+Limit the number of iterator steps during invariants. The diffharness CLI exposes this via `--iter-walk`.
 ```go
 type Cfg struct {
     // ...existing fields...


### PR DESCRIPTION
## Summary
- allow configuring iterator walk via `--iter-walk`
- assert iterator close errors in `TestHarness_RangeIteratorPrev`
- document `--iter-walk` in iterator testing plan

## Testing
- `make check`
- `make test`
- `make test-integration-smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c74d12749c8325b7a156ae3a67245f