### PR TITLE
fix: align range iterator prev with staged peek

### DIFF
--- a/range.go
+++ b/range.go
@@ -210,6 +210,10 @@ func (r *RangeIterator) primePrev() {
 		if sameKey {
 			if r.allowAnchorOnPrev() && r.matchesCrossingAnchor(rec) {
 				r.crossingAnchorSet = false
+			} else if r.nextPrepared && recordsEqual(rec, r.next) {
+				// A forward peek staged this record; treat it as the anchor so Prev can surface it.
+				r.crossingAnchor = rec
+				r.crossingAnchorSet = true
 			} else {
 				continue
 			}
@@ -394,6 +398,15 @@ func (r *RangeIterator) matchesCrossingAnchor(rec Record) bool {
 		rec.GetSequenceNumber() == r.crossingAnchor.GetSequenceNumber() &&
 		rec.GetType() == r.crossingAnchor.GetType() &&
 		rec.GetKey().Compare(r.crossingAnchor.GetKey()) == CmpEqual
+}
+
+func recordsEqual(a, b Record) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return a.GetSequenceNumber() == b.GetSequenceNumber() &&
+		a.GetType() == b.GetType() &&
+		a.GetKey().Compare(b.GetKey()) == CmpEqual
 }
 
 func newEmptyRangeIterator() *RangeIterator {

--- a/range.go
+++ b/range.go
@@ -393,11 +393,7 @@ func (r *RangeIterator) Close() error {
 }
 
 func (r *RangeIterator) matchesCrossingAnchor(rec Record) bool {
-	return r.crossingAnchorSet &&
-		r.crossingAnchor != nil &&
-		rec.GetSequenceNumber() == r.crossingAnchor.GetSequenceNumber() &&
-		rec.GetType() == r.crossingAnchor.GetType() &&
-		rec.GetKey().Compare(r.crossingAnchor.GetKey()) == CmpEqual
+	return r.crossingAnchorSet && recordsEqual(rec, r.crossingAnchor)
 }
 
 func recordsEqual(a, b Record) bool {

--- a/range_test.go
+++ b/range_test.go
@@ -317,8 +317,10 @@ func TestRangeIterator_PrevAfterHasNext(t *testing.T) {
 
 	require.True(t, iter.HasNext())
 
-	_, err := iter.Prev()
-	require.ErrorIs(t, err, EOI)
+	rec, err := iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, "a", string(rec.GetKey()))
+	require.Equal(t, "va", string(rec.GetValue()))
 }
 
 func TestRangeIterator_EmptyIterator(t *testing.T) {

--- a/sstable_iteration_test.go
+++ b/sstable_iteration_test.go
@@ -409,7 +409,7 @@ func TestSSTableIRange_PrevRespectsSequenceFilter(t *testing.T) {
 	sst, _, err := flush(ctx, cfg, mem, fs)
 	require.NoError(t, err)
 
-	iterIface, err := sst.IRange(Bytes("a"), Bytes("z"), 1)
+	iterIface, err := sst.IRange(Bytes("a"), Bytes("z"), RangeAsc, 1)
 	require.NoError(t, err)
 	iter := iterIface.(*sstableIRange)
 


### PR DESCRIPTION
## Summary
- ensure the SSTable sequence filter test requests an ascending range order
- allow `RangeIterator.Prev` to surface the staged forward record after a peek and add a helper for record equality
- update the range iterator regression test to assert the returned record instead of expecting `EOI`

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d884f5bb2c832580d1020263f7e232