### PR TITLE
Add descending seeding for SSTable range iterators

### DIFF
--- a/rindb.go
+++ b/rindb.go
@@ -307,7 +307,7 @@ func (r *Rindb) buildSources(ctx context.Context, start, end Bytes, order RangeO
 	}
 
 	for _, entry := range entries {
-		rangeIter, err := entry.Table.IRange(start, end, maxSeq)
+		rangeIter, err := entry.Table.IRange(start, end, order, maxSeq)
 		if err != nil {
 			cleanup()
 			return nil, nil, err

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -56,8 +56,8 @@ func (s SStable) IRange(start, end Bytes, order RangeOrder, seq ...uint64) (Iter
 			sri.offset = nextOffset
 			sri.cursor = nextOffset
 		} else {
-			sri.offset = 0
-			sri.cursor = 0
+			sri.offset = dataEnd
+			sri.cursor = dataEnd
 		}
 	}
 
@@ -73,7 +73,7 @@ func (s SStable) findOffsetLE(end Bytes) (int64, int64, bool) {
 	})
 	switch {
 	case idx == 0:
-		return 0, s.SparseIndex[0].offset, false
+		return 0, s.SparseIndex[0].offset, true
 	case idx < len(s.SparseIndex):
 		return s.SparseIndex[idx-1].offset, s.SparseIndex[idx].offset, true
 	default:

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -18,7 +18,7 @@ func (s SStable) Iterator() (Iterator[Record], error) {
 
 // IRange returns an iterator over records with keys in [start, end] and sequence
 // numbers less than or equal to seq.
-func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], error) {
+func (s SStable) IRange(start, end Bytes, order RangeOrder, seq ...uint64) (Iterator[Record], error) {
 	maxSeq := getMaxSeq(seq...)
 	startIdx := sort.Search(len(s.SparseIndex), func(i int) bool {
 		return s.SparseIndex[i].key.Compare(start) >= 0
@@ -40,7 +40,45 @@ func (s SStable) IRange(start, end Bytes, seq ...uint64) (Iterator[Record], erro
 	}
 	dataEnd := int64(byteOrder.Uint64(buf))
 
-	return &sstableIRange{s: &s, startKey: start, endKey: end, seq: maxSeq, offset: startOffset, startOffset: startOffset, dataEnd: dataEnd}, nil
+	sri := &sstableIRange{
+		s:           &s,
+		startKey:    start,
+		endKey:      end,
+		seq:         maxSeq,
+		offset:      startOffset,
+		startOffset: startOffset,
+		dataEnd:     dataEnd,
+		order:       order,
+	}
+
+	if order == RangeDesc {
+		if _, nextOffset, ok := s.findOffsetLE(end); ok {
+			sri.offset = nextOffset
+			sri.cursor = nextOffset
+		} else {
+			sri.offset = 0
+			sri.cursor = 0
+		}
+	}
+
+	return sri, nil
+}
+
+func (s SStable) findOffsetLE(end Bytes) (int64, int64, bool) {
+	if len(s.SparseIndex) == 0 {
+		return 0, 0, false
+	}
+	idx := sort.Search(len(s.SparseIndex), func(i int) bool {
+		return s.SparseIndex[i].key.Compare(end) == CmpGreater
+	})
+	switch {
+	case idx == 0:
+		return 0, s.SparseIndex[0].offset, false
+	case idx < len(s.SparseIndex):
+		return s.SparseIndex[idx-1].offset, s.SparseIndex[idx].offset, true
+	default:
+		return s.SparseIndex[len(s.SparseIndex)-1].offset, s.dataEnd, true
+	}
 }
 
 type sstableIterator struct {
@@ -142,20 +180,22 @@ func (s *sstableIterator) Last() (Record, error) {
 
 // sstableIRange iterates over a range of keys in an SSTable.
 type sstableIRange struct {
-	s              *SStable
-	startKey       Bytes
-	endKey         Bytes
-	seq            uint64
-	offset         int64
-	cursor         int64
-	startOffset    int64
-	preparedOffset int64
-	lowerBound     int64
-	haveLowerBound bool
-	dataEnd        int64
-	next           Record
-	err            error
-	prepared       bool
+	s                *SStable
+	startKey         Bytes
+	endKey           Bytes
+	seq              uint64
+	offset           int64
+	cursor           int64
+	startOffset      int64
+	preparedOffset   int64
+	lowerBound       int64
+	haveLowerBound   bool
+	dataEnd          int64
+	next             Record
+	err              error
+	prepared         bool
+	order            RangeOrder
+	descendingPrimed bool
 }
 
 func (sri *sstableIRange) prepare() {
@@ -194,8 +234,81 @@ func (sri *sstableIRange) prepare() {
 	}
 }
 
+func (sri *sstableIRange) primeDescending() {
+	if sri.descendingPrimed || sri.err != nil {
+		return
+	}
+	if sri.offset == 0 && sri.cursor > 0 {
+		sri.offset = sri.cursor
+	}
+	sri.descendingPrimed = true
+}
+
+func (sri *sstableIRange) primeNextDescending() {
+	if sri.err != nil {
+		return
+	}
+	if !sri.descendingPrimed {
+		sri.primeDescending()
+	}
+	for !sri.prepared && sri.err == nil {
+		if sri.offset <= 0 {
+			sri.err = EOI
+			return
+		}
+		reader := newOffsetReader(sri.s.FileSystem, sri.offset)
+		start, err := reader.PrevOffset()
+		switch {
+		case err == nil:
+		case errors.Is(err, io.EOF):
+			sri.err = EOI
+			return
+		default:
+			sri.err = err
+			return
+		}
+		reader.offset = start
+		rec, _, err := readRecord(reader)
+		switch {
+		case err == nil:
+		case errors.Is(err, EOI), errors.Is(err, io.EOF):
+			sri.offset = start
+			sri.cursor = start
+			continue
+		default:
+			sri.err = err
+			return
+		}
+		sri.offset = start
+		sri.cursor = reader.Offset()
+		key := rec.GetKey()
+		if key.Compare(sri.endKey) == CmpGreater {
+			continue
+		}
+		if key.Compare(sri.startKey) == CmpLess {
+			sri.err = EOI
+			return
+		}
+		if rec.GetSequenceNumber() > sri.seq {
+			continue
+		}
+		sri.preparedOffset = start
+		sri.next = rec
+		sri.prepared = true
+	}
+}
+
 // HasNext implements Iterator.
 func (sri *sstableIRange) HasNext() bool {
+	if sri.order == RangeDesc {
+		if !sri.descendingPrimed {
+			sri.primeDescending()
+		}
+		if !sri.prepared {
+			sri.primeNextDescending()
+		}
+		return sri.prepared
+	}
 	sri.prepare()
 	return sri.prepared
 }
@@ -206,11 +319,13 @@ func (sri *sstableIRange) Next() (Record, error) {
 		var empty Record
 		return empty, sri.err
 	}
-	if !sri.haveLowerBound {
+	if !sri.haveLowerBound || sri.preparedOffset < sri.lowerBound {
 		sri.lowerBound = sri.preparedOffset
 		sri.haveLowerBound = true
 	}
-	sri.cursor = sri.offset
+	if sri.order != RangeDesc {
+		sri.cursor = sri.offset
+	}
 	sri.prepared = false
 	next := sri.next
 	sri.next = nil

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -141,7 +141,7 @@ func TestSSTableIRange_ReverseIteration(t *testing.T) {
 	sst, _, err := flush(ctx, cfg, mem, fs)
 	require.NoError(t, err)
 
-	it, err := sst.IRange(Bytes("a"), Bytes("c"))
+	it, err := sst.IRange(Bytes("a"), Bytes("c"), RangeAsc)
 	require.NoError(t, err)
 
 	var fwd []Bytes
@@ -162,6 +162,71 @@ func TestSSTableIRange_ReverseIteration(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, rev)
 }
 
+func TestSSTableIRange_DescendingNext(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	for idx, key := range []string{"a", "b", "c", "d"} {
+		mem.Put(newRecord(Bytes(key), Bytes("v"+key), uint64(idx+1)))
+	}
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.IRange(Bytes("a"), Bytes("d"), RangeDesc)
+	require.NoError(t, err)
+
+	var keys []Bytes
+	for it.HasNext() {
+		rec, err := it.Next()
+		require.NoError(t, err)
+		keys = append(keys, rec.GetKey())
+	}
+
+	assert.Equal(t, []Bytes{Bytes("d"), Bytes("c"), Bytes("b"), Bytes("a")}, keys)
+}
+
+func TestSSTableIRange_DescendingOscillation(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc"), 3))
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.IRange(Bytes("a"), Bytes("c"), RangeDesc)
+	require.NoError(t, err)
+
+	rec, err := it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("c"), rec.GetKey())
+
+	rec, err = it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	rec, err = it.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	rec, err = it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+}
+
 func TestSSTableIRange_Last(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)
@@ -180,7 +245,7 @@ func TestSSTableIRange_Last(t *testing.T) {
 	sst, _, err := flush(ctx, cfg, mem, fs)
 	require.NoError(t, err)
 
-	it, err := sst.IRange(Bytes("a"), Bytes("c"), 2)
+	it, err := sst.IRange(Bytes("a"), Bytes("c"), RangeAsc, 2)
 	require.NoError(t, err)
 
 	last, err := it.Last()
@@ -252,7 +317,7 @@ func TestSSTableIRange_PrevFullTraversal(t *testing.T) {
 	sst, _, err := flush(ctx, cfg, mem, fs)
 	require.NoError(t, err)
 
-	it, err := sst.IRange(Bytes("b"), Bytes("e"))
+	it, err := sst.IRange(Bytes("b"), Bytes("e"), RangeAsc)
 	require.NoError(t, err)
 
 	var fwd []Bytes
@@ -341,7 +406,7 @@ func TestSSTableIRange_PrepareErrorPropagation(t *testing.T) {
 	sst, _, err := flush(ctx, cfg, mem, fs)
 	require.NoError(t, err)
 
-	iterIface, err := sst.IRange(Bytes("a"), Bytes("z"))
+	iterIface, err := sst.IRange(Bytes("a"), Bytes("z"), RangeAsc)
 	require.NoError(t, err)
 	iter := iterIface.(*sstableIRange)
 
@@ -374,7 +439,7 @@ func TestSSTableIRange_PrevOffsetEOFError(t *testing.T) {
 	sst, _, err := flush(ctx, cfg, mem, fs)
 	require.NoError(t, err)
 
-	iterIface, err := sst.IRange(Bytes("a"), Bytes("z"))
+	iterIface, err := sst.IRange(Bytes("a"), Bytes("z"), RangeAsc)
 	require.NoError(t, err)
 	iter := iterIface.(*sstableIRange)
 

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -319,7 +319,7 @@ func TestSSTable_BasicOperations(t *testing.T) {
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				iterator, err := sstable.IRange(tt.startKey, tt.endKey)
+				iterator, err := sstable.IRange(tt.startKey, tt.endKey, RangeAsc)
 				if tt.expectError {
 					assert.Error(t, err)
 					return
@@ -902,7 +902,7 @@ func TestSSTable_IRangeGetValueConsistency(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, meta.Number)
 
-			it, err := sst.IRange(tt.records[0].key, tt.records[len(tt.records)-1].key, tt.seq)
+			it, err := sst.IRange(tt.records[0].key, tt.records[len(tt.records)-1].key, RangeAsc, tt.seq)
 			require.NoError(t, err)
 
 			idx := 0


### PR DESCRIPTION
## Summary
- extend `SStable.IRange` to accept a `RangeOrder`, locate the final sparse-index block with `findOffsetLE`, and prime descending scans with a dedicated backward stepping path
- pass the requested order into SSTable sources so merging iterators reuse the descending seed logic
- cover descending SSTable range iteration and update callers to the new signature

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68d52accd9e48325b87d8a998fe39ac6