### PR TITLE
docs: outline asc/desc range iterator plan

### DIFF
--- a/docs/dev/312/overall_plan.md
+++ b/docs/dev/312/overall_plan.md
@@ -1,0 +1,110 @@
+# Asc/Desc Range Iteration Plan
+
+RinDB's range iterators currently assume callers walk forward before moving backward, so exposing an `asc`/`desc` flag needs deeper coordination than simply toggling a boolean.
+The goal is to thread an explicit order value through the public API and iterator stack while keeping tombstone filtering, crossing-anchor semantics, and resource cleanup intact.
+We will tackle the work in layered increments so each stage has a clear set of invariants and guardrails.
+
+1. **Step 1 – Expand the public API with an order parameter (Complexity 5/10).** We add an ergonomic option for callers and make sure defaults remain ascending so existing integrations behave the same.
+   This step also validates bounds early so we do not hand invalid ranges to lower layers.
+
+```go
+// Step 1: surface RangeOrder
+// type RangeOrder int
+// const (
+//   RangeAsc RangeOrder = iota
+//   RangeDesc
+// )
+// func IRangeOrder(order RangeOrder) RangeOption { ... }
+// func (r *Rindb) IRange(ctx, start, end Bytes, opts ...RangeOption) (*RangeIterator, error) {
+//   cfg := rangeDefaultConfig()
+//   for _, opt := range opts { opt(&cfg) }
+//   if cfg.order == RangeAsc && start.Compare(end) == CmpGreater { return nil, ErrInvalidRange }
+//   if cfg.order == RangeDesc && start.Compare(end) == CmpLess { return nil, ErrInvalidRange }
+//   mi, err := NewMergingIterator(iterators, cleanup, cfg.order)
+//   return NewRangeIterator(mi, cfg.order), err
+// }
+```
+
+2. **Step 2 – Teach RangeIterator/MergingIterator to honor the initial order (Complexity 9/10).** The iterators must seed their forward/backward heaps based on the requested orientation and cope with direction changes without duplicating records.
+   Because this rewrites core iteration mechanics, we will drive the finer design in `docs/dev/312/step2_merging_iterator_plan.md`.
+
+```go
+// Step 2: order-aware merging
+// func NewRangeIterator(mi *MergingIterator, order RangeOrder) *RangeIterator { ... }
+// func NewMergingIterator(iterators []Iterator[Record], cleanup func(), order RangeOrder) (*MergingIterator, error) {
+//   switch order {
+//   case RangeAsc:
+//     primeForward(iterators)
+//   case RangeDesc:
+//     primeReverse(iterators) // new helper that seeds rev heap and backfills fwd for oscillation
+//   }
+//   return &MergingIterator{fwd: fwd, rev: rev, forward: order == RangeAsc}, nil
+// }
+// func (m *MergingIterator) HasNext() bool {
+//   if m.order == RangeDesc && !m.forward && !m.revPrimed {
+//     m.preparePrev() // first call in desc mode should surface rev heap
+//   }
+//   ...
+// }
+// // Maintain crossingAnchor invariants regardless of initial direction.
+```
+
+3. **Step 3 – Provide descending cursors for memtable/skiplist layers (Complexity 7/10).** We modify the skip list range iterator so it can begin from the predecessor of the end key and update memtable filtering to respect that cursor.
+   The sequence filtering must stay symmetric so deletions remain hidden in both directions.
+
+```go
+// Step 3: skip list + memtable
+// func (list *SkipList[K,V]) IRange(start, end K, order RangeOrder) Iterator[V] {
+//   if order == RangeDesc {
+//     curr := findFloor(end)
+//     return &slIRange{curr: curr, startKey: start, endKey: end, order: RangeDesc}
+//   }
+//   ...
+// }
+// func (mi *memtableIRange) Next()/Prev() {
+//   if mi.order == RangeDesc {
+//     mi.preparePrevDescending()
+//   }
+//   // ensure preparedNext/preparedPrev flip correctly when alternating directions
+// }
+```
+
+4. **Step 4 – Add descending seed logic to `sstableIRange` (Complexity 8/10).** We reuse the table index to locate the last qualifying block, then walk backward while applying key-range and sequence filters.
+   This step ensures the iterator exposes the same contract regardless of initial direction.
+
+```go
+// Step 4: SSTable tail seeding
+// func (s SStable) IRange(start, end Bytes, order RangeOrder, seq ...uint64) (Iterator[Record], error) {
+//   if order == RangeDesc {
+//     offset := s.findOffsetLE(end)
+//     sri := &sstableIRange{offset: offset, cursor: offset, lowerBound: findLowerBound(start), order: RangeDesc}
+//     sri.primeDescending()
+//     return sri, nil
+//   }
+//   ...
+// }
+// func (sri *sstableIRange) primeDescending() error {
+//   // read prior block with PrevOffset until key < start or seq too new
+// }
+```
+
+5. **Step 5 – Update regression coverage and documentation (Complexity 6/10).** We extend unit and integration suites to cover descending usage and make sure docs & CLI helpers describe the new flag.
+   Coverage should include asc/desc parity checks and alternating direction smoke tests.
+
+```go
+// Step 5: verification assets
+// - rindb_test.go: add desc cases mirroring TestRindb_IRangeDirections
+// - integration/range_iterator_next_prev_test.go: table-driven asc vs desc checks
+// - sstable_iteration_test.go & memtable_test.go: ensure Prev before Next works when order == RangeDesc
+// - README + cmd/main.go usage banner: document the new order option
+```
+
+Pitfalls and test hooks: we will guard against regressions by pairing each risk with an existing or new test so failures surface early.
+Maintaining this mapping clarifies how to validate every layer as we iterate on the detailed designs.
+
+```go
+// Pitfall: reverse seeding skips first record -> Add desc variant of TestSSTableIRange_ReverseIteration.
+// Pitfall: duplicates during direction flip -> Extend integration/range_iterator_next_prev_test.go with desc oscillation.
+// Pitfall: tombstones leaking -> Mirror TestMemtableIRange_Reverse under desc mode.
+// Pitfall: invalid range inputs -> New unit tests for RangeOrder validation in rindb_test.go.
+```

--- a/docs/dev/312/step2_merging_iterator_plan.md
+++ b/docs/dev/312/step2_merging_iterator_plan.md
@@ -1,0 +1,223 @@
+# Step 2 – Merging Iterator Descending Seeding Plan
+
+## Goals
+We need the range iterator stack to honor an initial descending orientation without forcing callers to walk forward first.
+The merging iterator must seed both priority queues consistently, preserve crossing-anchor semantics, and still guarantee deterministic cleanup.
+This plan focuses on the mechanics inside `RangeIterator` and `MergingIterator` so that Step 3 and Step 4 can build on a stable contract.
+
+## Implementation Steps
+1. **Carry the requested order through RangeIterator state.** The wrapper should initialize anchor bookkeeping according to the incoming order and surface the correct `HasNext/HasPrev` answers before iteration begins.
+
+```go
+// range_iterator.go
+func NewRangeIterator(mi *MergingIterator, order RangeOrder) *RangeIterator {
+    ri := &RangeIterator{
+        mi:      mi,
+        order:   order,
+        forward: order == RangeAsc,
+    }
+    if order == RangeDesc {
+        ri.crossingAnchor.initDescending()
+        ri.cachedPrev, ri.prevErr = mi.peekReverse()
+        ri.hasPrevPrimed = ri.prevErr == nil
+    }
+    return ri
+}
+
+func (ri *RangeIterator) HasPrev() bool {
+    if ri.order == RangeDesc && !ri.forward {
+        return ri.hasPrevPrimed
+    }
+    return ri.mi.HasPrev()
+}
+```
+
+2. **Prime both heaps inside MergingIterator based on the chosen order.** Construct helpers that load the forward heap with the minimal record or the reverse heap with the maximal record from each child while respecting sequence filtering hooks.
+
+```go
+// merging_iterator.go
+type MergingIterator struct {
+    cleanup   func()
+    order     RangeOrder
+    forward   bool
+    fwdHeap   *recordHeap
+    revHeap   *recordHeap
+    anchors   crossingAnchor
+}
+
+func NewMergingIterator(children []Iterator[Record], cleanup func(), order RangeOrder) (*MergingIterator, error) {
+    m := &MergingIterator{
+        cleanup: cleanup,
+        order:   order,
+        forward: order == RangeAsc,
+        fwdHeap: newForwardHeap(),
+        revHeap: newReverseHeap(),
+    }
+    switch order {
+    case RangeAsc:
+        if err := m.seedForward(children); err != nil {
+            m.cleanup()
+            return nil, err
+        }
+    case RangeDesc:
+        if err := m.seedReverse(children); err != nil {
+            m.cleanup()
+            return nil, err
+        }
+    }
+    return m, nil
+}
+
+func (m *MergingIterator) seedReverse(children []Iterator[Record]) error {
+    for _, child := range children {
+        rec, err := child.Last()
+        if errors.Is(err, io.EOF) {
+            continue
+        }
+        if err != nil {
+            return err
+        }
+        m.revHeap.Push(rec, child)
+    }
+    if m.revHeap.Len() > 0 {
+        m.anchors.initFromReverse(m.revHeap.PeekKey())
+    }
+    return nil
+}
+```
+
+3. **Harmonize direction flips with crossing anchors.** Calling `Next` after `Prev` (and vice versa) should reuse the cached anchors to avoid duplicates while keeping tombstones hidden.
+
+```go
+func (m *MergingIterator) Next() (Record, error) {
+    if m.order == RangeDesc && !m.forward {
+        if err := m.syncFromReverse(); err != nil {
+            return Record{}, err
+        }
+    }
+    rec, src, err := m.popForward()
+    if err != nil {
+        return Record{}, err
+    }
+    m.forward = true
+    m.anchors.updateFromForward(rec.InternalKey)
+    if refill := src.HasNext(); refill {
+        nxt, err := src.Next()
+        if err == nil {
+            m.fwdHeap.Push(nxt, src)
+        }
+    }
+    return rec, nil
+}
+
+func (m *MergingIterator) Prev() (Record, error) {
+    if m.order == RangeAsc && m.forward {
+        if err := m.syncFromForward(); err != nil {
+            return Record{}, err
+        }
+    }
+    rec, src, err := m.popReverse()
+    if err != nil {
+        return Record{}, err
+    }
+    m.forward = false
+    m.anchors.updateFromReverse(rec.InternalKey)
+    if refill := src.HasPrev(); refill {
+        prv, err := src.Prev()
+        if err == nil {
+            m.revHeap.Push(prv, src)
+        }
+    }
+    return rec, nil
+}
+```
+
+4. **Centralize cleanup guarantees and error propagation.** Ensure both heaps drain correctly and the shared `cleanup` runs exactly once, even if seeding fails or a child iterator bubbles an error mid-iteration.
+
+```go
+func (m *MergingIterator) Close() error {
+    if m.cleanup == nil {
+        return nil
+    }
+    defer func() { m.cleanup = nil }()
+    for m.fwdHeap.Len() > 0 {
+        _, child := m.fwdHeap.Pop()
+        child.Close()
+    }
+    for m.revHeap.Len() > 0 {
+        _, child := m.revHeap.Pop()
+        child.Close()
+    }
+    m.cleanup()
+    return nil
+}
+
+func (m *MergingIterator) syncFromReverse() error {
+    if m.revHeap.Len() == 0 {
+        return io.EOF
+    }
+    pivot := m.revHeap.PeekKey()
+    if m.anchors.isForwardDuplicate(pivot) {
+        _, _, _ = m.revHeap.Pop()
+    }
+    if m.fwdHeap.Len() == 0 {
+        if err := m.backfillForward(); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+## Pitfalls & Test Hooks
+- **Duplicate emission when switching direction.** Guard with a regression that alternates `Next`/`Prev` starting from descending mode and asserts strict key monotonicity.
+
+```go
+func TestRangeIterator_DescendingOscillation(t *testing.T) {
+    it := buildRangeIterator(order: RangeDesc, keys: []string{"k3","k2","k1"})
+    assertKey(t, it.Prev(), "k3")
+    assertKey(t, it.Next(), "k2")
+    assertKey(t, it.Prev(), "k2")
+    assertKey(t, it.Next(), "k1")
+}
+```
+
+- **Reverse seeding skips tombstone filtering.** Add a memtable-backed fixture with deletes and verify descending reads hide shadowed entries just like ascending reads.
+
+```go
+func TestMergingIterator_DescTombstoneFiltering(t *testing.T) {
+    mt := fakeMemtable([]record{{Key: "a", Deleted: true}, {Key: "a", Seq: 1}})
+    it := newMergingIterator(order: RangeDesc, children: []Iterator{mt})
+    _, err := it.Prev()
+    require.ErrorIs(t, err, io.EOF)
+}
+```
+
+- **Cleanup leaks when seeding fails.** Inject a child iterator that errors on `Last` and assert that `cleanup` fires once and all children are closed.
+
+```go
+func TestMergingIterator_SeedReverseFailure(t *testing.T) {
+    called := 0
+    cleanup := func() { called++ }
+    bad := &faultyIterator{lastErr: errors.New("boom")}
+    _, err := NewMergingIterator([]Iterator{bad}, cleanup, RangeDesc)
+    require.Error(t, err)
+    require.Equal(t, 1, called)
+    require.True(t, bad.closed)
+}
+```
+
+- **Crossing anchor drift across SSTables.** Feed records that straddle SSTable boundaries and confirm the reverse heap drops anything ≥ anchor before replaying the forward heap.
+
+```go
+func TestMergingIterator_AnchorAlignmentAcrossSources(t *testing.T) {
+    left := fakeIterator(keys: []string{"k1","k2"})
+    right := fakeIterator(keys: []string{"k2","k3"})
+    it := newMergingIterator(order: RangeDesc, children: []Iterator{left, right})
+    assertKey(t, it.Prev(), "k3")
+    assertKey(t, it.Prev(), "k2") // single occurrence
+    assertKey(t, it.Prev(), "k1")
+    _, err := it.Prev()
+    require.ErrorIs(t, err, io.EOF)
+}
+```


### PR DESCRIPTION
## Summary
- add an overall plan for introducing asc/desc ordering to RinDB range iterators
- elaborate the dedicated merging iterator plan with code sketches, pitfalls, and targeted tests for descending seeding

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cf89c5e9b083258f5dd871ea932078