### PR TITLE
fix: return latest version when iterating backwards

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -38,7 +38,7 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func()) (*MergingI
 	lessRev := func(a, b pqItem) bool {
 		cmp := a.rec.GetKey().Compare(b.rec.GetKey())
 		if cmp == CmpEqual {
-			return a.rec.GetSequenceNumber() < b.rec.GetSequenceNumber()
+			return a.rec.GetSequenceNumber() > b.rec.GetSequenceNumber()
 		}
 		return cmp == CmpGreater
 	}

--- a/range_test.go
+++ b/range_test.go
@@ -204,6 +204,22 @@ func TestRangeIteratorPrev_SuppressesOlderVersion(t *testing.T) {
 	mustPrevEOI(t, iter)
 }
 
+func TestRangeIteratorPrev_ReturnsLatestAfterDirectionChange(t *testing.T) {
+	iter := buildRangeIter(t,
+		[]kv{
+			{key: "k", value: "v2", seq: 2},
+			{key: "z", value: "vz", seq: 1},
+		},
+		[]kv{{key: "k", value: "v1", seq: 1}},
+	)
+
+	mustNextValue(t, iter, "k", "v2")
+	mustNextValue(t, iter, "z", "vz")
+
+	mustPrevValue(t, iter, "z", "vz")
+	mustPrevValue(t, iter, "k", "v2")
+}
+
 func TestRangeIteratorAlternatingNextPrev(t *testing.T) {
 	iters := []Iterator[Record]{
 		&errIterator{records: []Record{rec("a", "va", 1, TypeValue)}, failIdx: -1},


### PR DESCRIPTION
## Summary
- add a regression test that demonstrates RangeIterator returning stale data when switching from forward to backward iteration
- prefer newer sequence numbers when ordering the reverse heap so Prev() yields the latest version of a key

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68cb3c05bc6c83258ef9f7e245f5a10d