### PR TITLE
test: add coverage for tombstone direction changes

### DIFF
--- a/range_test.go
+++ b/range_test.go
@@ -228,6 +228,35 @@ func TestRangeIteratorPrev_ReturnsLatestAfterDirectionChange(t *testing.T) {
 	mustPrevEOI(t, iter)
 }
 
+func TestRangeIteratorPrev_HidesTombstoneOnDirectionChange(t *testing.T) {
+	t.Parallel()
+
+	iter := buildRangeIter(t,
+		[]kv{{key: "k", seq: 3, typ: TypeDeletion}},
+		[]kv{{key: "k", value: "v2", seq: 2}},
+	)
+
+	mustNextValue(t, iter, "k", "v2")
+	mustPrevValue(t, iter, "k", "v2")
+	mustPrevEOI(t, iter)
+}
+
+func TestRangeIteratorPrev_HidesTombstoneWithinSource(t *testing.T) {
+	t.Parallel()
+
+	iter := buildRangeIter(t,
+		[]kv{
+			{key: "k", seq: 3, typ: TypeDeletion},
+			{key: "k", value: "v2", seq: 2},
+			{key: "k", value: "v1", seq: 1},
+		},
+	)
+
+	mustNextValue(t, iter, "k", "v2")
+	mustPrevValue(t, iter, "k", "v2")
+	mustPrevEOI(t, iter)
+}
+
 func TestRangeIterator_AlternatingNextPrev(t *testing.T) {
 	t.Parallel()
 	iters := []Iterator[Record]{


### PR DESCRIPTION
## Summary
- add regression tests illustrating how RangeIterator loses the latest value when reversing direction across tombstones coming from another source or the same SSTable

## Testing
- `go test -run 'TestRangeIteratorPrev_HidesTombstone' -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68d819c99878832594bba0e4c83367cc