### PR TITLE
Fix merging iterator rewind after Prev EOI

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -169,7 +169,10 @@ func (m *MergingIterator) preparePrev() {
 	case err == nil:
 		m.fwd.PushItem(curItem)
 	case errors.Is(err, EOI):
-		// Return the record without surfacing EOI.
+		// The iterator cannot step further back but still remains positioned on the
+		// current record. Requeue it so that subsequent Next calls can surface it
+		// again when rewinding from the beginning.
+		m.fwd.PushItem(curItem)
 	default:
 		m.err = err
 	}

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -166,12 +166,10 @@ func (m *MergingIterator) preparePrev() {
 	curItem := m.rev.PopItem()
 	_, err := curItem.iter.Prev()
 	switch {
-	case err == nil:
-		m.fwd.PushItem(curItem)
-	case errors.Is(err, EOI):
-		// The iterator cannot step further back but still remains positioned on the
-		// current record. Requeue it so that subsequent Next calls can surface it
-		// again when rewinding from the beginning.
+	case err == nil || errors.Is(err, EOI):
+		// If Prev() succeeds, the underlying iterator moved back. If it returns EOI,
+		// it's at the beginning. In both cases, the current item should be
+		// requeued so that subsequent Next calls can surface it again.
 		m.fwd.PushItem(curItem)
 	default:
 		m.err = err


### PR DESCRIPTION
## Summary
- ensure the merging iterator requeues the current record even when Prev hits EOI so Next can resurface it after rewinding

## Testing
- GOTOOLCHAIN=go1.25.0 go test -v -tags "integration smoke" ./integration
- make test

------
https://chatgpt.com/codex/tasks/task_e_68c96a1644fc83259fa566605cd0f04d