### PR TITLE
refactor: stage merging iterator movement

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -11,18 +11,18 @@ type pqItem struct {
 // records ordered by key and sequence number (descending) and supports
 // bidirectional traversal.
 type MergingIterator struct {
-    fwd     *PriorityQueue[pqItem]
-    rev     *PriorityQueue[pqItem]
-    cleanup func()
-    err     error
+	fwd     *PriorityQueue[pqItem]
+	rev     *PriorityQueue[pqItem]
+	cleanup func()
+	err     error
 
-    // prepared next state
-    nextPrepared bool
-    nextItem     pqItem
+	// prepared next state
+	nextPrepared bool
+	nextItem     pqItem
 
-    // prepared prev state
-    prevPrepared bool
-    prevItem     pqItem
+	// prepared prev state
+	prevPrepared bool
+	prevItem     pqItem
 }
 
 // NewMergingIterator constructs a MergingIterator over provided iterators.
@@ -64,168 +64,118 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func()) (*MergingI
 
 // HasNext implements Iterator[Record].
 func (m *MergingIterator) HasNext() bool {
-    // If already prepared, report success regardless of m.err.
-    if m.nextPrepared {
-        return true
-    }
-    if m.err != nil {
-        return false
-    }
-    if m.fwd.Len() == 0 {
-        return false
-    }
-    m.prepareNext()
-    return m.nextPrepared
+	if m.nextPrepared {
+		return true
+	}
+	if m.err != nil {
+		return false
+	}
+	if m.fwd.Len() == 0 {
+		return false
+	}
+	m.prepareNext()
+	return m.nextPrepared
 }
 
 // Next implements Iterator[Record].
 func (m *MergingIterator) Next() (Record, error) {
-    // If we have a prepared next item, consume it.
-    if m.nextPrepared {
-        m.nextPrepared = false
-        if m.err != nil || m.fwd.Len() == 0 {
-            var empty Record
-            if m.err != nil {
-                return empty, m.err
-            }
-            return empty, EOI
-        }
-        item := m.fwd.PopItem()
-        m.rev.PushItem(item)
-        if item.iter.HasNext() {
-            rec, err := item.iter.Next()
-            if err != nil {
-                if !errors.Is(err, EOI) {
-                    m.err = err
-                }
-            } else {
-                m.fwd.PushItem(pqItem{rec: rec, iter: item.iter})
-            }
-        }
-        return item.rec, nil
-    }
-
-    if m.err != nil || m.fwd.Len() == 0 {
-        var empty Record
-        if m.err != nil {
-            return empty, m.err
-        }
-        return empty, EOI
-    }
-
-    // Fallback legacy path: perform advancement inline.
-    item := m.fwd.PopItem()
-    m.rev.PushItem(item)
-    if item.iter.HasNext() {
-        rec, err := item.iter.Next()
-        if err != nil {
-            if !errors.Is(err, EOI) {
-                m.err = err
-            }
-        } else {
-            m.fwd.PushItem(pqItem{rec: rec, iter: item.iter})
-        }
-    }
-    return item.rec, nil
+	if !m.HasNext() {
+		var empty Record
+		if m.err != nil {
+			return empty, m.err
+		}
+		return empty, EOI
+	}
+	item := m.nextItem
+	m.nextPrepared = false
+	return item.rec, nil
 }
 
 // HasPrev implements Iterator[Record].
 func (m *MergingIterator) HasPrev() bool {
-    // If already prepared, report success regardless of m.err.
-    if m.prevPrepared {
-        return true
-    }
-    if m.err != nil {
-        return false
-    }
-    if m.rev.Len() == 0 {
-        return false
-    }
-    m.preparePrev()
-    return m.prevPrepared
+	if m.prevPrepared {
+		return true
+	}
+	if m.err != nil {
+		return false
+	}
+	if m.rev.Len() == 0 {
+		return false
+	}
+	m.preparePrev()
+	return m.prevPrepared
 }
 
 // Prev implements Iterator[Record].
 func (m *MergingIterator) Prev() (Record, error) {
-    // If we have a prepared prev item, consume it.
-    if m.prevPrepared {
-        m.prevPrepared = false
-        // Perform the legacy movement now to preserve semantics.
-        if m.err != nil || m.rev.Len() == 0 {
-            var empty Record
-            if m.err != nil {
-                return empty, m.err
-            }
-            return empty, EOI
-        }
-        curItem := m.rev.PopItem()
-        _, err := curItem.iter.Prev()
-        if err != nil {
-            if !errors.Is(err, EOI) {
-                m.err = err
-                return curItem.rec, err
-            }
-            // Align with range iterator expectations: return the record without EOI.
-            return curItem.rec, nil
-        }
-        m.fwd.PushItem(curItem)
-        return curItem.rec, nil
-    }
-
-    if m.err != nil || m.rev.Len() == 0 {
-        var empty Record
-        if m.err != nil {
-            return empty, m.err
-        }
-        return empty, EOI
-    }
-
-    // Fallback legacy path: perform backwards movement inline.
-    curItem := m.rev.PopItem()
-    _, err := curItem.iter.Prev()
-    if err != nil {
-        if !errors.Is(err, EOI) {
-            m.err = err
-            return curItem.rec, err
-        }
-        // Align with range iterator expectations: return the record without EOI.
-        return curItem.rec, nil
-    }
-
-    m.fwd.PushItem(curItem)
-    return curItem.rec, nil
+	if !m.HasPrev() {
+		var empty Record
+		if m.err != nil {
+			return empty, m.err
+		}
+		return empty, EOI
+	}
+	item := m.prevItem
+	m.prevPrepared = false
+	if m.err != nil {
+		return item.rec, m.err
+	}
+	return item.rec, nil
 }
 
 // prepareNext stages the next item so that HasNext is idempotent.
 func (m *MergingIterator) prepareNext() {
-    if m.nextPrepared {
-        return
-    }
-    // Switching direction: clear any pending prev preparation.
-    m.prevPrepared = false
+	if m.nextPrepared {
+		return
+	}
+	m.prevPrepared = false
 
-    if m.err != nil || m.fwd.Len() == 0 {
-        return
-    }
-    // Only stage by peeking; avoid mutating heaps until Next is called.
-    m.nextItem = m.fwd.PeekItem()
-    m.nextPrepared = true
+	if m.err != nil || m.fwd.Len() == 0 {
+		return
+	}
+
+	item := m.fwd.PopItem()
+	m.rev.PushItem(item)
+
+	if item.iter.HasNext() {
+		rec, err := item.iter.Next()
+		if err != nil {
+			if !errors.Is(err, EOI) {
+				m.err = err
+			}
+		} else {
+			m.fwd.PushItem(pqItem{rec: rec, iter: item.iter})
+		}
+	}
+
+	m.nextItem = item
+	m.nextPrepared = true
 }
 
 // preparePrev stages the previous item so that HasPrev is idempotent.
 func (m *MergingIterator) preparePrev() {
-    if m.prevPrepared {
-        return
-    }
-    // Switching direction: clear any pending next preparation.
-    m.nextPrepared = false
+	if m.prevPrepared {
+		return
+	}
+	m.nextPrepared = false
 
-    if m.err != nil || m.rev.Len() == 0 {
-        return
-    }
-    // Only stage by peeking; do not mutate heaps until Prev is called.
-    m.prevItem = m.rev.PeekItem()
-    m.prevPrepared = true
+	if m.err != nil || m.rev.Len() == 0 {
+		return
+	}
+
+	curItem := m.rev.PopItem()
+	_, err := curItem.iter.Prev()
+	switch {
+	case err == nil:
+		m.fwd.PushItem(curItem)
+	case errors.Is(err, EOI):
+		// Return the record without surfacing EOI.
+	default:
+		m.err = err
+	}
+
+	m.prevItem = curItem
+	m.prevPrepared = true
 }
 
 // Close releases any resources held by the iterator. It is safe to call

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -169,7 +169,10 @@ func (m *MergingIterator) preparePrev() {
 	case err == nil:
 		m.fwd.PushItem(curItem)
 	case errors.Is(err, EOI):
-		// Return the record without surfacing EOI.
+		// The iterator cannot step further back but still remains positioned on the
+		// current record. Requeue it so that subsequent Next calls can surface it
+		// again when rewinding from the beginning.
+		m.fwd.PushItem(curItem)
 	default:
 		m.err = err
 	}

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -166,12 +166,10 @@ func (m *MergingIterator) preparePrev() {
 	curItem := m.rev.PopItem()
 	_, err := curItem.iter.Prev()
 	switch {
-	case err == nil:
-		m.fwd.PushItem(curItem)
-	case errors.Is(err, EOI):
-		// The iterator cannot step further back but still remains positioned on the
-		// current record. Requeue it so that subsequent Next calls can surface it
-		// again when rewinding from the beginning.
+	case err == nil || errors.Is(err, EOI):
+		// If Prev() succeeds, the underlying iterator moved back. If it returns EOI,
+		// it's at the beginning. In both cases, the current item should be
+		// requeued so that subsequent Next calls can surface it again.
 		m.fwd.PushItem(curItem)
 	default:
 		m.err = err

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -250,3 +250,70 @@ func TestMergingIterator_ErrorPropagation(t *testing.T) {
 		})
 	}
 }
+
+func TestMergingIterator_PrepareNextNoopWhenPrepared(t *testing.T) {
+	iter := &errIterator{records: []Record{mkRec("a", "va", 1, TypeValue)}, failIdx: -1}
+	mi, err := NewMergingIterator([]Iterator[Record]{iter}, nil)
+	require.NoError(t, err)
+
+	require.True(t, mi.HasNext())
+
+	prepared := mi.nextItem
+	fwdLen := mi.fwd.Len()
+	revLen := mi.rev.Len()
+
+	mi.prepareNext()
+
+	assert.True(t, mi.nextPrepared)
+	assert.Equal(t, prepared, mi.nextItem)
+	assert.Equal(t, fwdLen, mi.fwd.Len())
+	assert.Equal(t, revLen, mi.rev.Len())
+}
+
+func TestMergingIterator_HasNextAfterIteratorError(t *testing.T) {
+	iter := &errIterator{
+		records: []Record{
+			mkRec("a", "v1", 1, TypeValue),
+			mkRec("b", "v2", 1, TypeValue),
+		},
+		failIdx: 1,
+	}
+
+	mi, err := NewMergingIterator([]Iterator[Record]{iter}, nil)
+	require.NoError(t, err)
+
+	first, err := mi.Next()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("a", "v1", 1, TypeValue), first)
+
+	assert.False(t, mi.HasNext())
+
+	_, err = mi.Next()
+	assert.EqualError(t, err, "boom")
+	assert.EqualError(t, mi.err, "boom")
+}
+
+func TestMergingIterator_PrevErrorPropagation(t *testing.T) {
+	iter := &errIterator{
+		records: []Record{mkRec("a", "va", 1, TypeValue)},
+		failIdx: -1,
+	}
+
+	mi, err := NewMergingIterator([]Iterator[Record]{iter}, nil)
+	require.NoError(t, err)
+
+	require.True(t, mi.HasNext())
+	first, err := mi.Next()
+	require.NoError(t, err)
+
+	iter.failIdx = 0
+
+	assert.True(t, mi.HasPrev())
+	back, err := mi.Prev()
+	assert.Equal(t, first, back)
+	assert.EqualError(t, err, "boom")
+	assert.EqualError(t, mi.err, "boom")
+
+	mi.prepareNext()
+	assert.False(t, mi.nextPrepared)
+}


### PR DESCRIPTION
## Summary
- simplify Next and Prev to delegate to HasNext/HasPrev
- move the merging and backtracking logic into prepareNext/preparePrev so preparation stages records and errors

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c94c38eb58832595d8fa5fee241e05