### PR TITLE
docs: clarify iterator Last responsibilities

### DIFF
--- a/docs/dev/312/step1b_iterator_last_plan.md
+++ b/docs/dev/312/step1b_iterator_last_plan.md
@@ -39,22 +39,46 @@ child implementation.
    ```
 
 2. **Teach foundational iterators how to reach the tail.**
-   * `slIterator` already has the skip list cursor helpers necessary to jump to
-     the final node. Wrap that logic inside `Last()` so `Prev` continues from the
-     returned element.
-   * `memtableIRange` should delegate to the underlying skip list iterator while
-     keeping sequence/tombstone filtering intact.
-   * `sstableIRange` can reuse the block index walk performed today by
-     `seekBlockLE`/`preparePrev`. `Last()` should position the state machine so
-     the next `Prev` call flows through existing reverse iteration logic.
+   * **`slIterator`.** Reuse the skip list cursor helpers to locate the final
+     node, return its value, and then rewind `curr` to the predecessor so a
+     follow-up `Prev()` yields the penultimate element. This mirrors the way
+     `Next()` advances past the returned record.
+   * **`slIRange`.** Walk the range until the highest key `<= endKey` while
+     continuing to respect the `startKey` guard. `Last()` must leave `curr`
+     pointing to the predecessor of the returned node so `Prev()` retains its
+     boundary-aware filtering.
+   * **`memtableIRange`.** Delegate to the wrapped skip list iterator but pipe
+     the result through the existing sequence/tombstone filtering loops used by
+     `preparePrev()`. The goal is to surface the same logical record that `Prev`
+     would choose while keeping `preparedNext`/`preparedPrev` bookkeeping in
+     sync.
+   * **`sstableIterator`.** Use the file offsets gathered during forward scans
+     to position the reader at the final block (mirroring the `PrevOffset()`
+     dance already present in `Prev`). Return that record and update `offset` so
+     another `Prev()` walks to the previous entry without re-reading the tail.
+   * **`sstableIRange`.** Reuse the `prepare()` loop so key-range and sequence
+     filtering stay intact. `Last()` should respect `lowerBound`/`cursor`
+     invariants by rewinding the iterator state machine exactly as the existing
+     `Prev()` path expects.
 
-3. **Adapt composed iterators.**
-   * The step 2 merging iterator plan will call `child.Last()` while seeding the
-     reverse heap. During this step, update any other iterator wrappers (e.g.,
-     caching adapters or integration test doubles) to expose the new method and
-     delegate to their inner iterator.
-   * Ensure helper constructors used in tests (such as `fakeIterator` fixtures)
-     grow a trivial `Last()` implementation so existing coverage keeps compiling.
+3. **Adapt composed iterators and wrappers.**
+   * **`MergingIterator`.** Implement `Last()` by leveraging the current
+     forward/reverse heap choreography—drain the forward heap into the reverse
+     heap until `preparePrev()` produces the maximal item, update
+     `crossingAnchor`, set `forward` to `false`, and return that record while
+     keeping both heaps ready for a subsequent `Prev()`.
+   * **`RangeIterator`.** Feed `Last()` through `preparePrev()` so tombstone and
+     duplicate suppression remains centralized. The method should set the anchor
+     just like `Prev()` and toggle the iterator into reverse mode so another
+     `Prev()` exposes the next visible record.
+   * **Test doubles.** Update fixtures such as the `errIterator` in
+     `merging_iterator_test.go` (and any future `Iterator[Record]` fakes) to grow
+     a minimal `Last()` that iterates to the tail while preserving their
+     failure-injection semantics.
+   * **Wrapper helpers.** Audit adapters that embed other iterators—e.g., caching
+     decorators or integration-test instrumentation that forward calls—to ensure
+     they simply delegate `Last()` to the wrapped iterator. Call this out in
+     helper docs so new wrappers remember to add the pass-through implementation.
 
 4. **Update tests.**
    * Extend iterator-focused suites (`skiplist_test.go`, `memtable_test.go`,


### PR DESCRIPTION
## Summary
- expand the Step 1b plan so it spells out Last() expectations for core iterators (skip list, memtable, and SSTable variants)
- document how composed iterators, test doubles, and wrappers should delegate or reuse filtering when implementing Last()

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68cfe2f1e71c8325a61e01f4a88c4ca5