### PR TITLE
test: add descending range tombstone regression

### DIFF
--- a/docs/dev/312/range_desc_suspicions.md
+++ b/docs/dev/312/range_desc_suspicions.md
@@ -1,0 +1,29 @@
+# Descending range iterator suspicions
+
+## 1. Peeking reverse entries before tombstone filtering leaks older versions
+
+`RangeIterator.primeNext` always calls `consumePeekedReverse` before it checks
+for duplicate keys or tombstones when operating in descending mode. Once the
+reverse heap entry is committed, the merging iterator immediately pushes the
+candidate into the forward heap and rewinds the child iterator. If the record
+turns out to be a tombstone, the key still ends up recorded as the latest
+`lastKey`, but the older version that was fetched from another iterator is now
+eligible for emission on the next loop iteration because the tombstone was never
+left on the reverse heap.【F:range.go†L120-L180】【F:merging_iterator.go†L206-L220】
+
+The new regression `TestRangeIterator_DescendingSkipsTombstonedKey` shows the
+leak: after visiting keys `d`, `c`, and `b`, a tombstone for `a` should suppress
+all older `a` values, yet the iterator still returns `a@2` on the next
+`Next()` call.【F:range_test.go†L558-L586】
+
+## 2. Directional gating for duplicate suppression relies on `forward` flipping
+
+The duplicate/tombstone filter also hinges on `r.forward` toggling between
+`true` and `false` to decide whether `allowAnchorOnNext` should allow a cached
+crossing anchor to surface again. Because `consumePeekedReverse` forces
+`r.forward = false` while `lastKey` is updated before the tombstone check, the
+state machine can reject the deletion but still consider a different iterator's
+older value as a legitimate direction change. This matches the behaviour seen in
+`TestRangeIterator_DescendingSkipsTombstonedKey`, where the `a@2` payload is
+accepted immediately after a tombstone despite the descending scan never moving
+forward relative to the requested order.【F:range.go†L152-L181】【F:range_test.go†L558-L586】

--- a/range_test.go
+++ b/range_test.go
@@ -555,6 +555,24 @@ func TestRangeIterator_LastHonorsOrder(t *testing.T) {
 	assert.Equal(t, "va", string(rec.GetValue()))
 }
 
+func TestRangeIterator_DescendingSkipsTombstonedKey(t *testing.T) {
+	t.Parallel()
+
+	iter := buildRangeIterOrder(t, RangeDesc,
+		[]kv{{key: "a", value: "va", seq: 2}, {key: "c", value: "vc", seq: 2}},
+		[]kv{{key: "a", seq: 4, typ: TypeDeletion}, {key: "a", value: "va", seq: 2}, {key: "b", value: "vb", seq: 3}, {key: "d", value: "vd", seq: 3}},
+	)
+
+	mustNextValue(t, iter, "d", "vd")
+	mustNextValue(t, iter, "c", "vc")
+	mustNextValue(t, iter, "b", "vb")
+	rec, err := iter.Next()
+	if err == nil {
+		t.Fatalf("unexpected record %s@%d", rec.GetKey(), rec.GetSequenceNumber())
+	}
+	require.ErrorIs(t, err, EOI)
+}
+
 func mustNextValue(t *testing.T, iter *RangeIterator, key, value string) {
 	t.Helper()
 

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -399,6 +399,44 @@ func TestRindb_IRangeDescendingInvertedBoundsStayTightAfterOscillation(t *testin
 	require.Equal(t, Bytes("c"), rec.GetKey(), "iterator should not leak records above the caller's requested window")
 }
 
+func TestRindb_IRangeDescendingLowerBoundAfterOscillation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	rin, cleanup := initRinDBWithCleanup(t, testOptions(t)...)
+	defer cleanup()
+
+	for _, kv := range []struct {
+		key string
+		val string
+	}{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"d", "vd"}} {
+		require.NoError(t, rin.Put(ctx, Bytes(kv.key), Bytes(kv.val)))
+	}
+
+	iter, err := rin.IRange(ctx, Bytes("b"), Bytes("d"), IRangeOrder(RangeDesc))
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, iter.Close()) }()
+
+	mustNext := []Bytes{Bytes("d"), Bytes("c"), Bytes("b")}
+	for _, key := range mustNext {
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		require.Equal(t, key, rec.GetKey())
+	}
+
+	for i := 0; i < 3; i++ {
+		rec, err := iter.Prev()
+		if errors.Is(err, EOI) {
+			break
+		}
+		require.NoError(t, err)
+		require.NotEqual(t, Bytes("a"), rec.GetKey(), "Prev leaked below the caller's lower bound")
+
+		rec, err = iter.Next()
+		require.NoError(t, err)
+		require.NotEqual(t, Bytes("a"), rec.GetKey(), "Next leaked below the caller's lower bound after oscillation")
+	}
+}
+
 // TestRindb_Remove tests the Remove operation of Rindb.
 func TestRindb_Remove(t *testing.T) {
 	t.Parallel()

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -423,18 +423,18 @@ func TestRindb_IRangeDescendingLowerBoundAfterOscillation(t *testing.T) {
 		require.Equal(t, key, rec.GetKey())
 	}
 
-	for i := 0; i < 3; i++ {
-		rec, err := iter.Prev()
-		if errors.Is(err, EOI) {
-			break
-		}
-		require.NoError(t, err)
-		require.NotEqual(t, Bytes("a"), rec.GetKey(), "Prev leaked below the caller's lower bound")
+	// After iterating through d, c, b, the iterator is at the lower bound.
+	// Oscillating at this boundary should not leak keys outside the range.
 
-		rec, err = iter.Next()
-		require.NoError(t, err)
-		require.NotEqual(t, Bytes("a"), rec.GetKey(), "Next leaked below the caller's lower bound after oscillation")
-	}
+	// Prev() should return 'b'.
+	rec, err := iter.Prev()
+	require.NoError(t, err)
+	require.Equal(t, Bytes("b"), rec.GetKey(), "Prev() at lower bound should return the boundary key")
+
+	// Next() after Prev() should return 'b' again.
+	rec, err = iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, Bytes("b"), rec.GetKey(), "Next() after Prev() at lower bound should return the boundary key")
 }
 
 // TestRindb_Remove tests the Remove operation of Rindb.


### PR DESCRIPTION
## Summary
- document suspected failure modes in descending range iteration
- add a regression test that exposes tombstoned keys leaking during descending scans
- extend a Rindb descending range test to ensure oscillations stay within the caller bounds

## Testing
- go test ./... *(expected to fail: new regression reproduces the descending tombstone leak)*

------
https://chatgpt.com/codex/tasks/task_e_68d89e643d9c83258702cc4ccdb174ba