### PR TITLE
test: capture descending range seq regression

### DIFF
--- a/docs/dev/312/suspicious_range_direction.md
+++ b/docs/dev/312/suspicious_range_direction.md
@@ -1,0 +1,7 @@
+# Range iteration directional audit
+
+## Suspicious logic
+
+- `sstable_iteration.go`: `sstableIRange.Prev` surfaces the record found at the previous physical offset without reapplying the original `[start, end]` window or the `seq` ceiling. When walking backwards after a forward scan has skipped entries (for example because their sequence exceeds the caller's snapshot), `Prev` can reintroduce those filtered versions, leaking state from outside the requested snapshot into descending scans.
+- `range.go`: `RangeIterator.preparePrev` and `prepareNext` assume that every child iterator enforces the snapshot bounds in both directions. They only filter tombstones/duplicates, so if an underlying iterator leaks an out-of-range version during `Prev` (as in `sstableIRange` above) the user-facing iterator cannot defend against it. This makes the backward direction particularly risky when multiple layers contribute to the merged view.
+

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -213,6 +213,45 @@ func TestSSTableIRange_PrevFullTraversal(t *testing.T) {
 	assert.False(t, it.HasPrev())
 }
 
+func TestSSTableIRange_PrevRespectsSequenceFilter(t *testing.T) {
+	t.Parallel()
+	cfg := testConfig(t)
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+	fs := fss[0]
+
+	mem := InitMemtable(cfg)
+	mem.Put(newRecord(Bytes("a"), Bytes("va"), 1))
+	mem.Put(newRecord(Bytes("b"), Bytes("vb"), 4))
+	mem.Put(newRecord(Bytes("c"), Bytes("vc"), 1))
+
+	sst, _, err := flush(ctx, cfg, mem, fs)
+	require.NoError(t, err)
+
+	iterIface, err := sst.IRange(Bytes("a"), Bytes("z"), 1)
+	require.NoError(t, err)
+	iter := iterIface.(*sstableIRange)
+
+	var forward []Bytes
+	for iter.HasNext() {
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		forward = append(forward, rec.GetKey())
+	}
+	require.Equal(t, []Bytes{Bytes("a"), Bytes("c")}, forward)
+
+	require.True(t, iter.HasPrev())
+	rec, err := iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, Bytes("c"), rec.GetKey())
+
+	require.True(t, iter.HasPrev())
+	rec, err = iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, Bytes("a"), rec.GetKey(), "Prev leaked a version that should have been filtered by the seq bound")
+}
+
 func TestSSTableIterator_PrevOffsetErrorPropagation(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -250,6 +250,7 @@ func TestSSTableIRange_PrevRespectsSequenceFilter(t *testing.T) {
 	rec, err = iter.Prev()
 	require.NoError(t, err)
 	require.Equal(t, Bytes("a"), rec.GetKey(), "Prev leaked a version that should have been filtered by the seq bound")
+	require.False(t, iter.HasPrev())
 }
 
 func TestSSTableIterator_PrevOffsetErrorPropagation(t *testing.T) {


### PR DESCRIPTION
## Summary
- record the most suspicious range-direction logic in docs/dev/312/suspicious_range_direction.md
- add TestSSTableIRange_PrevRespectsSequenceFilter to demonstrate backward scans leaking high-sequence versions

## Testing
- go test ./... *(fails: TestSSTableIRange_PrevRespectsSequenceFilter reproduces the regression)*

------
https://chatgpt.com/codex/tasks/task_e_68d819c99878832594bba0e4c83367cc