### PR TITLE
fix: implement iterator tail priming

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -25,4 +25,9 @@ type Iterator[T any] interface {
 	// Prev returns the current element and moves the iterator one step
 	// backward. It returns EOI when no more elements remain.
 	Prev() (T, error)
+	// Last positions the iterator at the final element and returns it. The
+	// subsequent Prev call should yield the element that precedes the value
+	// returned by Last, mirroring how Next leaves the cursor after the
+	// current record.
+	Last() (T, error)
 }

--- a/memtable.go
+++ b/memtable.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"bytes"
+	"errors"
 	"math"
 )
 
@@ -184,6 +185,32 @@ func (mi *memtableIRange) Prev() (Record, error) {
 	mi.preparedPrev = false
 	mi.preparedNext = false
 	return mi.prev, nil
+}
+
+// Last implements Iterator[Record].
+func (mi *memtableIRange) Last() (Record, error) {
+	mi.err = nil
+	mi.preparedNext = false
+	mi.preparedPrev = false
+
+	var empty Record
+	rec, err := mi.it.Last()
+	if err != nil {
+		return empty, err
+	}
+	for rec.GetSequenceNumber() > mi.seq {
+		if !mi.it.HasPrev() {
+			return empty, EOI
+		}
+		rec, err = mi.it.Prev()
+		if err != nil {
+			if errors.Is(err, EOI) {
+				return empty, EOI
+			}
+			return empty, err
+		}
+	}
+	return rec, nil
 }
 
 // Cleanup removes records with sequence numbers less than minSeq.

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -522,6 +522,30 @@ func TestMemtableIRange_Reverse(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("b"), Bytes("a")}, keys)
 }
 
+func TestMemtableIRange_Last(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va1"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb2"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc3"), 3))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc4"), 4))
+
+	it := mem.IRange(Bytes("a"), Bytes("c"), 3)
+	mi, ok := it.(*memtableIRange)
+	assert.True(t, ok)
+
+	last, err := mi.Last()
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("c"), last.GetKey())
+	assert.Equal(t, uint64(3), last.GetSequenceNumber())
+
+	prev, err := mi.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("b"), prev.GetKey())
+	assert.Equal(t, uint64(2), prev.GetSequenceNumber())
+}
+
 func TestMemtableIRange_PrevBeforeNext(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -13,11 +13,13 @@ type pqItem struct {
 // records ordered by key and sequence number (descending) and supports
 // bidirectional traversal.
 type MergingIterator struct {
-	fwd     *PriorityQueue[pqItem]
-	rev     *PriorityQueue[pqItem]
-	cleanup func()
-	err     error
-	order   RangeOrder
+	fwd              *PriorityQueue[pqItem]
+	rev              *PriorityQueue[pqItem]
+	cleanup          func()
+	err              error
+	order            RangeOrder
+	iters            []Iterator[Record]
+	descendingPrimed bool
 
 	// prepared next state
 	nextPrepared bool
@@ -81,11 +83,15 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func(), order Rang
 	}
 	fwd := NewPriorityQueue(lessFwd)
 	rev := NewPriorityQueue(lessRev)
+	active := make([]Iterator[Record], 0, len(iterators))
+	for _, it := range iterators {
+		if it == nil {
+			continue
+		}
+		active = append(active, it)
+	}
 	if order == RangeDesc {
-		for _, it := range iterators {
-			if it == nil {
-				continue
-			}
+		for _, it := range active {
 			if _, err := it.Last(); err != nil && !errors.Is(err, EOI) {
 				if cleanup != nil {
 					cleanup()
@@ -94,7 +100,7 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func(), order Rang
 			}
 		}
 	}
-	for _, it := range iterators {
+	for _, it := range active {
 		if it.HasNext() {
 			rec, err := it.Next()
 			switch {
@@ -113,7 +119,7 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func(), order Rang
 			fwd.PushItem(pqItem{rec: rec, iter: it})
 		}
 	}
-	return &MergingIterator{fwd: fwd, rev: rev, cleanup: cleanup, forward: true, order: order}, nil
+	return &MergingIterator{fwd: fwd, rev: rev, cleanup: cleanup, forward: true, order: order, iters: active}, nil
 }
 
 // HasNext implements Iterator[Record].
@@ -185,11 +191,69 @@ func (m *MergingIterator) Prev() (Record, error) {
 	return item.rec, nil
 }
 
+// Last implements Iterator[Record].
+func (m *MergingIterator) Last() (Record, error) {
+	var empty Record
+	if m.err != nil {
+		return empty, m.err
+	}
+	m.nextPrepared = false
+	m.prevPrepared = false
+	m.forward = false
+	m.crossingAnchorSet = false
+	m.nextItem = pqItem{}
+	m.prevItem = pqItem{}
+
+	if m.fwd != nil {
+		m.fwd.Clear()
+	}
+	if m.rev != nil {
+		m.rev.Clear()
+	}
+
+	m.descendingPrimed = true
+
+	for _, it := range m.iters {
+		if it == nil {
+			continue
+		}
+		rec, err := it.Last()
+		switch {
+		case err == nil:
+			m.rev.PushItem(pqItem{rec: rec, iter: it})
+		case errors.Is(err, EOI):
+			continue
+		default:
+			m.err = err
+			return empty, err
+		}
+	}
+
+	if m.rev.Len() == 0 {
+		return empty, EOI
+	}
+
+	lastItem := m.rev.PopItem()
+	if prev, err := lastItem.iter.Prev(); err == nil {
+		m.rev.PushItem(pqItem{rec: prev, iter: lastItem.iter})
+	} else if !errors.Is(err, EOI) {
+		m.err = err
+		return empty, err
+	}
+
+	m.crossingAnchor = lastItem
+	m.crossingAnchorSet = true
+
+	return lastItem.rec, nil
+}
+
 // prepareNext stages the next item so that HasNext is idempotent.
 func (m *MergingIterator) prepareNext() {
 	if m.nextPrepared {
 		return
 	}
+
+	m.descendingPrimed = false
 
 	// When moving forward, any previously prepared backward state is invalidated.
 	m.prevPrepared = false
@@ -271,21 +335,34 @@ func (m *MergingIterator) preparePrev() {
 		}
 
 		// Prev returns the current element and rewinds the iterator by one
-		// position so another Prev call can continue walking backwards. The
-		// returned record is ignored because curItem already holds it.
-		_, err := curItem.iter.Prev()
-		if err != nil && !errors.Is(err, EOI) {
-			m.err = err
-			m.prevItem = curItem
-			m.prevPrepared = true
-			return
+		// position so another Prev call can continue walking backwards. When
+		// descendingPrimed is set, the returned record represents the next
+		// candidate for reverse iteration and is pushed onto the reverse heap.
+		if m.descendingPrimed {
+			prevRec, err := curItem.iter.Prev()
+			switch {
+			case err == nil:
+				m.rev.PushItem(pqItem{rec: prevRec, iter: curItem.iter})
+			case errors.Is(err, EOI):
+				// No more records from this iterator when walking backwards.
+			default:
+				m.err = err
+				m.prevItem = curItem
+				m.prevPrepared = true
+				return
+			}
+		} else {
+			if _, err := curItem.iter.Prev(); err != nil && !errors.Is(err, EOI) {
+				m.err = err
+				m.prevItem = curItem
+				m.prevPrepared = true
+				return
+			}
 		}
 
-		// If Prev() succeeds, the underlying iterator moved back. If it returns EOI,
-		// it's at the beginning. In both cases, the current item should be requeued so
-		// that subsequent Next calls can surface it again.
-		// Pushing into the forward heap preserves the contract where Prev
-		// immediately followed by Next yields the same record.
+		// Requeue the current item so a subsequent forward traversal can surface it
+		// again. This maintains the invariant that Prev followed by Next returns the
+		// same record.
 		m.fwd.PushItem(curItem)
 
 		// Store the prepared item for Prev().

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -81,6 +81,19 @@ func NewMergingIterator(iterators []Iterator[Record], cleanup func(), order Rang
 	}
 	fwd := NewPriorityQueue(lessFwd)
 	rev := NewPriorityQueue(lessRev)
+	if order == RangeDesc {
+		for _, it := range iterators {
+			if it == nil {
+				continue
+			}
+			if _, err := it.Last(); err != nil && !errors.Is(err, EOI) {
+				if cleanup != nil {
+					cleanup()
+				}
+				return nil, err
+			}
+		}
+	}
 	for _, it := range iterators {
 		if it.HasNext() {
 			rec, err := it.Next()

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -137,6 +137,38 @@ func TestMergingIterator_LastErrorSurfaced(t *testing.T) {
 	assert.EqualError(t, err, "tail boom")
 }
 
+func TestMergingIterator_LastReturnsMaxAndPrimesPrev(t *testing.T) {
+	t.Parallel()
+	iterators := []Iterator[Record]{
+		&errIterator{records: []Record{mkRec("a", "va", 1, TypeValue), mkRec("c", "vc1", 2, TypeValue)}, failIdx: -1},
+		&errIterator{records: []Record{mkRec("b", "vb", 1, TypeValue), mkRec("c", "vc2", 3, TypeValue)}, failIdx: -1},
+	}
+	mi, err := NewMergingIterator(iterators, nil, RangeAsc)
+	require.NoError(t, err)
+
+	last, err := mi.Last()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("c", "vc2", 3, TypeValue), last)
+
+	prev, err := mi.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("c", "vc1", 2, TypeValue), prev)
+
+	prev2, err := mi.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("b", "vb", 1, TypeValue), prev2)
+}
+
+func TestMergingIterator_LastEmpty(t *testing.T) {
+	t.Parallel()
+	iterators := []Iterator[Record]{&errIterator{records: nil, failIdx: -1}}
+	mi, err := NewMergingIterator(iterators, nil, RangeAsc)
+	require.NoError(t, err)
+
+	_, err = mi.Last()
+	assert.ErrorIs(t, err, EOI)
+}
+
 func TestMergingIterator_MergesRecords(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -47,6 +47,38 @@ func (e *errIterator) Prev() (Record, error) {
 	return e.records[e.idx], nil
 }
 
+func (e *errIterator) Last() (Record, error) {
+	var empty Record
+	if len(e.records) == 0 {
+		return empty, EOI
+	}
+	e.idx = len(e.records) - 1
+	return e.records[e.idx], nil
+}
+
+type lastErrorIterator struct {
+	err error
+}
+
+func (l *lastErrorIterator) HasNext() bool { return false }
+
+func (l *lastErrorIterator) Next() (Record, error) {
+	var empty Record
+	return empty, EOI
+}
+
+func (l *lastErrorIterator) HasPrev() bool { return false }
+
+func (l *lastErrorIterator) Prev() (Record, error) {
+	var empty Record
+	return empty, EOI
+}
+
+func (l *lastErrorIterator) Last() (Record, error) {
+	var empty Record
+	return empty, l.err
+}
+
 func mkRec(k, v string, seq uint64, typ RecordType) Record {
 	var nv Bytes
 	if v != "" {
@@ -96,6 +128,13 @@ func TestMergingIterator_IncludesDuplicatesAndTombstones(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMergingIterator_LastErrorSurfaced(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("tail boom")
+	_, err := NewMergingIterator([]Iterator[Record]{&lastErrorIterator{err: boom}}, nil, RangeDesc)
+	assert.EqualError(t, err, "tail boom")
 }
 
 func TestMergingIterator_MergesRecords(t *testing.T) {

--- a/priority_queue.go
+++ b/priority_queue.go
@@ -46,3 +46,9 @@ func (pq *PriorityQueue[T]) PopItem() T { return heap.Pop(pq).(T) }
 
 // PeekItem returns, but does not remove, the highest priority item from the queue.
 func (pq PriorityQueue[T]) PeekItem() T { return pq.items[0] }
+
+// Clear removes all items from the queue while preserving the comparator.
+func (pq *PriorityQueue[T]) Clear() {
+	pq.items = pq.items[:0]
+	heap.Init(pq)
+}

--- a/range.go
+++ b/range.go
@@ -183,19 +183,8 @@ func (r *RangeIterator) Last() (Record, error) {
 	var empty Record
 	r.err = nil
 
-	var last Record
-	for r.HasNext() {
-		rec, err := r.Next()
-		if err != nil {
-			return empty, err
-		}
-		last = rec
-	}
-	if last == nil {
-		return empty, EOI
-	}
-
-	if _, err := r.mi.Prev(); err != nil && !errors.Is(err, EOI) {
+	rec, err := r.mi.Last()
+	if err != nil {
 		return empty, err
 	}
 
@@ -206,10 +195,42 @@ func (r *RangeIterator) Last() (Record, error) {
 	r.prev = nil
 	r.next = nil
 	r.err = nil
-	r.lastKey = last.GetKey().Clone()
-	r.lastKeySet = true
+	r.lastKeySet = false
 
-	return last, nil
+	for {
+		sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
+		if sameKey {
+			prev, err := r.mi.Prev()
+			switch {
+			case err == nil:
+				rec = prev
+			case errors.Is(err, EOI):
+				return empty, EOI
+			default:
+				return empty, err
+			}
+			continue
+		}
+
+		r.lastKey = rec.GetKey().Clone()
+		r.lastKeySet = true
+		if rec.GetType() == TypeDeletion {
+			prev, err := r.mi.Prev()
+			switch {
+			case err == nil:
+				rec = prev
+			case errors.Is(err, EOI):
+				return empty, EOI
+			default:
+				return empty, err
+			}
+			continue
+		}
+
+		r.crossingAnchor = rec
+		r.crossingAnchorSet = true
+		return rec, nil
+	}
 }
 
 // Close releases any resources held by the iterator.

--- a/range.go
+++ b/range.go
@@ -178,6 +178,40 @@ func (r *RangeIterator) Prev() (Record, error) {
 	return rec, nil
 }
 
+// Last implements Iterator[Record].
+func (r *RangeIterator) Last() (Record, error) {
+	var empty Record
+	r.err = nil
+
+	var last Record
+	for r.HasNext() {
+		rec, err := r.Next()
+		if err != nil {
+			return empty, err
+		}
+		last = rec
+	}
+	if last == nil {
+		return empty, EOI
+	}
+
+	if _, err := r.mi.Prev(); err != nil && !errors.Is(err, EOI) {
+		return empty, err
+	}
+
+	r.prevPrepared = false
+	r.nextPrepared = false
+	r.forward = false
+	r.crossingAnchorSet = false
+	r.prev = nil
+	r.next = nil
+	r.err = nil
+	r.lastKey = last.GetKey().Clone()
+	r.lastKeySet = true
+
+	return last, nil
+}
+
 // Close releases any resources held by the iterator.
 func (r *RangeIterator) Close() error {
 	return r.mi.Close()

--- a/range_test.go
+++ b/range_test.go
@@ -228,6 +228,30 @@ func TestRangeIteratorPrev_ReturnsLatestAfterDirectionChange(t *testing.T) {
 	mustPrevEOI(t, iter)
 }
 
+func TestRangeIterator_LastPositionsPrevBeforeTail(t *testing.T) {
+	t.Parallel()
+	iter := buildRangeIter(t,
+		[]kv{
+			{key: "a", value: "va1", seq: 1},
+			{key: "c", value: "vc5", seq: 5},
+		},
+		[]kv{
+			{key: "b", value: "vb2", seq: 2},
+			{key: "c", value: "vc3", seq: 3},
+		},
+	)
+
+	last, err := iter.Last()
+	require.NoError(t, err)
+	assert.Equal(t, "c", string(last.GetKey()))
+	assert.Equal(t, "vc5", string(last.GetValue()))
+
+	prev, err := iter.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, "b", string(prev.GetKey()))
+	assert.Equal(t, "vb2", string(prev.GetValue()))
+}
+
 func TestRangeIterator_AlternatingNextPrev(t *testing.T) {
 	t.Parallel()
 	iters := []Iterator[Record]{

--- a/skiplist.go
+++ b/skiplist.go
@@ -34,6 +34,7 @@ type SkipList[K Comparable, V any] struct {
 	level    uint
 	length   uint
 	headNote *SLNode[K, V]
+	tail     *SLNode[K, V]
 	config   Config
 }
 
@@ -99,6 +100,12 @@ func (list *SkipList[K, V]) Put(searchKey K, newValue V) {
 		newNode.backward = pred
 		if succ != nil {
 			succ.backward = newNode
+		} else {
+			list.tail = newNode
+		}
+
+		if list.tail == nil {
+			list.tail = newNode
 		}
 
 		list.length++
@@ -145,6 +152,21 @@ func (list *SkipList[K, V]) FindGreaterOrEqual(searchKey K) (*SLNode[K, V], erro
 	return rn, nil
 }
 
+func (list *SkipList[K, V]) findLessOrEqual(searchKey K) (*SLNode[K, V], bool) {
+	rn := list.Head()
+	rl := list.level
+	for rl > 0 {
+		rl--
+		for rn.forwards[rl] != nil && Compare(rn.forwards[rl].Key, searchKey) != CmpGreater {
+			rn = rn.forwards[rl]
+		}
+	}
+	if rn == list.Head() {
+		return nil, false
+	}
+	return rn, true
+}
+
 // Head returns the head sentinel node of the list.
 func (list *SkipList[K, V]) Head() *SLNode[K, V] {
 	if list == nil || list.headNote == nil {
@@ -184,6 +206,13 @@ func (list *SkipList[K, V]) Remove(searchKey K) error {
 			succ.backward = pred
 		}
 		rn.backward = nil
+		if list.tail == rn {
+			if pred != nil && pred != list.Head() {
+				list.tail = pred
+			} else {
+				list.tail = nil
+			}
+		}
 		for list.level > 1 && list.Head().forwards[list.level-1] == nil {
 			list.level--
 		}
@@ -208,6 +237,7 @@ func (list *SkipList[K, V]) Clear() {
 	list.level = newList.level
 	list.length = newList.length
 	list.headNote = newList.headNote
+	list.tail = nil
 }
 
 // Len returns the number of elements currently stored in the list.
@@ -223,6 +253,7 @@ var _ Iterator[any] = (*slIterator[Comparable, any])(nil)
 type slIterator[K Comparable, V any] struct {
 	head *SLNode[K, V]
 	curr *SLNode[K, V]
+	list *SkipList[K, V]
 }
 
 // HasNext implements Iterator.
@@ -256,12 +287,24 @@ func (s *slIterator[K, V]) Prev() (V, error) {
 	return value, nil
 }
 
+// Last implements Iterator.
+func (s *slIterator[K, V]) Last() (V, error) {
+	var empty V
+	if s.list == nil || s.list.tail == nil {
+		return empty, EOI
+	}
+	tail := s.list.tail
+	s.curr = tail.backward
+	return tail.Value, nil
+}
+
 // Iterator returns a bidirectional iterator over the list's values.
 func (list *SkipList[K, V]) Iterator() Iterator[V] {
 	h := list.Head()
 	return &slIterator[K, V]{
 		head: h,
 		curr: h,
+		list: list,
 	}
 }
 
@@ -270,6 +313,7 @@ type slIRange[K Comparable, V any] struct {
 	curr     *SLNode[K, V]
 	startKey K
 	endKey   K
+	list     *SkipList[K, V]
 }
 
 // HasNext implements Iterator.
@@ -303,6 +347,23 @@ func (s *slIRange[K, V]) Prev() (V, error) {
 	return value, nil
 }
 
+// Last implements Iterator.
+func (s *slIRange[K, V]) Last() (V, error) {
+	var empty V
+	if s.list == nil {
+		return empty, EOI
+	}
+	node, ok := s.list.findLessOrEqual(s.endKey)
+	if !ok {
+		return empty, EOI
+	}
+	if Compare(node.Key, s.startKey) == CmpLess {
+		return empty, EOI
+	}
+	s.curr = node.backward
+	return node.Value, nil
+}
+
 // IRange returns an iterator over records with keys in [start, end].
 func (list *SkipList[K, V]) IRange(start, end K) Iterator[V] {
 	rn := list.Head()
@@ -318,6 +379,7 @@ func (list *SkipList[K, V]) IRange(start, end K) Iterator[V] {
 		curr:     curr,
 		startKey: start,
 		endKey:   end,
+		list:     list,
 	}
 }
 

--- a/skiplist.go
+++ b/skiplist.go
@@ -104,10 +104,6 @@ func (list *SkipList[K, V]) Put(searchKey K, newValue V) {
 			list.tail = newNode
 		}
 
-		if list.tail == nil {
-			list.tail = newNode
-		}
-
 		list.length++
 	}
 }

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -319,6 +319,28 @@ func TestSkipList_IteratorMixed(t *testing.T) {
 	assert.Equal(t, 2, v)
 }
 
+func TestSkipList_IteratorLast(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	for i := 1; i <= 4; i++ {
+		list.Put(i, i)
+	}
+
+	it, ok := list.Iterator().(*slIterator[int, int])
+	assert.True(t, ok)
+
+	last, err := it.Last()
+	assert.NoError(t, err)
+	assert.Equal(t, 4, last)
+
+	prev, err := it.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, prev)
+}
+
 func TestSkipList_IteratorConcurrentMutations(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)
@@ -426,6 +448,28 @@ func TestSkipList_IRangeMixed(t *testing.T) {
 	v, err = it.Next()
 	assert.NoError(t, err)
 	assert.Equal(t, 3, v)
+}
+
+func TestSkipList_IRangeLast(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	for i := 1; i <= 5; i++ {
+		list.Put(i, i)
+	}
+
+	it, ok := list.IRange(2, 4).(*slIRange[int, int])
+	assert.True(t, ok)
+
+	last, err := it.Last()
+	assert.NoError(t, err)
+	assert.Equal(t, 4, last)
+
+	prev, err := it.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, 3, prev)
 }
 
 func TestSkipList_Clear(t *testing.T) {

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -326,7 +326,7 @@ func (sri *sstableIRange) Last() (Record, error) {
 		})
 		switch {
 		case idx == 0:
-			return empty, EOI
+			cursor = sri.s.SparseIndex[0].offset
 		case idx < len(sri.s.SparseIndex):
 			cursor = sri.s.SparseIndex[idx].offset
 		default:

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -12,6 +12,7 @@ func (s SStable) Iterator() (Iterator[Record], error) {
 	return &sstableIterator{
 		FileSystem: s.FileSystem,
 		dataEnd:    s.dataEnd,
+		cursor:     0,
 	}, nil
 }
 
@@ -39,12 +40,13 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, dataEnd: dataEnd}, nil
+	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, startOffset: startOffset, dataEnd: dataEnd}, nil
 }
 
 type sstableIterator struct {
 	*FileSystem
 	offset  int64
+	cursor  int64
 	dataEnd int64
 }
 
@@ -69,12 +71,16 @@ func (s *sstableIterator) Next() (Record, error) {
 		return nil, err
 	}
 	s.offset = reader.Offset()
+	s.cursor = s.offset
 	return record, nil
 }
 
 // HasPrev implements Iterator.
 func (s *sstableIterator) HasPrev() bool {
-	return s.offset > 0
+	if s.cursor == 0 && s.offset > 0 {
+		s.cursor = s.offset
+	}
+	return s.cursor > 0
 }
 
 // Prev implements Iterator.
@@ -82,7 +88,7 @@ func (s *sstableIterator) Prev() (Record, error) {
 	if !s.HasPrev() {
 		return nil, EOI
 	}
-	reader := newOffsetReader(s.FileSystem, s.offset)
+	reader := newOffsetReader(s.FileSystem, s.cursor)
 	start, err := reader.PrevOffset()
 	switch {
 	case err == nil:
@@ -103,6 +109,34 @@ func (s *sstableIterator) Prev() (Record, error) {
 		return nil, err
 	}
 	s.offset = start
+	s.cursor = start
+	return record, nil
+}
+
+// Last implements Iterator.
+func (s *sstableIterator) Last() (Record, error) {
+	reader := newOffsetReader(s.FileSystem, s.dataEnd)
+	start, err := reader.PrevOffset()
+	switch {
+	case err == nil:
+		// continue
+	case errors.Is(err, io.EOF):
+		return nil, EOI
+	default:
+		return nil, err
+	}
+	reader.offset = start
+	record, _, err := readRecord(reader)
+	switch {
+	case err == nil:
+		// continue
+	case errors.Is(err, EOI), errors.Is(err, io.EOF):
+		return nil, EOI
+	default:
+		return nil, err
+	}
+	s.cursor = start
+	s.offset = reader.Offset()
 	return record, nil
 }
 
@@ -114,6 +148,7 @@ type sstableIRange struct {
 	seq            uint64
 	offset         int64
 	cursor         int64
+	startOffset    int64
 	preparedOffset int64
 	lowerBound     int64
 	haveLowerBound bool
@@ -182,6 +217,40 @@ func (sri *sstableIRange) Next() (Record, error) {
 	return next, nil
 }
 
+func (sri *sstableIRange) ensureLowerBound() error {
+	if sri.haveLowerBound {
+		return nil
+	}
+	reader := newOffsetReader(sri.s.FileSystem, sri.startOffset)
+	offset := sri.startOffset
+	for offset < sri.dataEnd {
+		cur := offset
+		rec, _, err := readRecord(reader)
+		switch {
+		case err == nil:
+			// continue
+		case errors.Is(err, EOI), errors.Is(err, io.EOF):
+			return EOI
+		default:
+			return err
+		}
+		offset = reader.Offset()
+		if rec.GetKey().Compare(sri.startKey) < 0 {
+			continue
+		}
+		if rec.GetKey().Compare(sri.endKey) > 0 {
+			return EOI
+		}
+		if rec.GetSequenceNumber() > sri.seq {
+			continue
+		}
+		sri.lowerBound = cur
+		sri.haveLowerBound = true
+		return nil
+	}
+	return EOI
+}
+
 // HasPrev implements Iterator.
 func (sri *sstableIRange) HasPrev() bool {
 	if !sri.haveLowerBound {
@@ -192,36 +261,120 @@ func (sri *sstableIRange) HasPrev() bool {
 
 // Prev implements Iterator.
 func (sri *sstableIRange) Prev() (Record, error) {
-	if !sri.HasPrev() {
-		var empty Record
-		return empty, EOI
+	var empty Record
+	for {
+		if !sri.HasPrev() {
+			return empty, EOI
+		}
+		reader := newOffsetReader(sri.s.FileSystem, sri.cursor)
+		start, err := reader.PrevOffset()
+		switch {
+		case err == nil:
+			// continue
+		case errors.Is(err, io.EOF):
+			return empty, EOI
+		default:
+			return nil, err
+		}
+		reader.offset = start
+		rec, _, err := readRecord(reader)
+		switch {
+		case err == nil:
+			// continue
+		case errors.Is(err, EOI), errors.Is(err, io.EOF):
+			sri.cursor = start
+			sri.offset = start
+			continue
+		default:
+			return nil, err
+		}
+
+		sri.offset = start
+		sri.cursor = start
+		if rec.GetKey().Compare(sri.endKey) > 0 {
+			continue
+		}
+		if rec.GetKey().Compare(sri.startKey) < 0 {
+			return empty, EOI
+		}
+		if rec.GetSequenceNumber() > sri.seq {
+			continue
+		}
+
+		sri.prepared = false
+		sri.err = nil
+		sri.next = nil
+		return rec, nil
 	}
-	reader := newOffsetReader(sri.s.FileSystem, sri.cursor)
-	start, err := reader.PrevOffset()
-	switch {
-	case err == nil:
-		// No error, continue processing
-	case errors.Is(err, io.EOF):
-		var empty Record
-		return empty, EOI
-	default:
-		return nil, err
-	}
-	reader.offset = start
-	rec, _, err := readRecord(reader)
-	switch {
-	case err == nil:
-		// No error, continue processing
-	case errors.Is(err, EOI), errors.Is(err, io.EOF):
-		var empty Record
-		return empty, EOI
-	default:
-		return nil, err
-	}
-	sri.offset = start
-	sri.cursor = start
-	sri.prepared = false
+}
+
+// Last implements Iterator.
+func (sri *sstableIRange) Last() (Record, error) {
+	var empty Record
 	sri.err = nil
+	sri.prepared = false
 	sri.next = nil
-	return rec, nil
+
+	if err := sri.ensureLowerBound(); err != nil {
+		return empty, err
+	}
+
+	cursor := sri.dataEnd
+	if len(sri.s.SparseIndex) > 0 {
+		idx := sort.Search(len(sri.s.SparseIndex), func(i int) bool {
+			return sri.s.SparseIndex[i].key.Compare(sri.endKey) == CmpGreater
+		})
+		switch {
+		case idx == 0:
+			return empty, EOI
+		case idx < len(sri.s.SparseIndex):
+			cursor = sri.s.SparseIndex[idx].offset
+		default:
+			cursor = sri.dataEnd
+		}
+	}
+
+	for {
+		if cursor <= 0 {
+			return empty, EOI
+		}
+		reader := newOffsetReader(sri.s.FileSystem, cursor)
+		start, err := reader.PrevOffset()
+		switch {
+		case err == nil:
+			// continue
+		case errors.Is(err, io.EOF):
+			return empty, EOI
+		default:
+			return empty, err
+		}
+		reader.offset = start
+		rec, _, err := readRecord(reader)
+		switch {
+		case err == nil:
+			// continue
+		case errors.Is(err, EOI), errors.Is(err, io.EOF):
+			cursor = start
+			continue
+		default:
+			return empty, err
+		}
+		cursor = start
+		key := rec.GetKey()
+		if key.Compare(sri.endKey) == CmpGreater {
+			continue
+		}
+		if key.Compare(sri.startKey) == CmpLess {
+			return empty, EOI
+		}
+		if rec.GetSequenceNumber() > sri.seq {
+			continue
+		}
+		sri.cursor = start
+		sri.offset = reader.Offset()
+		if sri.offset > sri.dataEnd {
+			sri.offset = sri.dataEnd
+		}
+		return rec, nil
+	}
 }

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -96,6 +96,35 @@ func TestSSTableIterator_MixedDirectionIteration(t *testing.T) {
 	assert.False(t, it.HasPrev())
 }
 
+func TestSSTableIterator_Last(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc"), 3))
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.Iterator()
+	require.NoError(t, err)
+
+	last, err := it.Last()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("c"), last.GetKey())
+	assert.Equal(t, Bytes("vc"), last.GetValue())
+
+	prev, err := it.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), prev.GetKey())
+}
+
 func TestSSTableIRange_ReverseIteration(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)
@@ -131,6 +160,38 @@ func TestSSTableIRange_ReverseIteration(t *testing.T) {
 
 	assert.Equal(t, []Bytes{Bytes("a"), Bytes("b"), Bytes("c")}, fwd)
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, rev)
+}
+
+func TestSSTableIRange_Last(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va1"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb3"), 3))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb2"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc5"), 5))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc1"), 1))
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.IRange(Bytes("a"), Bytes("c"), 2)
+	require.NoError(t, err)
+
+	last, err := it.Last()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("c"), last.GetKey())
+	assert.Equal(t, uint64(1), last.GetSequenceNumber())
+
+	prev, err := it.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), prev.GetKey())
+	assert.Equal(t, uint64(2), prev.GetSequenceNumber())
 }
 
 func TestSSTableIterator_PrevFullTraversal(t *testing.T) {


### PR DESCRIPTION
## Summary
- extend the iterator contract with a Last helper and implement tail-aware positioning across the skip list, memtable range iterator, and SSTable iterators
- teach the merging iterator to invoke child Last during descending seeding and ensure range iterators rewind so Prev skips the tail record
- add regression coverage for the new Last/Prev behaviour on skip lists, memtable ranges, SSTable ranges, and the public range iterator

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68d227b969048325ad3da7959b0bdf31