### PR TITLE
fix: preserve snapshot-visible versions during cleanup

### DIFF
--- a/memtable.go
+++ b/memtable.go
@@ -193,8 +193,9 @@ func (m *memtable) Cleanup(minSeq uint64) {
 		vlen int
 	}
 	var (
-		obs     []obsolete
-		lastKey Bytes
+		obs      []obsolete
+		lastKey  Bytes
+		snapKept bool
 	)
 	it := m.data.Iterator()
 	for it.HasNext() {
@@ -205,9 +206,15 @@ func (m *memtable) Cleanup(minSeq uint64) {
 		key := rec.GetKey()
 		if !bytes.Equal(lastKey, key) {
 			lastKey = key.Clone()
+			snapKept = rec.GetSequenceNumber() <= minSeq
 			continue // keep latest version for this key
 		}
-		if rec.GetSequenceNumber() < minSeq {
+		seq := rec.GetSequenceNumber()
+		if !snapKept && seq <= minSeq {
+			snapKept = true
+			continue
+		}
+		if seq < minSeq {
 			ik := InternalKey{UserKey: key, Seq: rec.GetSequenceNumber(), Type: rec.GetType()}
 			obs = append(obs, obsolete{key: ik, vlen: len(rec.GetValue())})
 		}

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemtable_BasicOperations(t *testing.T) {
@@ -283,20 +284,23 @@ func TestMemtable_Cleanup(t *testing.T) {
 	cfg := testConfig()
 	entryOverhead := slNodeOverhead + internalKeySuffixLen
 
-	t.Run("RemovesObsoleteRecordsAndUpdatesSize", func(t *testing.T) {
+	t.Run("RetainsSnapshotVisibleRecordAndRemovesOlderVersions", func(t *testing.T) {
 		mem := InitMemtable(cfg)
 
 		key1 := Bytes("key1")
 		key2 := Bytes("key2")
 
 		testData := []struct {
-			rec      Record
-			obsolete bool
+			rec  Record
+			keep bool
 		}{
-			{rec: newRecord(key1, Bytes("v1"), 1), obsolete: true},
-			{rec: newRecord(key1, Bytes("v2"), 6), obsolete: false},
-			{rec: newRecord(key2, nil, 3), obsolete: true},
-			{rec: newRecord(key2, Bytes("v3"), 7), obsolete: false},
+			{rec: newRecord(key1, Bytes("v3"), 9), keep: true},
+			{rec: newRecord(key1, Bytes("v2"), 6), keep: true},
+			{rec: newRecord(key1, Bytes("v1"), 4), keep: true},
+			{rec: newRecord(key1, Bytes("v0"), 1), keep: false},
+			{rec: newRecord(key2, nil, 8), keep: true},
+			{rec: newRecord(key2, nil, 5), keep: true},
+			{rec: newRecord(key2, Bytes("legacy"), 2), keep: false},
 		}
 
 		var expectedTotal, expectedAfterCleanup int
@@ -304,7 +308,7 @@ func TestMemtable_Cleanup(t *testing.T) {
 			mem.Put(td.rec)
 			entrySize := len(td.rec.GetKey()) + len(td.rec.GetValue()) + entryOverhead
 			expectedTotal += entrySize
-			if !td.obsolete {
+			if td.keep {
 				expectedAfterCleanup += entrySize
 			}
 		}
@@ -316,14 +320,26 @@ func TestMemtable_Cleanup(t *testing.T) {
 
 		v, err := mem.Get(key1)
 		assert.NoError(t, err)
-		assert.Equal(t, Bytes("v2"), v)
+		assert.Equal(t, Bytes("v3"), v)
+
+		v, err = mem.GetAt(key1, 5)
+		assert.NoError(t, err)
+		assert.Equal(t, Bytes("v1"), v)
 
 		_, err = mem.GetAt(key1, 1)
 		assert.ErrorIs(t, err, ErrKeyNotFound)
 
-		v, err = mem.Get(key2)
-		assert.NoError(t, err)
-		assert.Equal(t, Bytes("v3"), v)
+		_, err = mem.Get(key2)
+		assert.ErrorIs(t, err, ErrKeyNotFound)
+
+		_, err = mem.GetAt(key2, 5)
+		assert.ErrorIs(t, err, ErrKeyNotFound)
+
+		_, err = mem.GetAt(key2, 7)
+		assert.ErrorIs(t, err, ErrKeyNotFound)
+
+		_, err = mem.GetAt(key2, 2)
+		assert.ErrorIs(t, err, ErrKeyNotFound)
 	})
 
 	t.Run("KeepsLatestRecord", func(t *testing.T) {
@@ -337,6 +353,41 @@ func TestMemtable_Cleanup(t *testing.T) {
 		v, err := mem.Get(key)
 		assert.NoError(t, err)
 		assert.Equal(t, Bytes("v2"), v)
+	})
+}
+
+func TestMemtable_CleanupRetainsSnapshotVisibleVersion(t *testing.T) {
+	cfg := testConfig()
+	snapshotSeq := uint64(2)
+
+	newMem := func() memtable {
+		mem := InitMemtable(cfg)
+		mem.Put(newRecord(Bytes("primary"), Bytes("v1"), 1))
+		mem.Put(newRecord(Bytes("bump"), Bytes("noop"), snapshotSeq))
+		mem.Put(newRecord(Bytes("primary"), Bytes("v2"), 3))
+		return mem
+	}
+
+	t.Run("GetAt retains snapshot-visible version", func(t *testing.T) {
+		mem := newMem()
+
+		mem.Cleanup(snapshotSeq)
+
+		v, err := mem.GetAt(Bytes("primary"), snapshotSeq)
+		require.NoError(t, err)
+		assert.Equal(t, Bytes("v1"), v)
+	})
+
+	t.Run("IRange retains snapshot-visible version", func(t *testing.T) {
+		mem := newMem()
+
+		mem.Cleanup(snapshotSeq)
+
+		iter := mem.IRange(Bytes("primary"), Bytes("primary"), snapshotSeq)
+		require.True(t, iter.HasNext(), "expected snapshot-visible version to remain after cleanup")
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		assert.Equal(t, Bytes("v1"), rec.GetValue())
 	})
 }
 

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -39,6 +39,43 @@ func TestSnapshot_MemtableCleanupAfterRelease(t *testing.T) {
 	assert.Equal(t, Bytes("v2"), val)
 }
 
+func TestSnapshot_CleanupRetainsSnapshotVisibleVersion(t *testing.T) {
+	ctx := context.Background()
+	rin, cleanup := initRinDBWithCleanup(t, WithDatabaseDir(t.TempDir()), WithMaxMemtableSize(1<<20))
+	defer cleanup()
+
+	key := Bytes("primary")
+	require.NoError(t, rin.Put(ctx, key, Bytes("v1")))
+
+	snap, err := rin.NewSnapshot(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, rin.Put(ctx, key, Bytes("v2")))
+
+	newerSnap, err := rin.NewSnapshot(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, newerSnap.Release(ctx))
+
+	current, err := rin.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("v2"), current)
+
+	snapVal, err := snap.Get(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("v1"), snapVal)
+
+	iter, err := snap.IRange(ctx, key, key)
+	require.NoError(t, err)
+	require.True(t, iter.HasNext(), "expected snapshot-visible version to remain after cleanup")
+	rec, err := iter.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("v1"), rec.GetValue())
+	require.NoError(t, iter.Close())
+
+	require.NoError(t, snap.Release(ctx))
+}
+
 func TestSnapshot_WALSegmentsRespectSnapshots(t *testing.T) {
 	ctx := context.Background()
 	const maxSize = uint(128)


### PR DESCRIPTION
## Summary
- keep the highest record at or below the snapshot cutoff when trimming the memtable
- exercise the new cleanup rules with multi-version keys, including tombstone retention
- add a snapshot regression proving Get and IRange still see historical values after newer snapshots are released

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68cbebcab4888325bbb8af86d034a2b1