### PR TITLE
refactor: centralize range iterator backward traversal

### DIFF
--- a/range.go
+++ b/range.go
@@ -116,6 +116,13 @@ func (r *RangeIterator) allowAnchorOnPrev() bool {
 	return r.forward
 }
 
+func (r *RangeIterator) allowAnchorOnPrevForOrder(order RangeOrder) bool {
+	if order == RangeDesc {
+		return !r.forward
+	}
+	return r.forward
+}
+
 func (r *RangeIterator) primeNext() {
 	for !r.nextPrepared && r.err == nil {
 		var (
@@ -185,14 +192,18 @@ func (r *RangeIterator) primeNext() {
 }
 
 func (r *RangeIterator) primePrev() {
+	r.primePrevWithOrder(r.order)
+}
+
+func (r *RangeIterator) primePrevWithOrder(order RangeOrder) {
 	for !r.prevPrepared && r.err == nil {
 		var (
 			rec Record
 			err error
 		)
-		if r.order == RangeDesc {
+		if order == RangeDesc {
 			rec, err = r.mi.Next()
-			if errors.Is(r.reverseErr, EOI) {
+			if order == r.order && errors.Is(r.reverseErr, EOI) {
 				r.reverseErr = nil
 			}
 		} else {
@@ -206,29 +217,37 @@ func (r *RangeIterator) primePrev() {
 			return
 		}
 
-		sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
-		if sameKey {
-			if r.allowAnchorOnPrev() && r.matchesCrossingAnchor(rec) {
-				r.crossingAnchorSet = false
-			} else if r.nextPrepared && recordsEqual(rec, r.next) {
-				// A forward peek staged this record; treat it as the anchor so Prev can surface it.
-				r.crossingAnchor = rec
-				r.crossingAnchorSet = true
-			} else {
-				continue
-			}
-		}
-		r.lastKey = rec.GetKey().Clone()
-		r.lastKeySet = true
-		if rec.GetType() == TypeDeletion {
+		if !r.stagePrevCandidate(rec, order) {
 			continue
 		}
-		r.prev = rec
-		r.prevPrepared = true
 	}
 	if r.prevPrepared {
 		r.nextPrepared = false
 	}
+}
+
+func (r *RangeIterator) stagePrevCandidate(rec Record, order RangeOrder) bool {
+	sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
+	if sameKey {
+		if r.allowAnchorOnPrevForOrder(order) && r.matchesCrossingAnchor(rec) {
+			r.crossingAnchorSet = false
+		} else if r.nextPrepared && recordsEqual(rec, r.next) {
+			// A forward peek staged this record; treat it as the anchor so Prev can surface it.
+			r.crossingAnchor = rec
+			r.crossingAnchorSet = true
+		} else {
+			return false
+		}
+	}
+	r.lastKey = rec.GetKey().Clone()
+	r.lastKeySet = true
+	if rec.GetType() == TypeDeletion {
+		return false
+	}
+	r.prev = rec
+	r.prevPrepared = true
+	r.nextPrepared = false
+	return true
 }
 
 // HasNext implements Iterator[Record].
@@ -309,81 +328,62 @@ func (r *RangeIterator) Last() (Record, error) {
 	r.reverseCached = nil
 	r.reverseErr = nil
 
+	initialOrder := r.order
+	if r.order == RangeDesc {
+		initialOrder = RangeAsc
+	}
+
+	prepared := r.stagePrevCandidate(rec, initialOrder)
 	if r.order == RangeDesc {
 		var lastValid Record
+		if prepared {
+			current, err := r.Prev()
+			if err != nil {
+				return empty, err
+			}
+			lastValid = current
+			prepared = false
+		}
+
 		for {
-			sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
-			if sameKey || rec.GetType() == TypeDeletion {
-				prev, err := r.mi.Prev()
-				switch {
-				case err == nil:
-					rec = prev
-					continue
-				case errors.Is(err, EOI):
-					if lastValid == nil {
-						return empty, EOI
+			if !prepared {
+				r.primePrevWithOrder(RangeAsc)
+				if !r.prevPrepared {
+					if r.err != nil {
+						return empty, r.err
 					}
-					r.lastKey = lastValid.GetKey().Clone()
-					r.lastKeySet = true
-					r.crossingAnchor = lastValid
-					r.crossingAnchorSet = true
-					return lastValid, nil
-				default:
-					return empty, err
+					if lastValid != nil {
+						return lastValid, nil
+					}
+					return empty, EOI
 				}
 			}
 
-			r.lastKey = rec.GetKey().Clone()
-			r.lastKeySet = true
-			lastValid = rec
-
-			prev, err := r.mi.Prev()
-			switch {
-			case err == nil:
-				rec = prev
-			case errors.Is(err, EOI):
-				r.crossingAnchor = lastValid
-				r.crossingAnchorSet = true
-				return lastValid, nil
-			default:
+			current, err := r.Prev()
+			if err != nil {
 				return empty, err
 			}
+			lastValid = current
+			prepared = false
 		}
 	}
 
 	for {
-		sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
-		if sameKey {
-			prev, err := r.mi.Prev()
-			switch {
-			case err == nil:
-				rec = prev
-			case errors.Is(err, EOI):
+		if !prepared {
+			r.primePrev()
+			if !r.prevPrepared {
+				if r.err != nil {
+					return empty, r.err
+				}
 				return empty, EOI
-			default:
-				return empty, err
 			}
-			continue
 		}
 
-		r.lastKey = rec.GetKey().Clone()
-		r.lastKeySet = true
-		if rec.GetType() == TypeDeletion {
-			prev, err := r.mi.Prev()
-			switch {
-			case err == nil:
-				rec = prev
-			case errors.Is(err, EOI):
-				return empty, EOI
-			default:
-				return empty, err
-			}
-			continue
+		current, err := r.Prev()
+		if err != nil {
+			return empty, err
 		}
-
-		r.crossingAnchor = rec
-		r.crossingAnchorSet = true
-		return rec, nil
+		return current, nil
 	}
 }
 

--- a/range.go
+++ b/range.go
@@ -109,13 +109,6 @@ func (r *RangeIterator) allowAnchorOnNext() bool {
 	return !r.forward
 }
 
-func (r *RangeIterator) allowAnchorOnPrev() bool {
-	if r.order == RangeDesc {
-		return !r.forward
-	}
-	return r.forward
-}
-
 func (r *RangeIterator) allowAnchorOnPrevForOrder(order RangeOrder) bool {
 	if order == RangeDesc {
 		return !r.forward
@@ -368,23 +361,21 @@ func (r *RangeIterator) Last() (Record, error) {
 		}
 	}
 
-	for {
-		if !prepared {
-			r.primePrev()
-			if !r.prevPrepared {
-				if r.err != nil {
-					return empty, r.err
-				}
-				return empty, EOI
+	if !prepared {
+		r.primePrev()
+		if !r.prevPrepared {
+			if r.err != nil {
+				return empty, r.err
 			}
+			return empty, EOI
 		}
-
-		current, err := r.Prev()
-		if err != nil {
-			return empty, err
-		}
-		return current, nil
 	}
+
+	current, err := r.Prev()
+	if err != nil {
+		return empty, err
+	}
+	return current, nil
 }
 
 // Close releases any resources held by the iterator.

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -470,12 +470,12 @@ func (sri *sstableIRange) Prev() (Record, error) {
 			return empty, sri.prevErr
 		}
 		return empty, EOI
-        }
-        rec := sri.prev
-        sri.prev = nil
-        sri.prevPrepared = false
-        sri.prevErr = nil
-        return rec, nil
+	}
+	rec := sri.prev
+	sri.prev = nil
+	sri.prevPrepared = false
+	sri.prevErr = nil
+	return rec, nil
 }
 
 // Last implements Iterator.
@@ -513,17 +513,15 @@ func (sri *sstableIRange) Last() (Record, error) {
 	sri.replayPrimed = false
 	sri.replayCursor = 0
 
-	for {
-		sri.primePrev()
-		if sri.prevPrepared {
-			rec := sri.prev
-			sri.prev = nil
-			sri.prevPrepared = false
-			return rec, nil
-		}
-		if sri.prevErr != nil {
-			return empty, sri.prevErr
-		}
-		return empty, EOI
+	sri.primePrev()
+	if sri.prevPrepared {
+		rec := sri.prev
+		sri.prev = nil
+		sri.prevPrepared = false
+		return rec, nil
 	}
+	if sri.prevErr != nil {
+		return empty, sri.prevErr
+	}
+	return empty, EOI
 }

--- a/sstable_iteration.go
+++ b/sstable_iteration.go
@@ -199,6 +199,9 @@ type sstableIRange struct {
 	replayNext       Record
 	replayPrimed     bool
 	replayCursor     int64
+	prev             Record
+	prevPrepared     bool
+	prevErr          error
 }
 
 func (sri *sstableIRange) prepare() {
@@ -342,6 +345,9 @@ func (sri *sstableIRange) Next() (Record, error) {
 	sri.prepared = false
 	next := sri.next
 	sri.next = nil
+	sri.prev = nil
+	sri.prevPrepared = false
+	sri.prevErr = nil
 	return next, nil
 }
 
@@ -379,8 +385,74 @@ func (sri *sstableIRange) ensureLowerBound() error {
 	return EOI
 }
 
+func (sri *sstableIRange) primePrev() {
+	if sri.prevPrepared || sri.prevErr != nil {
+		return
+	}
+	if !sri.haveLowerBound {
+		return
+	}
+	sri.prevErr = nil
+	for !sri.prevPrepared {
+		if sri.cursor <= sri.lowerBound {
+			sri.prevErr = EOI
+			return
+		}
+		reader := newOffsetReader(sri.s.FileSystem, sri.cursor)
+		start, err := reader.PrevOffset()
+		switch {
+		case err == nil:
+		case errors.Is(err, io.EOF):
+			sri.prevErr = EOI
+			return
+		default:
+			sri.prevErr = err
+			return
+		}
+		reader.offset = start
+		rec, _, err := readRecord(reader)
+		switch {
+		case err == nil:
+		case errors.Is(err, EOI), errors.Is(err, io.EOF):
+			sri.cursor = start
+			sri.offset = start
+			continue
+		default:
+			sri.prevErr = err
+			return
+		}
+
+		sri.offset = start
+		sri.cursor = start
+
+		if rec.GetKey().Compare(sri.endKey) == CmpGreater {
+			continue
+		}
+		if rec.GetKey().Compare(sri.startKey) == CmpLess {
+			sri.prevErr = EOI
+			return
+		}
+		if rec.GetSequenceNumber() > sri.seq {
+			continue
+		}
+
+		sri.prev = rec
+		sri.prevPrepared = true
+		sri.prepared = false
+		sri.err = nil
+		sri.next = nil
+		sri.replayNext = rec
+		sri.replayPrimed = true
+		sri.replayCursor = reader.Offset()
+		return
+	}
+}
+
 // HasPrev implements Iterator.
 func (sri *sstableIRange) HasPrev() bool {
+	if sri.prevPrepared {
+		return true
+	}
 	if !sri.haveLowerBound {
 		return false
 	}
@@ -390,53 +462,20 @@ func (sri *sstableIRange) HasPrev() bool {
 // Prev implements Iterator.
 func (sri *sstableIRange) Prev() (Record, error) {
 	var empty Record
-	for {
-		if !sri.HasPrev() {
-			return empty, EOI
-		}
-		reader := newOffsetReader(sri.s.FileSystem, sri.cursor)
-		start, err := reader.PrevOffset()
-		switch {
-		case err == nil:
-			// continue
-		case errors.Is(err, io.EOF):
-			return empty, EOI
-		default:
-			return nil, err
-		}
-		reader.offset = start
-		rec, _, err := readRecord(reader)
-		switch {
-		case err == nil:
-			// continue
-		case errors.Is(err, EOI), errors.Is(err, io.EOF):
-			sri.cursor = start
-			sri.offset = start
-			continue
-		default:
-			return nil, err
-		}
-
-		sri.offset = start
-		sri.cursor = start
-		if rec.GetKey().Compare(sri.endKey) > 0 {
-			continue
-		}
-		if rec.GetKey().Compare(sri.startKey) < 0 {
-			return empty, EOI
-		}
-		if rec.GetSequenceNumber() > sri.seq {
-			continue
-		}
-
-		sri.prepared = false
-		sri.err = nil
-		sri.next = nil
-		sri.replayNext = rec
-		sri.replayPrimed = true
-		sri.replayCursor = reader.Offset()
-		return rec, nil
+	if !sri.prevPrepared {
+		sri.primePrev()
 	}
+	if !sri.prevPrepared {
+		if sri.prevErr != nil {
+			return empty, sri.prevErr
+		}
+		return empty, EOI
+        }
+        rec := sri.prev
+        sri.prev = nil
+        sri.prevPrepared = false
+        sri.prevErr = nil
+        return rec, nil
 }
 
 // Last implements Iterator.
@@ -445,6 +484,9 @@ func (sri *sstableIRange) Last() (Record, error) {
 	sri.err = nil
 	sri.prepared = false
 	sri.next = nil
+	sri.prev = nil
+	sri.prevPrepared = false
+	sri.prevErr = nil
 
 	if err := sri.ensureLowerBound(); err != nil {
 		return empty, err
@@ -465,47 +507,23 @@ func (sri *sstableIRange) Last() (Record, error) {
 		}
 	}
 
+	sri.cursor = cursor
+	sri.offset = cursor
+	sri.replayNext = nil
+	sri.replayPrimed = false
+	sri.replayCursor = 0
+
 	for {
-		if cursor <= 0 {
-			return empty, EOI
+		sri.primePrev()
+		if sri.prevPrepared {
+			rec := sri.prev
+			sri.prev = nil
+			sri.prevPrepared = false
+			return rec, nil
 		}
-		reader := newOffsetReader(sri.s.FileSystem, cursor)
-		start, err := reader.PrevOffset()
-		switch {
-		case err == nil:
-			// continue
-		case errors.Is(err, io.EOF):
-			return empty, EOI
-		default:
-			return empty, err
+		if sri.prevErr != nil {
+			return empty, sri.prevErr
 		}
-		reader.offset = start
-		rec, _, err := readRecord(reader)
-		switch {
-		case err == nil:
-			// continue
-		case errors.Is(err, EOI), errors.Is(err, io.EOF):
-			cursor = start
-			continue
-		default:
-			return empty, err
-		}
-		cursor = start
-		key := rec.GetKey()
-		if key.Compare(sri.endKey) == CmpGreater {
-			continue
-		}
-		if key.Compare(sri.startKey) == CmpLess {
-			return empty, EOI
-		}
-		if rec.GetSequenceNumber() > sri.seq {
-			continue
-		}
-		sri.cursor = start
-		sri.offset = reader.Offset()
-		if sri.offset > sri.dataEnd {
-			sri.offset = sri.dataEnd
-		}
-		return rec, nil
+		return empty, EOI
 	}
 }


### PR DESCRIPTION
## Summary
- refactor `sstableIRange` backward iteration by introducing a reusable `primePrev` helper and simplifying `Prev`/`Last`
- extend the range iterator to share backward filtering logic via `stagePrevCandidate` and reuse it from `Last`

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d88a8aba388325a32f35be5bfa07e6