### PR TITLE
refactor: drop sstable iterator history knob

### DIFF
--- a/config.go
+++ b/config.go
@@ -96,11 +96,6 @@ type Config struct {
 	// systems. Provide an implementation to bound FD usage.
 	fdLimiter FDLimiter
 
-	// sstableIterMaxHistory bounds the number of previous offsets retained
-	// by SSTable iterators to support Prev(). Older offsets are discarded
-	// once this limit is exceeded.
-	sstableIterMaxHistory int
-
 	// logger receives log messages. Defaults to a no-op implementation.
 	logger Logger
 
@@ -151,7 +146,6 @@ func DefaultConfig() Config {
 		cacheCorruptTTL:           5 * time.Minute,
 		cacheTombstoneTTL:         0,
 		fdLimiter:                 noopFDLimiter{},
-		sstableIterMaxHistory:     1 << 16,
 		logger:                    nopLogger{},
 		logLevel:                  LogLevelWarn,
 	}
@@ -234,9 +228,6 @@ func (c Config) Validate() {
 	if c.cacheTombstoneTTL < 0 {
 		panic("cacheTombstoneTTL must be >= 0")
 	}
-	if c.sstableIterMaxHistory < 0 {
-		panic("sstableIterMaxHistory must be >= 0")
-	}
 	if c.logger == nil {
 		panic("logger cannot be nil")
 	}
@@ -293,12 +284,6 @@ func WithCacheTombstoneTTL(d time.Duration) Option {
 // unlimited implementation.
 func WithFDLimiter(l FDLimiter) Option {
 	return func(c *Config) { c.fdLimiter = l }
-}
-
-// WithSSTableIterMaxHistory sets the maximum number of offsets retained by
-// SSTable iterators to support Prev().
-func WithSSTableIterMaxHistory(n int) Option {
-	return func(c *Config) { c.sstableIterMaxHistory = n }
 }
 
 // WithLogger sets the logger used by RinDB. A nil logger results in a no-op logger.

--- a/docs/dev/00/record_size/00_plan.md
+++ b/docs/dev/00/record_size/00_plan.md
@@ -1,0 +1,100 @@
+# Record Size Encoding & Iterator Overhaul
+
+1. **Thread record byte-length through the encoding layer.**
+   - Extend `CalOnDiskSize` and the writer to account for the new trailer, emit the trailer after the checksum, and have the reader validate it so we can retro-derive the previous record's start without rescanning. Update any helpers that depend on the serialized footprint.
+   - Surface the parsed byte-length (including header, payload, checksum, and trailer) so callers don't need to recompute it. This will require reshaping `readRecord`'s signature and plumbing the value through call sites.
+   - **Complexity:** 8/10 &mdash; see the dedicated deep-dive in [`01_record_encoding_plan.md`](./01_record_encoding_plan.md).
+   ```go
+   func CalOnDiskSize(r Record) int {
+       payload := len(r.GetKey()) + internalKeySuffixLen + len(r.GetValue())
+       return 3*mdByteSize /* lens */ + payload + checksumSize + mdByteSize /* trailer */
+   }
+
+   func readRecord(storage io.Reader) (Record, int, error) {
+       start := newMeteredReader(storage)
+       // ... existing length reads ...
+       checksum := consumeChecksum(start)
+       size := start.BytesRead()
+       trailer := readUint64(start)
+       if int(trailer) != size {
+           return nil, 0, fmt.Errorf("record size mismatch: got %d expect %d", trailer, size)
+       }
+       return RecordImpl{Key: userKey, Value: valueBytes, SequenceNumber: seq, Type: typ}, size, nil
+   }
+
+   func writeRecord(tx *transaction, record Record) error {
+       // ... write header/payload/checksum ...
+       return writeNumber(tx, uint64(CalOnDiskSize(record)))
+   }
+   ```
+
+2. **Introduce a lightweight reader wrapper that can rewind via trailing sizes.**
+   - Implement a helper (e.g., `recordReader`) that keeps track of the current offset and provides `PrevOffset()` by subtracting the recorded length from the current offset.
+   - Update `offsetReader` usages to leverage the new metadata without allocating stacks, ensuring the helper can rehydrate the previous record by reopening a reader and reading the trailer.
+   - **Complexity:** 6/10.
+   ```go
+   type recordReader struct {
+       fs     *FileSystem
+       offset int64
+   }
+
+   func (rr *recordReader) PrevOffset() (int64, error) {
+       if rr.offset == 0 {
+           return 0, io.EOF
+       }
+       buf := make([]byte, mdByteSize)
+       if _, err := rr.fs.ReadAt(buf, rr.offset-mdByteSize); err != nil {
+           return 0, err
+       }
+       size := int64(byteOrder.Uint64(buf))
+       return rr.offset - size, nil
+   }
+   ```
+
+3. **Refactor SSTable iterators to exploit record sizes instead of the offset stack.**
+   - Replace `offsetStack` usages in `sstableIterator` and `sstableIRange` with on-demand calls to the new rewind helper, keeping the iterator state minimal while preserving O(1) `HasPrev` checks via cached offsets.
+   - Ensure `Next`/`Prev` reuse the shared `readRecord` signature to obtain both the `Record` and its serialized size, updating the iterator's internal offset as they traverse.
+   - **Complexity:** 7/10.
+   ```go
+   func (s *sstableIterator) Next() (Record, error) {
+       reader := newOffsetReader(s.FileSystem, s.offset)
+       rec, size, err := readRecord(reader)
+       if err != nil {
+           return nil, err
+       }
+       s.lastSize = int64(size)
+       s.offset = reader.Offset()
+       return rec, nil
+   }
+
+   func (s *sstableIterator) Prev() (Record, error) {
+       if s.lastSize == 0 {
+           return nil, EOI
+       }
+       start := s.offset - s.lastSize
+       reader := newOffsetReader(s.FileSystem, start)
+       rec, size, err := readRecord(reader)
+       if err != nil {
+           return nil, err
+       }
+       s.offset = start
+       s.lastSize = int64(size)
+       return rec, nil
+   }
+   ```
+
+4. **Align builders, footers, and tests with the new layout.**
+   - Update the SSTable builder's offset tracking, footer validation, and sparse index generation so `offset += CalOnDiskSize(rec)` remains accurate with the trailer; refresh fixtures and test helpers that assume the previous size.
+   - Extend iterator and IO tests to assert round-tripping with the trailer, add regression coverage for `Prev` without the stack, and adjust any binary compatibility checks.
+   - **Complexity:** 5/10.
+   - **Status:** Completed &mdash; builder smoke tests now re-read trailer-sized records straight off disk, footers continue to gate sparse index placement, and iterator regressions cover `Prev`/`HasPrev` after eliminating the offset history knob.
+   ```go
+   func TestSSTableIterator_PrevWithoutStack(t *testing.T) {
+       it, err := sst.Iterator()
+       require.NoError(t, err)
+       rec1, _ := it.Next()
+       rec2, _ := it.Next()
+       prev, _ := it.Prev()
+       assert.Equal(t, rec2.GetKey(), prev.GetKey())
+   }
+   ```

--- a/docs/dev/00/record_size/01_record_encoding_plan.md
+++ b/docs/dev/00/record_size/01_record_encoding_plan.md
@@ -1,0 +1,24 @@
+# Detailed Plan: Record Encoding Trailer
+
+## Goals
+- Append an 8-byte length trailer to every serialized record so iterators can jump backwards without auxiliary stacks.
+- Preserve checksum validation semantics while ensuring the trailer can't be out of sync with the actual bytes consumed.
+- Maintain compatibility with existing builders/tests by updating helpers and fixtures atomically.
+
+## Tasks
+1. **Augment size accounting.** Revise `CalOnDiskSize` to include the trailer, and audit any other arithmetic that assumed `CalOnDiskSize` only covered header+payload+checksum.
+2. **Refactor `readRecord`.**
+   - Introduce a small `meteredReader` (wrapping `io.Reader`) to count consumed bytes.
+   - Parse the existing header/value/checksum sequence, then read the trailing size.
+   - Return both the materialized `Record` and the measured size so callers avoid double-reading.
+3. **Update `writeRecord`.** After writing the checksum, emit the trailer using the new size accounting.
+4. **Call-site updates.** Touch all places that call `readRecord` so they handle the new `(Record, int, error)` signature and store the size when needed.
+5. **Validation tests.** Add/extend tests (likely in `io_test.go` and `sstable_iteration_test.go`) to cover malformed trailers and ensure `Prev` seeks correctly using the trailer.
+
+## Open Questions & Follow-ups
+- Decide whether legacy SSTables (without trailers) must remain readable; if yes, gate the trailer behind a version byte in the footer or detect via feature flag.
+- Confirm whether WAL or memtable serialization shares the same encoding; adjust the scope if other components rely on the record layout.
+
+## Definition of Done
+- Builders emit the new trailer and iterators no longer depend on `offsetStack`.
+- All unit/integration tests pass, and new tests cover regression scenarios for mismatched trailers and backward iteration.

--- a/integration/range_iterator_next_prev_test.go
+++ b/integration/range_iterator_next_prev_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestRangeIterator_AlternatingNextPrevAcrossLevels(t *testing.T) {
-	// Limit history to ensure Prev() hits EOI after exceeding bounds.
-	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(100), rindb.WithSSTableIterMaxHistory(1))
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(100))
 	t.Cleanup(cleanup)
 	ctx := context.Background()
 
@@ -53,7 +52,7 @@ func TestRangeIterator_AlternatingNextPrevAcrossLevels(t *testing.T) {
 	assertPrev("c")
 	assertPrev("a")
 
-	// History exceeded: cannot go back further.
+	// Beginning of iteration: cannot go back further.
 	_, err = iter.Prev()
 	require.ErrorIs(t, err, rindb.EOI)
 
@@ -69,4 +68,8 @@ func TestRangeIterator_AlternatingNextPrevAcrossLevels(t *testing.T) {
 	assertPrev("e")
 	assertPrev("d")
 	assertPrev("c")
+	assertPrev("a")
+
+	_, err = iter.Prev()
+	require.ErrorIs(t, err, rindb.EOI)
 }

--- a/io.go
+++ b/io.go
@@ -15,6 +15,25 @@ const (
 	checksumSize = 4
 )
 
+type meteredReader struct {
+	r io.Reader
+	n int
+}
+
+func newMeteredReader(r io.Reader) *meteredReader {
+	return &meteredReader{r: r}
+}
+
+func (mr *meteredReader) Read(p []byte) (int, error) {
+	n, err := mr.r.Read(p)
+	mr.n += n
+	return n, err
+}
+
+func (mr *meteredReader) BytesRead() int {
+	return mr.n
+}
+
 var ErrChecksumMismatch = errors.New("checksum mismatch")
 
 func readNumber(storage io.Reader) (uint64, error) {
@@ -25,45 +44,56 @@ func readNumber(storage io.Reader) (uint64, error) {
 	return byteOrder.Uint64(numBytes[:]), nil
 }
 
-func readRecord(storage io.Reader) (Record, error) {
-	internalKeyLen, err := readNumber(storage)
+func readRecord(storage io.Reader) (Record, int, error) {
+	reader := newMeteredReader(storage)
+
+	internalKeyLen, err := readNumber(reader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read internal key length: %w", err)
+		return nil, 0, fmt.Errorf("failed to read internal key length: %w", err)
 	}
 
-	valueLen, err := readNumber(storage)
+	valueLen, err := readNumber(reader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read value length: %w", err)
+		return nil, 0, fmt.Errorf("failed to read value length: %w", err)
 	}
 
 	var internalKeyBytes Bytes
 	if internalKeyLen > 0 {
 		internalKeyBytes = make(Bytes, internalKeyLen)
-		if _, err := io.ReadFull(storage, internalKeyBytes); err != nil {
-			return nil, fmt.Errorf("failed to read internal key bytes: %w", err)
+		if _, err := io.ReadFull(reader, internalKeyBytes); err != nil {
+			return nil, 0, fmt.Errorf("failed to read internal key bytes: %w", err)
 		}
 	}
 
 	userKey, seq, typ, err := DecodeInternalKey(internalKeyBytes)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	var valueBytes Bytes
 	if valueLen > 0 {
 		valueBytes = make(Bytes, valueLen)
-		if _, err := io.ReadFull(storage, valueBytes); err != nil {
-			return nil, fmt.Errorf("failed to read value bytes: %w", err)
+		if _, err := io.ReadFull(reader, valueBytes); err != nil {
+			return nil, 0, fmt.Errorf("failed to read value bytes: %w", err)
 		}
 	}
 
 	var checksumBytes [checksumSize]byte
-	if _, err := io.ReadFull(storage, checksumBytes[:]); err != nil {
-		return nil, fmt.Errorf("failed to read checksum: %w", err)
+	if _, err := io.ReadFull(reader, checksumBytes[:]); err != nil {
+		return nil, 0, fmt.Errorf("failed to read checksum: %w", err)
 	}
 	expected := byteOrder.Uint32(checksumBytes[:])
 	if actual := checksum(internalKeyBytes, valueBytes); actual != expected {
-		return nil, ErrChecksumMismatch
+		return nil, 0, ErrChecksumMismatch
+	}
+
+	trailer, err := readNumber(reader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read record size trailer: %w", err)
+	}
+	size := reader.BytesRead()
+	if trailer != uint64(size) {
+		return nil, 0, fmt.Errorf("record size mismatch: got %d expect %d", trailer, size)
 	}
 
 	return RecordImpl{
@@ -71,7 +101,7 @@ func readRecord(storage io.Reader) (Record, error) {
 		Value:          valueBytes,
 		SequenceNumber: seq,
 		Type:           typ,
-	}, nil
+	}, size, nil
 }
 
 func writeNumber(tx *transaction, number uint64) error {
@@ -109,6 +139,10 @@ func writeRecord(tx *transaction, record Record) error {
 	byteOrder.PutUint32(checksumBytes[:], checksum)
 	if _, err := tx.write(checksumBytes[:]); err != nil {
 		return fmt.Errorf("failed to write checksum: %w", err)
+	}
+
+	if err := writeNumber(tx, uint64(CalOnDiskSize(record))); err != nil {
+		return fmt.Errorf("failed to write record size trailer: %w", err)
 	}
 
 	return nil

--- a/io_test.go
+++ b/io_test.go
@@ -71,13 +71,15 @@ func TestRecord_WriteRead(t *testing.T) {
 			defer cleanup()
 			path := tx.log.Path()
 
-			err := writeRecord(tx, newRecord(tt.key, tt.value, 0))
+			rec := newRecord(tt.key, tt.value, 0)
+			err := writeRecord(tx, rec)
 			assert.NoError(t, err)
 
 			data, err := os.ReadFile(path)
 			assert.NoError(t, err)
-			record, err := readRecord(bytes.NewReader(data))
+			record, size, err := readRecord(bytes.NewReader(data))
 			assert.NoError(t, err)
+			assert.Equal(t, CalOnDiskSize(rec), size)
 			assert.Equal(t, tt.key, record.GetKey())
 			assert.Equal(t, tt.value, record.GetValue())
 		})
@@ -171,13 +173,51 @@ func TestReadRecord_Errors(t *testing.T) {
 			},
 			errIs: ErrChecksumMismatch,
 		},
+		{
+			name: "Error reading size trailer",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
+				value := Bytes("value")
+				writeNumberBuf(&buf, uint64(len(ikey)))
+				writeNumberBuf(&buf, uint64(len(value)))
+				buf.Write(ikey)
+				buf.Write(value)
+				var checksumBytes [checksumSize]byte
+				chk := checksum(ikey, value)
+				byteOrder.PutUint32(checksumBytes[:], chk)
+				buf.Write(checksumBytes[:])
+				return &buf
+			},
+			errContains: []string{"failed to read record size trailer"},
+			errIs:       io.EOF,
+		},
+		{
+			name: "Record size mismatch",
+			setup: func() io.Reader {
+				var buf bytes.Buffer
+				ikey := EncodeInternalKey(Bytes("key"), 0, TypeValue)
+				value := Bytes("value")
+				writeNumberBuf(&buf, uint64(len(ikey)))
+				writeNumberBuf(&buf, uint64(len(value)))
+				buf.Write(ikey)
+				buf.Write(value)
+				var checksumBytes [checksumSize]byte
+				chk := checksum(ikey, value)
+				byteOrder.PutUint32(checksumBytes[:], chk)
+				buf.Write(checksumBytes[:])
+				writeNumberBuf(&buf, 1)
+				return &buf
+			},
+			errContains: []string{"record size mismatch"},
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := tt.setup()
-			_, err := readRecord(r)
+			_, _, err := readRecord(r)
 			for _, msg := range tt.errContains {
 				assert.ErrorContains(t, err, msg)
 			}
@@ -211,12 +251,15 @@ func BenchmarkReadRecord(b *testing.B) {
 	byteOrder.PutUint32(checksumBytes[:], chk)
 	buf.Write(checksumBytes[:])
 
+	baseLen := buf.Len()
+	writeNumberBuf(&buf, uint64(baseLen+mdByteSize))
+
 	recordBytes := buf.Bytes()
 
 	b.SetBytes(int64(len(recordBytes)))
 
 	for b.Loop() {
-		_, err := readRecord(bytes.NewReader(recordBytes))
+		_, _, err := readRecord(bytes.NewReader(recordBytes))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/merging_iterator_prepare_test.go
+++ b/merging_iterator_prepare_test.go
@@ -1,74 +1,74 @@
 package rindb
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergingIterator_HasNext_PrepareIdempotent(t *testing.T) {
-    iterators := []Iterator[Record]{
-        &errIterator{records: []Record{mkRec("a", "va", 1, TypeValue)}, failIdx: -1},
-        &errIterator{records: []Record{mkRec("b", "vb", 1, TypeValue)}, failIdx: -1},
-    }
-    mi, err := NewMergingIterator(iterators, nil)
-    assert.NoError(t, err)
+	iterators := []Iterator[Record]{
+		&errIterator{records: []Record{mkRec("a", "va", 1, TypeValue)}, failIdx: -1},
+		&errIterator{records: []Record{mkRec("b", "vb", 1, TypeValue)}, failIdx: -1},
+	}
+	mi, err := NewMergingIterator(iterators, nil)
+	assert.NoError(t, err)
 
-    // Call HasNext multiple times; it should not advance.
-    assert.True(t, mi.HasNext())
-    assert.True(t, mi.HasNext())
+	// Call HasNext multiple times; it should not advance.
+	assert.True(t, mi.HasNext())
+	assert.True(t, mi.HasNext())
 
-    r1, err := mi.Next()
-    assert.NoError(t, err)
-    assert.Equal(t, mkRec("a", "va", 1, TypeValue), r1)
+	r1, err := mi.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, mkRec("a", "va", 1, TypeValue), r1)
 
-    r2, err := mi.Next()
-    assert.NoError(t, err)
-    assert.Equal(t, mkRec("b", "vb", 1, TypeValue), r2)
+	r2, err := mi.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, mkRec("b", "vb", 1, TypeValue), r2)
 }
 
 func TestMergingIterator_HasPrev_PrepareIdempotent(t *testing.T) {
-    iterators := []Iterator[Record]{
-        &errIterator{records: []Record{mkRec("a", "va", 1, TypeValue)}, failIdx: -1},
-        &errIterator{records: []Record{mkRec("b", "vb", 1, TypeValue)}, failIdx: -1},
-    }
-    mi, err := NewMergingIterator(iterators, nil)
-    assert.NoError(t, err)
+	iterators := []Iterator[Record]{
+		&errIterator{records: []Record{mkRec("a", "va", 1, TypeValue)}, failIdx: -1},
+		&errIterator{records: []Record{mkRec("b", "vb", 1, TypeValue)}, failIdx: -1},
+	}
+	mi, err := NewMergingIterator(iterators, nil)
+	assert.NoError(t, err)
 
-    // Move forward once to establish a current element.
-    r1, err := mi.Next()
-    assert.NoError(t, err)
-    assert.Equal(t, mkRec("a", "va", 1, TypeValue), r1)
+	// Move forward once to establish a current element.
+	r1, err := mi.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, mkRec("a", "va", 1, TypeValue), r1)
 
-    // Prepare previous multiple times; should not over-advance or corrupt state.
-    assert.True(t, mi.HasPrev())
-    assert.True(t, mi.HasPrev())
+	// Prepare previous multiple times; should not over-advance or corrupt state.
+	assert.True(t, mi.HasPrev())
+	assert.True(t, mi.HasPrev())
 
-    back, err := mi.Prev()
-    assert.Equal(t, mkRec("a", "va", 1, TypeValue), back)
-    assert.NoError(t, err)
+	back, err := mi.Prev()
+	assert.Equal(t, mkRec("a", "va", 1, TypeValue), back)
+	assert.NoError(t, err)
 
-    // Next again should return the same element per iterator contract.
-    rAgain, err := mi.Next()
-    assert.NoError(t, err)
-    assert.Equal(t, mkRec("a", "va", 1, TypeValue), rAgain)
+	// Next again should return the same element per iterator contract.
+	rAgain, err := mi.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, mkRec("a", "va", 1, TypeValue), rAgain)
 }
 
 func TestMergingIterator_HasNext_PrefetchErrorSurfacedAfterConsume(t *testing.T) {
-    r1 := mkRec("a", "1", 1, TypeValue)
-    r2 := mkRec("b", "2", 2, TypeValue)
-    it := &errIterator{records: []Record{r1, r2}, failIdx: 1}
-    mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
-    assert.NoError(t, err)
+	r1 := mkRec("a", "1", 1, TypeValue)
+	r2 := mkRec("b", "2", 2, TypeValue)
+	it := &errIterator{records: []Record{r1, r2}, failIdx: 1}
+	mi, err := NewMergingIterator([]Iterator[Record]{it}, nil)
+	assert.NoError(t, err)
 
-    // Prepare next; this will attempt to prefetch and encounter an error,
-    // but the first record should still be available.
-    assert.True(t, mi.HasNext())
-    rec, err := mi.Next()
-    assert.NoError(t, err)
-    assert.Equal(t, r1, rec)
+	// Prepare next; this will attempt to prefetch and encounter an error,
+	// but the first record should still be available.
+	assert.True(t, mi.HasNext())
+	rec, err := mi.Next()
+	assert.NoError(t, err)
+	assert.Equal(t, r1, rec)
 
-    // The next call should surface the error set during preparation.
-    _, err = mi.Next()
-    assert.EqualError(t, err, "boom")
+	// The next call should surface the error set during preparation.
+	_, err = mi.Next()
+	assert.EqualError(t, err, "boom")
 }

--- a/offset_reader.go
+++ b/offset_reader.go
@@ -1,5 +1,10 @@
 package rindb
 
+import (
+	"fmt"
+	"io"
+)
+
 type offsetReader struct {
 	fs     *FileSystem
 	offset int64
@@ -19,4 +24,31 @@ func (r *offsetReader) Read(p []byte) (int, error) {
 
 func (r *offsetReader) Offset() int64 {
 	return r.offset
+}
+
+func (r *offsetReader) PrevOffset() (int64, error) {
+	if r.offset == 0 {
+		return 0, io.EOF
+	}
+	if r.offset < mdByteSize {
+		return 0, fmt.Errorf("offset %d smaller than trailer size %d", r.offset, mdByteSize)
+	}
+
+	var trailer [mdByteSize]byte
+	start := r.offset - mdByteSize
+	if _, err := r.fs.ReadAt(trailer[:], start); err != nil {
+		return 0, err
+	}
+
+	size := int64(byteOrder.Uint64(trailer[:]))
+	if size <= 0 {
+		return 0, fmt.Errorf("invalid record size trailer %d at offset %d", size, r.offset)
+	}
+
+	prev := r.offset - size
+	if prev < 0 {
+		return 0, fmt.Errorf("record size %d exceeds current offset %d", size, r.offset)
+	}
+
+	return prev, nil
 }

--- a/offset_reader_test.go
+++ b/offset_reader_test.go
@@ -65,3 +65,46 @@ func TestOffsetReader_Read(t *testing.T) {
 		})
 	}
 }
+
+func TestOffsetReader_PrevOffset(t *testing.T) {
+	t.Run("rewinds using trailer", func(t *testing.T) {
+		data := make([]byte, 24)
+		byteOrder.PutUint64(data[len(data)-mdByteSize:], uint64(len(data)))
+
+		fss, closer := initTempFileSystems(t, 1, [][]byte{data})
+		defer closer()
+
+		fs := fss[0]
+		r := newOffsetReader(fs, int64(len(data)))
+
+		start, err := r.PrevOffset()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), start)
+	})
+
+	t.Run("offset zero returns eof", func(t *testing.T) {
+		fss, closer := initTempFileSystems(t, 1, [][]byte{nil})
+		defer closer()
+
+		fs := fss[0]
+		r := newOffsetReader(fs, 0)
+
+		start, err := r.PrevOffset()
+		assert.ErrorIs(t, err, io.EOF)
+		assert.Equal(t, int64(0), start)
+	})
+
+	t.Run("invalid trailer", func(t *testing.T) {
+		data := make([]byte, 24)
+		byteOrder.PutUint64(data[len(data)-mdByteSize:], uint64(len(data))*2)
+
+		fss, closer := initTempFileSystems(t, 1, [][]byte{data})
+		defer closer()
+
+		fs := fss[0]
+		r := newOffsetReader(fs, int64(len(data)))
+
+		_, err := r.PrevOffset()
+		require.Error(t, err)
+	})
+}

--- a/record.go
+++ b/record.go
@@ -21,7 +21,8 @@ func CalOnDiskSize(r Record) int {
 		len(r.GetKey()) /* user key */ +
 		internalKeySuffixLen /* seq+type */ +
 		len(r.GetValue()) /* value */ +
-		checksumSize /* checksum */)
+		checksumSize /* checksum */ +
+		mdByteSize /* record size trailer */)
 }
 
 var _ Record = RecordImpl{}

--- a/record_test.go
+++ b/record_test.go
@@ -18,12 +18,12 @@ func TestCalOnDiskSize_ReturnsExpectedSize(t *testing.T) {
 		{
 			name: "Key and value",
 			args: args{newRecord(Bytes("key"), Bytes("value"), 1)},
-			want: 37,
+			want: 45,
 		},
 		{
 			name: "Empty key and value",
 			args: args{newRecord(Bytes(nil), Bytes(nil), 18446744073709551615)},
-			want: 29,
+			want: 37,
 		},
 	}
 	for _, tt := range tests {

--- a/sstable.go
+++ b/sstable.go
@@ -36,11 +36,10 @@ type (
 
 type SStable struct {
 	*FileSystem
-	SparseIndex    SparseIndex
-	Bloom          *BloomFilter
-	dataEnd        int64
-	iterMaxHistory int
-	log            scopedLogger
+	SparseIndex SparseIndex
+	Bloom       *BloomFilter
+	dataEnd     int64
+	log         scopedLogger
 }
 
 func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, error) {
@@ -89,7 +88,7 @@ func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, er
 	}
 
 	log.info(ctx, "Successfully created SSTable at %s with %d sparse index entries", fs.Path(), len(sparseIndex))
-	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom, dataEnd: int64(f.indexOffset), iterMaxHistory: config.sstableIterMaxHistory, log: log}, nil
+	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom, dataEnd: int64(f.indexOffset), log: log}, nil
 }
 
 func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes, error) {
@@ -136,7 +135,7 @@ func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes,
 		if reader.Offset() >= s.dataEnd {
 			return nil, ErrKeyNotFound
 		}
-		record, err := readRecord(reader)
+		record, size, err := readRecord(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				s.log.errorf(ctx, "Unexpected EOF after reading at offset %d in %s", offset, s.Path())
@@ -156,7 +155,7 @@ func (s SStable) GetValue(ctx context.Context, key Bytes, seq ...uint64) (Bytes,
 			s.log.errorf(ctx, "Failed to read record at offset %d in %s: %v", reader.Offset(), s.Path(), err)
 			return nil, fmt.Errorf("failed to read record at offset %d: %w", reader.Offset(), err)
 		}
-		bytesRead += CalOnDiskSize(record)
+		bytesRead += size
 		cmp := record.GetKey().Compare(key)
 		if cmp == CmpLess {
 			continue

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -168,7 +168,7 @@ func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, meta fileMeta,
 	}
 
 	b.built = true
-	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom, dataEnd: indexOffset, iterMaxHistory: b.config.sstableIterMaxHistory, log: b.config.scopedLogger()}
+	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom, dataEnd: indexOffset, log: b.config.scopedLogger()}
 	num, nerr := fileNum(b.fs.Path())
 	if nerr != nil {
 		err = fmt.Errorf("invalid sstable path %s: %w", b.fs.Path(), nerr)

--- a/sstable_builder_test.go
+++ b/sstable_builder_test.go
@@ -56,6 +56,15 @@ func TestSSTableBuilder(t *testing.T) {
 			assert.True(t, sst.Bloom.Lookup(r.GetKey()))
 			offset += int64(CalOnDiskSize(r))
 		}
+		reader := newOffsetReader(fs, 0)
+		for _, r := range recs {
+			rec, size, err := readRecord(reader)
+			require.NoError(t, err)
+			assert.Equal(t, r.GetKey(), rec.GetKey())
+			assert.Equal(t, r.GetValue(), rec.GetValue())
+			assert.Equal(t, CalOnDiskSize(r), size)
+		}
+		assert.Equal(t, offset, reader.Offset())
 		info, err := os.Stat(fs.Path())
 		require.NoError(t, err)
 		tail := info.Size() - footerSize

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -7,42 +7,6 @@ import (
 	"sort"
 )
 
-type offsetStack struct {
-	buf   []int64
-	start int
-	count int
-}
-
-func newOffsetStack(n int) *offsetStack {
-	return &offsetStack{buf: make([]int64, n)}
-}
-
-func (o *offsetStack) push(v int64) {
-	if len(o.buf) == 0 {
-		return
-	}
-	if o.count < len(o.buf) {
-		idx := (o.start + o.count) % len(o.buf)
-		o.buf[idx] = v
-		o.count++
-		return
-	}
-	o.buf[o.start] = v
-	o.start = (o.start + 1) % len(o.buf)
-}
-
-func (o *offsetStack) pop() (int64, bool) {
-	if o.count == 0 {
-		return 0, false
-	}
-	idx := (o.start + o.count - 1) % len(o.buf)
-	v := o.buf[idx]
-	o.count--
-	return v, true
-}
-
-func (o *offsetStack) len() int { return o.count }
-
 var _ Iterator[Record] = (*sstableIterator)(nil)
 
 func (s SStable) Iterator() (Iterator[Record], error) {
@@ -55,8 +19,6 @@ func (s SStable) Iterator() (Iterator[Record], error) {
 	return &sstableIterator{
 		FileSystem: s.FileSystem,
 		dataEnd:    s.dataEnd,
-		offset:     0,
-		offs:       newOffsetStack(s.iterMaxHistory),
 	}, nil
 }
 
@@ -89,14 +51,13 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd, offs: newOffsetStack(s.iterMaxHistory)}, nil
+	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd}, nil
 }
 
 type sstableIterator struct {
 	*FileSystem
 	offset  int64
 	dataEnd int64
-	offs    *offsetStack
 }
 
 // HasNext implements Iterator.
@@ -109,9 +70,8 @@ func (s *sstableIterator) Next() (Record, error) {
 	if !s.HasNext() {
 		return nil, EOI
 	}
-	s.offs.push(s.offset)
 	reader := newOffsetReader(s.FileSystem, s.offset)
-	record, err := readRecord(reader)
+	record, _, err := readRecord(reader)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +81,7 @@ func (s *sstableIterator) Next() (Record, error) {
 
 // HasPrev implements Iterator.
 func (s *sstableIterator) HasPrev() bool {
-	return s.offs.len() > 0
+	return s.offset > 0
 }
 
 // Prev implements Iterator.
@@ -129,28 +89,38 @@ func (s *sstableIterator) Prev() (Record, error) {
 	if !s.HasPrev() {
 		return nil, EOI
 	}
-	prev, _ := s.offs.pop()
-	reader := newOffsetReader(s.FileSystem, prev)
-	record, err := readRecord(reader)
+	reader := newOffsetReader(s.FileSystem, s.offset)
+	start, err := reader.PrevOffset()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, EOI
+		}
+		return nil, err
+	}
+	reader.offset = start
+	record, _, err := readRecord(reader)
 	if err != nil {
 		return nil, err
 	}
-	s.offset = prev
+	s.offset = start
 	return record, nil
 }
 
 // sstableIRange iterates over a range of keys in an SSTable.
 type sstableIRange struct {
-	s        *SStable
-	startKey Bytes
-	endKey   Bytes
-	seq      uint64
-	offset   int64
-	dataEnd  int64
-	next     Record
-	err      error
-	prepared bool
-	offs     *offsetStack
+	s              *SStable
+	startKey       Bytes
+	endKey         Bytes
+	seq            uint64
+	offset         int64
+	cursor         int64
+	preparedOffset int64
+	lowerBound     int64
+	haveLowerBound bool
+	dataEnd        int64
+	next           Record
+	err            error
+	prepared       bool
 }
 
 func (sri *sstableIRange) prepare() {
@@ -161,7 +131,7 @@ func (sri *sstableIRange) prepare() {
 		}
 		cur := sri.offset
 		reader := newOffsetReader(sri.s.FileSystem, cur)
-		rec, err := readRecord(reader)
+		rec, _, err := readRecord(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				sri.err = EOI
@@ -181,7 +151,7 @@ func (sri *sstableIRange) prepare() {
 		if rec.GetSequenceNumber() > sri.seq {
 			continue
 		}
-		sri.offs.push(cur)
+		sri.preparedOffset = cur
 		sri.next = rec
 		sri.prepared = true
 	}
@@ -199,13 +169,23 @@ func (sri *sstableIRange) Next() (Record, error) {
 		var empty Record
 		return empty, sri.err
 	}
+	if !sri.haveLowerBound {
+		sri.lowerBound = sri.preparedOffset
+		sri.haveLowerBound = true
+	}
+	sri.cursor = sri.offset
 	sri.prepared = false
-	return sri.next, nil
+	next := sri.next
+	sri.next = nil
+	return next, nil
 }
 
 // HasPrev implements Iterator.
 func (sri *sstableIRange) HasPrev() bool {
-	return sri.offs.len() > 0
+	if !sri.haveLowerBound {
+		return false
+	}
+	return sri.cursor > sri.lowerBound
 }
 
 // Prev implements Iterator.
@@ -214,14 +194,24 @@ func (sri *sstableIRange) Prev() (Record, error) {
 		var empty Record
 		return empty, EOI
 	}
-	prev, _ := sri.offs.pop()
-	reader := newOffsetReader(sri.s.FileSystem, prev)
-	rec, err := readRecord(reader)
+	reader := newOffsetReader(sri.s.FileSystem, sri.cursor)
+	start, err := reader.PrevOffset()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			var empty Record
+			return empty, EOI
+		}
+		return nil, err
+	}
+	reader.offset = start
+	rec, _, err := readRecord(reader)
 	if err != nil {
 		return nil, err
 	}
-	sri.offset = prev
+	sri.offset = start
+	sri.cursor = start
 	sri.prepared = false
 	sri.err = nil
+	sri.next = nil
 	return rec, nil
 }

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,6 +81,17 @@ func TestSSTableIteratorMixed(t *testing.T) {
 	rec, err = it.Next()
 	require.NoError(t, err)
 	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	assert.True(t, it.HasPrev())
+	rec, err = it.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	assert.True(t, it.HasPrev())
+	rec, err = it.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+	assert.False(t, it.HasPrev())
 }
 
 func TestSSTableIRangeReverse(t *testing.T) {
@@ -118,100 +130,20 @@ func TestSSTableIRangeReverse(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, rev)
 }
 
-type historyIterFunc func(SStable) (Iterator[Record], *offsetStack, error)
-
-func testHistoryLimit(t *testing.T, mk historyIterFunc) {
-	t.Helper()
-	cases := []struct {
-		name    string
-		history int
-		keys    []string
-	}{
-		{"h0", 0, []string{"a", "b", "c", "d", "e"}},
-		{"h1", 1, []string{"a", "b", "c", "d", "e"}},
-		{"h2", 2, []string{"a", "b", "c", "d", "e"}},
-		{"empty_keys_h1", 1, []string{}},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := testConfig()
-			cfg.sstableIterMaxHistory = tc.history
-			ctx := context.Background()
-			fss, closer := initTempFileSystems(t, 1, nil)
-			defer closer()
-			fs := fss[0]
-
-			mem := InitMemtable(cfg)
-			for i, k := range tc.keys {
-				mem.Put(newRecord(Bytes(k), Bytes("v"), uint64(i+1)))
-			}
-
-			if len(tc.keys) == 0 {
-				offs := newOffsetStack(tc.history)
-				assert.Equal(t, 0, offs.len())
-				return
-			}
-
-			sst, _, err := flush(ctx, cfg, mem, fs)
-			require.NoError(t, err)
-
-			it, offs, err := mk(sst)
-			require.NoError(t, err)
-
-			for range tc.keys {
-				_, err := it.Next()
-				require.NoError(t, err)
-			}
-
-			expLen := tc.history
-			if expLen > len(tc.keys) {
-				expLen = len(tc.keys)
-			}
-			assert.Equal(t, expLen, offs.len())
-
-			for i := 0; i < tc.history && i < len(tc.keys); i++ {
-				rec, err := it.Prev()
-				require.NoError(t, err)
-				assert.Equal(t, Bytes(tc.keys[len(tc.keys)-1-i]), rec.GetKey())
-			}
-
-			_, err = it.Prev()
-			assert.ErrorIs(t, err, EOI)
-		})
-	}
-}
-
-func TestSSTableIteratorHistoryLimit(t *testing.T) {
-	testHistoryLimit(t, func(sst SStable) (Iterator[Record], *offsetStack, error) {
-		it, err := sst.Iterator()
-		if err != nil {
-			return nil, nil, err
-		}
-		return it, it.(*sstableIterator).offs, nil
-	})
-}
-
-func TestSSTableIRangeHistoryLimit(t *testing.T) {
-	testHistoryLimit(t, func(sst SStable) (Iterator[Record], *offsetStack, error) {
-		it, err := sst.IRange(Bytes("a"), Bytes("e"))
-		if err != nil {
-			return nil, nil, err
-		}
-		return it, it.(*sstableIRange).offs, nil
-	})
-}
-
-func TestSSTableIteratorHistoryReset(t *testing.T) {
+func TestSSTableIteratorPrevFullTraversal(t *testing.T) {
 	cfg := testConfig()
-	cfg.sstableIterMaxHistory = 2
 	ctx := context.Background()
 	fss, closer := initTempFileSystems(t, 1, nil)
 	defer closer()
 	fs := fss[0]
 
 	mem := InitMemtable(cfg)
-	mem.Put(newRecord(Bytes("a"), Bytes("v"), 1))
-	mem.Put(newRecord(Bytes("b"), Bytes("v"), 2))
+	var expected []Bytes
+	for i := 0; i < 10; i++ {
+		key := Bytes(fmt.Sprintf("k%02d", i))
+		mem.Put(newRecord(key, Bytes("v"), uint64(i+1)))
+		expected = append(expected, key)
+	}
 
 	sst, _, err := flush(ctx, cfg, mem, fs)
 	require.NoError(t, err)
@@ -219,16 +151,59 @@ func TestSSTableIteratorHistoryReset(t *testing.T) {
 	it, err := sst.Iterator()
 	require.NoError(t, err)
 
-	si := it.(*sstableIterator)
-	_, err = it.Next()
-	require.NoError(t, err)
-	_, err = it.Next()
-	require.NoError(t, err)
-	require.True(t, it.HasPrev())
+	var fwd []Bytes
+	for it.HasNext() {
+		rec, err := it.Next()
+		require.NoError(t, err)
+		fwd = append(fwd, rec.GetKey())
+	}
 
-	si.offset = 0
-	si.offs = newOffsetStack(cfg.sstableIterMaxHistory)
+	assert.Equal(t, expected, fwd)
+
+	for i := len(fwd) - 1; i >= 0; i-- {
+		require.True(t, it.HasPrev())
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		assert.Equal(t, fwd[i], rec.GetKey())
+	}
 
 	assert.False(t, it.HasPrev())
-	assert.Equal(t, 0, si.offs.len())
+}
+
+func TestSSTableIRangePrevFullTraversal(t *testing.T) {
+	cfg := testConfig()
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	keys := []string{"a", "b", "c", "d", "e", "f"}
+	for i, k := range keys {
+		mem.Put(newRecord(Bytes(k), Bytes("v"), uint64(i+1)))
+	}
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.IRange(Bytes("b"), Bytes("e"))
+	require.NoError(t, err)
+
+	var fwd []Bytes
+	for it.HasNext() {
+		rec, err := it.Next()
+		require.NoError(t, err)
+		fwd = append(fwd, rec.GetKey())
+	}
+
+	assert.Equal(t, []Bytes{Bytes("b"), Bytes("c"), Bytes("d"), Bytes("e")}, fwd)
+
+	for i := len(fwd) - 1; i >= 0; i-- {
+		require.True(t, it.HasPrev())
+		rec, err := it.Prev()
+		require.NoError(t, err)
+		assert.Equal(t, fwd[i], rec.GetKey())
+	}
+
+	assert.False(t, it.HasPrev())
 }

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -60,7 +60,7 @@ func TestSSTable_BasicOperations(t *testing.T) {
 		ret := int64(0)
 		idx := 0
 		for ret < int64(f.indexOffset) {
-			record, err := readRecord(reader)
+			record, _, err := readRecord(reader)
 			assert.NoError(t, err)
 			assert.Equal(t, data[idx].key, record.GetKey())
 			assert.Equal(t, data[idx].value, record.GetValue())
@@ -114,7 +114,7 @@ func TestSSTable_BasicOperations(t *testing.T) {
 		for idx := len(sparseIndex) - 1; idx > -1; idx-- {
 			keyOffset := sparseIndex[idx]
 			reader := newOffsetReader(sstable.FileSystem, keyOffset.offset)
-			record, err := readRecord(reader)
+			record, _, err := readRecord(reader)
 			assert.NoError(t, err)
 			assert.Equal(t, keyOffset.key, record.GetKey())
 		}
@@ -602,7 +602,7 @@ func TestSStableChecksumMismatch(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotZero(t, meta.Number)
 
-	offset := int64(CalOnDiskSize(rec)) - checksumSize
+	offset := int64(CalOnDiskSize(rec)) - checksumSize - mdByteSize
 	_, err = fs.WriteAt([]byte{0}, offset)
 	assert.NoError(t, err)
 

--- a/sstablemgmt_test.go
+++ b/sstablemgmt_test.go
@@ -459,7 +459,7 @@ func TestSSTableManager_SearchKey(t *testing.T) {
 		ts.AddSSTable(0, sst)
 
 		rec := newRecord(key, value, 1)
-		offset := int64(CalOnDiskSize(rec)) - checksumSize
+		offset := int64(CalOnDiskSize(rec)) - checksumSize - mdByteSize
 		f, err := os.OpenFile(sst.Path(), os.O_WRONLY, 0)
 		require.NoError(t, err)
 		defer func() { _ = f.Close() }()

--- a/utils_test.go
+++ b/utils_test.go
@@ -90,9 +90,6 @@ func newTestRindbSetup(t *testing.T, ctx context.Context, cfg *Config) *testRind
 		if finalCfg.skipListP == 0.0 {
 			finalCfg.skipListP = defaultCfg.skipListP
 		}
-		if finalCfg.sstableIterMaxHistory == 0 {
-			finalCfg.sstableIterMaxHistory = defaultCfg.sstableIterMaxHistory
-		}
 	}
 
 	tempDir := t.TempDir()

--- a/wal.go
+++ b/wal.go
@@ -83,7 +83,7 @@ func (w *wal) Load(ctx context.Context) (memtable, error) {
 	reader := newOffsetReader(w.FileSystem, 0)
 	mem := InitMemtable(w.config)
 	for {
-		record, err := readRecord(reader)
+		record, size, err := readRecord(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break // Normal end of file
@@ -96,7 +96,7 @@ func (w *wal) Load(ctx context.Context) (memtable, error) {
 
 		mem.Put(record)
 		w.records.Add(1)
-		w.bytes.Add(uint64(CalOnDiskSize(record)))
+		w.bytes.Add(uint64(size))
 	}
 	walRecordsCounter.Add(ctx, int64(w.records.Load()))
 	walBytesCounter.Add(ctx, int64(w.bytes.Load()))
@@ -196,7 +196,7 @@ func (w *wal) Clean(ctx context.Context, minSeq uint64) error {
 	var keptBytes int64
 
 	for {
-		rec, err := readRecord(reader)
+		rec, size, err := readRecord(reader)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
@@ -224,7 +224,7 @@ func (w *wal) Clean(ctx context.Context, minSeq uint64) error {
 			return fmt.Errorf("failed to commit WAL transaction: %w", err)
 		}
 		keptRecords++
-		keptBytes += int64(CalOnDiskSize(rec))
+		keptBytes += int64(size)
 	}
 
 	if err := tmpFS.Sync(); err != nil {

--- a/wal_test.go
+++ b/wal_test.go
@@ -75,6 +75,14 @@ func validateWALFormat(t *testing.T, file io.ReadSeeker) {
 		actual := checksum(keyBytes, valueBytes)
 		assert.Equal(t, expected, actual)
 
+		// Read and validate the trailing size metadata
+		sizeBytes := [mdByteSize]byte{}
+		_, err = io.ReadFull(file, sizeBytes[:])
+		assert.NoError(t, err)
+		actualSize := byteOrder.Uint64(sizeBytes[:])
+		expectedSize := uint64(2*mdByteSize) + keyLen + valueLen + uint64(checksumSize) + uint64(mdByteSize)
+		assert.Equal(t, expectedSize, actualSize)
+
 		_ = seq // silence unused warning if seq not used otherwise
 	}
 }
@@ -137,7 +145,8 @@ func TestWAL_CleanErrors(t *testing.T) {
 
 		info, err := fs.file.Stat()
 		require.NoError(t, err)
-		_, err = fs.file.WriteAt([]byte{0}, info.Size()-1)
+		offset := info.Size() - int64(mdByteSize+checksumSize)
+		_, err = fs.file.WriteAt([]byte{0}, offset)
 		require.NoError(t, err)
 
 		err = w.Clean(ctx, 0)
@@ -353,7 +362,8 @@ func TestWAL_LoadChecksumMismatch(t *testing.T) {
 
 	info, err := fs.file.Stat()
 	assert.NoError(t, err)
-	_, err = fs.WriteAt([]byte{0}, info.Size()-1)
+	offset := info.Size() - int64(mdByteSize+checksumSize)
+	_, err = fs.WriteAt([]byte{0}, offset)
 	assert.NoError(t, err)
 
 	_, err = w.Load(context.Background())


### PR DESCRIPTION
## Summary
- remove the sstable iterator history config knob now that trailer metadata handles rewinds
- keep SStable construction lean and add a builder regression that replays trailer-sized records from disk
- strengthen iterator and integration tests for Prev/HasPrev while marking the record-size plan's final step complete

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68c9eee384bc832587068638227f8f22