### PR TITLE
Clarify range order bounds validation

### DIFF
--- a/docs/dev/312/overall_plan.md
+++ b/docs/dev/312/overall_plan.md
@@ -36,7 +36,7 @@ We will tackle the work in layered increments so each stage has a clear set of i
 // }
 ```
 
-Callers continue to supply `start <= end`; `RangeOrder` only determines whether we traverse that span from low-to-high or high-to-low.
+Callers must supply `start <= end`; `RangeOrder` only determines whether we traverse that span from low-to-high or high-to-low.
 This keeps the contract consistent for skip list, memtable, and SSTable updates later in the plan.
 
 2. **Step 1b – Add iterator tail priming support (Complexity 6/10).** Before the merging iterator can seed descending order we need a shared `Last()` helper on every iterator implementation.


### PR DESCRIPTION
## Summary
- allow the Step 1 validation plan to only reject obviously inverted bounds
- document that RangeOrder flips iteration direction without reordering the range
- note that later iterator layers continue to rely on `start <= end` semantics

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68cfe2b3b68083259ec345633c276e21