### PR TITLE
fix: make merging iterator Last non-destructive

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -294,54 +294,44 @@ func (m *MergingIterator) Last() (Record, error) {
 	if m.err != nil {
 		return empty, m.err
 	}
-	m.nextPrepared = false
-	m.prevPrepared = false
-	m.forward = false
-	m.crossingAnchorSet = false
-	m.nextItem = pqItem{}
-	m.prevItem = pqItem{}
 
-	if m.fwd != nil {
-		m.fwd.Clear()
-	}
-	if m.rev != nil {
-		m.rev.Clear()
-	}
+	var (
+		lastItem pqItem
+		lastRec  Record
+	)
 
-	m.descendingPrimed = true
-
-	for _, it := range m.iters {
-		if it == nil {
-			continue
-		}
-		rec, err := it.Last()
-		switch {
-		case err == nil:
-			m.rev.PushItem(pqItem{rec: rec, iter: it})
-		case errors.Is(err, EOI):
-			continue
-		default:
-			m.err = err
+	for m.HasNext() {
+		rec, err := m.Next()
+		if err != nil {
 			return empty, err
 		}
+		lastRec = rec
+	}
+
+	if m.err != nil {
+		return empty, m.err
 	}
 
 	if m.rev.Len() == 0 {
 		return empty, EOI
 	}
 
-	lastItem := m.rev.PopItem()
-	if prev, err := lastItem.iter.Prev(); err == nil {
-		m.rev.PushItem(pqItem{rec: prev, iter: lastItem.iter})
-	} else if !errors.Is(err, EOI) {
-		m.err = err
-		return empty, err
-	}
+	lastItem = m.rev.PeekItem()
+	lastRec = lastItem.rec
 
+	m.nextPrepared = false
+	m.prevPrepared = false
+	m.nextItem = pqItem{}
+	m.prevItem = pqItem{}
+	m.forward = false
 	m.crossingAnchor = lastItem
 	m.crossingAnchorSet = true
+	m.descendingPrimed = true
+	m.reversePrimed = false
+	m.reverseErr = nil
+	m.cachedReverse = pqItem{}
 
-	return lastItem.rec, nil
+	return lastRec, nil
 }
 
 // prepareNext stages the next item so that HasNext is idempotent.

--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -301,11 +301,10 @@ func (m *MergingIterator) Last() (Record, error) {
 	)
 
 	for m.HasNext() {
-		rec, err := m.Next()
+		_, err := m.Next()
 		if err != nil {
 			return empty, err
 		}
-		lastRec = rec
 	}
 
 	if m.err != nil {

--- a/merging_iterator_test.go
+++ b/merging_iterator_test.go
@@ -201,6 +201,45 @@ func TestMergingIterator_LastReturnsMaxAndPrimesPrev(t *testing.T) {
 	assert.Equal(t, mkRec("b", "vb", 1, TypeValue), prev2)
 }
 
+func TestMergingIterator_LastKeepsForwardIterationViable(t *testing.T) {
+	t.Parallel()
+
+	iterators := []Iterator[Record]{
+		&errIterator{records: []Record{mkRec("a", "va", 1, TypeValue), mkRec("b", "vb", 2, TypeValue)}, failIdx: -1},
+		&errIterator{records: []Record{mkRec("c", "vc", 3, TypeValue)}, failIdx: -1},
+	}
+
+	mi, err := NewMergingIterator(iterators, nil, RangeAsc)
+	require.NoError(t, err)
+
+	first, err := mi.Next()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("a", "va", 1, TypeValue), first)
+
+	last, err := mi.Last()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("c", "vc", 3, TypeValue), last)
+
+	var backwards []Record
+	for mi.HasPrev() {
+		rec, err := mi.Prev()
+		require.NoError(t, err)
+		backwards = append(backwards, rec)
+	}
+	assert.Equal(t, []Record{mkRec("b", "vb", 2, TypeValue), mkRec("a", "va", 1, TypeValue)}, backwards)
+
+	next1, err := mi.Next()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("a", "va", 1, TypeValue), next1)
+
+	next2, err := mi.Next()
+	require.NoError(t, err)
+	assert.Equal(t, mkRec("b", "vb", 2, TypeValue), next2)
+
+	_, err = mi.Next()
+	assert.ErrorIs(t, err, EOI)
+}
+
 func TestMergingIterator_PeekReverseReprimesAfterEmpty(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- iterate forward to populate the reverse heap and peek the terminal element instead of clearing heap state in Last
- reset iterator bookkeeping while preserving heap contents so callers can still walk backwards after Last
- add a regression test covering forward iteration after Last is invoked

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d88aa05e34832588300f2abc2254cb