### PR TITLE
docs: clarify descending iterator priming

### DIFF
--- a/docs/dev/312/overall_plan.md
+++ b/docs/dev/312/overall_plan.md
@@ -86,22 +86,26 @@ We will tackle the work in layered increments so each stage has a clear set of i
 // }
 ```
 
-5. **Step 4 – Add descending seed logic to `sstableIRange` (Complexity 8/10).** We reuse the table index to locate the last qualifying block, then walk backward while applying key-range and sequence filters.
-   This step ensures the iterator exposes the same contract regardless of initial direction.
+5. **Step 4 – Add descending seed logic to `sstableIRange` (Complexity 8/10).** Introduce a `findOffsetLE` helper that binary searches the sparse index for the final block whose key is ≤ `end`, then have `primeDescending` step backward with `PrevOffset` until the first in-range record is prepared.
+   This keeps the work logarithmic in table size and ensures the iterator exposes the same contract regardless of initial direction.
 
 ```go
 // Step 4: SSTable tail seeding
 // func (s SStable) IRange(start, end Bytes, order RangeOrder, seq ...uint64) (Iterator[Record], error) {
 //   if order == RangeDesc {
-//     offset := s.findOffsetLE(end)
+//     offset, haveOffset := s.findOffsetLE(end)
+//     if !haveOffset { return emptyIterator(), nil }
 //     sri := &sstableIRange{offset: offset, cursor: offset, lowerBound: findLowerBound(start), order: RangeDesc}
-//     sri.primeDescending()
+//     if err := sri.primeDescending(); err != nil { return nil, err }
 //     return sri, nil
 //   }
 //   ...
 // }
+// func (s *SStable) findOffsetLE(end Bytes) (int64, bool) {
+//   // binary search SparseIndex for block starting key <= end
+// }
 // func (sri *sstableIRange) primeDescending() error {
-//   // read prior block with PrevOffset until key < start or seq too new
+//   // use PrevOffset to walk blocks/records until key < start or seq too new
 // }
 ```
 

--- a/docs/dev/312/step1b_iterator_last_plan.md
+++ b/docs/dev/312/step1b_iterator_last_plan.md
@@ -44,9 +44,13 @@ child implementation.
      returned element.
    * `memtableIRange` should delegate to the underlying skip list iterator while
      keeping sequence/tombstone filtering intact.
-   * `sstableIRange` can reuse the block index walk performed today by
-     `seekBlockLE`/`preparePrev`. `Last()` should position the state machine so
-     the next `Prev` call flows through existing reverse iteration logic.
+   * `sstableIRange` should binary search the sparse index to locate the last
+     block whose starting key is less than or equal to `end` (mirroring the
+     `IRange` startup logic) and then walk backwards with `PrevOffset` until the
+     terminal record is in range.
+     Cross-reference the `sstable_iteration.go` state machine so `Last()` seeds
+     `offset`, `cursor`, and `haveLowerBound` exactly as `Prev` expects before the
+     first reverse step.
 
 3. **Adapt composed iterators.**
    * The step 2 merging iterator plan will call `child.Last()` while seeding the
@@ -76,3 +80,6 @@ child implementation.
 * **Divergent iterator semantics.** Document the expectation that calling
   `Last()` immediately followed by `Prev()` returns the same element, keeping the
   iteration contract symmetric with `Next()`.
+* **Large SSTables.** Avoid rescanning the entire table when priming the tail;
+  rely on the sparse index + `PrevOffset` walk so `Last()` remains logarithmic in
+  table size even for multi-gigabyte files.


### PR DESCRIPTION
## Summary
- document how sstableIRange.Last should binary search the sparse index and seed iterator state before calling Prev
- update the overall plan to call out the findOffsetLE and primeDescending helpers for SSTable descending seeding
- add a pitfall about avoiding full scans on large SSTables

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cfe652d770832588e4d935069598d1