### PR TITLE
feat: document descending range order

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,19 @@ for it.HasPrev() {
     fmt.Printf("rev %s => %s\n", rec.GetKey(), rec.GetValue())
 }
 it.Close()
+
+// Descending scans stream the highest key first.
+desc, _ := db.IRange(ctx, []byte("k1"), []byte("k3"), rindb.IRangeOrder(rindb.RangeDesc))
+for desc.HasNext() {
+    rec, _ := desc.Next()
+    fmt.Printf("desc %s => %s\n", rec.GetKey(), rec.GetValue())
+}
+desc.Close()
 ```
+
+Range scans walk keys in ascending order by default. Pass
+`rindb.IRangeOrder(rindb.RangeDesc)` (or `range <start> <end> desc` in the CLI) to
+stream records from the upper bound down to the start key.
 
 ### Runtime Statistics
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,7 @@ func main() {
 		fmt.Println("Error initializing database:", err)
 		return
 	}
-	fmt.Println("rindb started. Commands: put <key> <value>, get <key>, remove <key>, range <start> <end>, stats, exit")
+	fmt.Println("rindb started. Commands: put <key> <value>, get <key>, remove <key>, range <start> <end> [asc|desc], stats, exit")
 	defer db.Close()
 
 	scanner := bufio.NewScanner(os.Stdin)
@@ -75,11 +75,29 @@ func main() {
 				fmt.Println("OK")
 			}
 		case "range":
-			if len(parts) != 3 {
-				fmt.Println("Usage: range <start> <end>")
+			if len(parts) < 3 || len(parts) > 4 {
+				fmt.Println("Usage: range <start> <end> [asc|desc]")
 				continue
 			}
-			iter, err := db.IRange(ctx, rindb.Bytes(parts[1]), rindb.Bytes(parts[2]))
+			order := rindb.RangeAsc
+			if len(parts) == 4 {
+				switch strings.ToLower(parts[3]) {
+				case "asc", "ascending":
+					order = rindb.RangeAsc
+				case "desc", "descending":
+					order = rindb.RangeDesc
+				default:
+					fmt.Println("Usage: range <start> <end> [asc|desc]")
+					continue
+				}
+			}
+
+			opts := make([]rindb.RangeOption, 0, 1)
+			if order == rindb.RangeDesc {
+				opts = append(opts, rindb.IRangeOrder(order))
+			}
+
+			iter, err := db.IRange(ctx, rindb.Bytes(parts[1]), rindb.Bytes(parts[2]), opts...)
 			if err != nil {
 				fmt.Println("Error:", err)
 				continue

--- a/integration/range_iterator_next_prev_test.go
+++ b/integration/range_iterator_next_prev_test.go
@@ -117,6 +117,38 @@ func TestRangeIterator_AlternatingNextPrevAcrossLevels(t *testing.T) {
 	require.ErrorIs(t, err, rindb.EOI)
 }
 
+func TestRangeIterator_DescendingNextPrevAcrossLevels(t *testing.T) {
+	t.Parallel()
+	db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(100))
+	t.Cleanup(cleanup)
+	ctx := context.Background()
+
+	large := strings.Repeat("x", 40)
+
+	require.NoError(t, db.Put(ctx, rindb.Bytes("a"), rindb.Bytes(large)))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("b"), rindb.Bytes(large)))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("c"), rindb.Bytes(large)))
+
+	require.NoError(t, db.Remove(ctx, rindb.Bytes("b")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("d"), rindb.Bytes("1")))
+	require.NoError(t, db.Put(ctx, rindb.Bytes("e"), rindb.Bytes("2")))
+
+	iter, err := db.IRange(ctx, rindb.Bytes("a"), rindb.Bytes("z"), rindb.IRangeOrder(rindb.RangeDesc))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, iter.Close()) })
+
+	runRangeIterSequence(t, iter, []rangeIterStep{
+		{dir: iterPrev, eoi: true},
+		{dir: iterNext, key: "e", value: "2"},
+		{dir: iterNext, key: "d", value: "1"},
+		{dir: iterPrev, key: "d", value: "1"},
+		{dir: iterNext, key: "c", value: large},
+		{dir: iterNext, key: "a", value: large},
+		{dir: iterNext, eoi: true},
+		{dir: iterPrev, key: "a", value: large},
+	})
+}
+
 func TestRangeIterator_AlternatingNextPrevSequences(t *testing.T) {
 	t.Parallel()
 	t.Run("single-key-latest-version-only", func(t *testing.T) {
@@ -197,6 +229,55 @@ func TestRangeIterator_AlternatingNextPrevSequences(t *testing.T) {
 			{dir: iterPrev, key: keyC, value: valueC3},
 			{dir: iterNext, key: keyC, value: valueC3},
 			{dir: iterNext, eoi: true},
+		})
+	})
+
+	t.Run("multi-key-span-desc", func(t *testing.T) {
+		db, cleanup := initTestDB(t, rindb.WithMaxMemtableSize(300))
+		t.Cleanup(cleanup)
+		ctx := context.Background()
+
+		const (
+			keyA = "a"
+			keyB = "b"
+			keyC = "c"
+		)
+
+		valueA1 := strings.Repeat("a1", 90)
+		valueA2 := strings.Repeat("a2", 90)
+		valueB1 := strings.Repeat("b1", 90)
+		valueB2 := strings.Repeat("b2", 90)
+		valueC1 := strings.Repeat("c1", 90)
+		valueC2 := strings.Repeat("c2", 90)
+		valueA3 := "a3"
+		valueB3 := "b3"
+		valueC3 := "c3"
+
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyA), rindb.Bytes(valueA1)))
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyA), rindb.Bytes(valueA2)))
+
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyB), rindb.Bytes(valueB1)))
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyB), rindb.Bytes(valueB2)))
+
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyC), rindb.Bytes(valueC1)))
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyC), rindb.Bytes(valueC2)))
+
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyA), rindb.Bytes(valueA3)))
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyB), rindb.Bytes(valueB3)))
+		require.NoError(t, db.Put(ctx, rindb.Bytes(keyC), rindb.Bytes(valueC3)))
+
+		iter, err := db.IRange(ctx, rindb.Bytes(keyA), rindb.Bytes("z"), rindb.IRangeOrder(rindb.RangeDesc))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, iter.Close()) })
+
+		runRangeIterSequence(t, iter, []rangeIterStep{
+			{dir: iterPrev, eoi: true},
+			{dir: iterNext, key: keyC, value: valueC3},
+			{dir: iterNext, key: keyB, value: valueB3},
+			{dir: iterPrev, key: keyB, value: valueB3},
+			{dir: iterNext, key: keyA, value: valueA3},
+			{dir: iterNext, eoi: true},
+			{dir: iterPrev, key: keyA, value: valueA3},
 		})
 	})
 

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -542,6 +542,38 @@ func TestMemtableIRange_DescendingPrev(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("c"), Bytes("b"), Bytes("a")}, keys)
 }
 
+func TestMemtableIRange_DescendingNext(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va1"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb2"), 2))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc3"), 3))
+
+	it := mem.IRange(Bytes("a"), Bytes("c"), 3, RangeDesc)
+
+	rec, err := it.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("c"), rec.GetKey())
+
+	it = mem.IRange(Bytes("a"), Bytes("c"), 3, RangeDesc)
+
+	var keys []Bytes
+	for it.HasNext() {
+		rec, err := it.Next()
+		assert.NoError(t, err)
+		keys = append(keys, rec.GetKey())
+	}
+	assert.Equal(t, []Bytes{Bytes("a"), Bytes("b"), Bytes("c")}, keys)
+
+	_, err = it.Next()
+	assert.ErrorIs(t, err, EOI)
+
+	rec, err = it.Prev()
+	assert.NoError(t, err)
+	assert.Equal(t, Bytes("c"), rec.GetKey())
+}
+
 func TestMemtableIRange_DescendingSequenceFilter(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -314,14 +314,27 @@ func TestRindb_IRangeDescending(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { assert.NoError(t, iter.Close()) }()
 
-	var keys []string
-	for iter.HasNext() {
-		rec, err := iter.Next()
-		require.NoError(t, err)
-		keys = append(keys, string(rec.GetKey()))
-	}
+	_, err = iter.Prev()
+	require.ErrorIs(t, err, EOI)
 
-	assert.Equal(t, []string{"c", "b", "a"}, keys)
+	rec, err := iter.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("c"), rec.GetKey())
+
+	rec, err = iter.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	rec, err = iter.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+
+	_, err = iter.Next()
+	require.ErrorIs(t, err, EOI)
 }
 
 // TestRindb_Remove tests the Remove operation of Rindb.

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -191,6 +191,48 @@ func TestSSTableIRange_DescendingNext(t *testing.T) {
 	assert.Equal(t, []Bytes{Bytes("d"), Bytes("c"), Bytes("b"), Bytes("a")}, keys)
 }
 
+func TestSSTableIRange_DescendingPriming(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	for idx, key := range []string{"a", "b", "c"} {
+		mem.Put(newRecord(Bytes(key), Bytes("v"+key), uint64(idx+1)))
+	}
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	it, err := sst.IRange(Bytes("a"), Bytes("c"), RangeDesc)
+	require.NoError(t, err)
+
+	_, err = it.Prev()
+	require.ErrorIs(t, err, EOI)
+
+	rec, err := it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("c"), rec.GetKey())
+
+	rec, err = it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	rec, err = it.Prev()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("b"), rec.GetKey())
+
+	rec, err = it.Next()
+	require.NoError(t, err)
+	assert.Equal(t, Bytes("a"), rec.GetKey())
+
+	_, err = it.Next()
+	require.ErrorIs(t, err, EOI)
+}
+
 func TestSSTableIRange_DescendingOscillation(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)


### PR DESCRIPTION
## Summary
- add documentation and CLI support for the descending `IRange` order flag
- expand unit and integration tests to exercise descending scans across Rindb, memtable, and SSTable iterators

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68d56b75834c8325be897594fc5a3b24