### PR TITLE
test: expose descending Prev priming gap

### DIFF
--- a/range_test.go
+++ b/range_test.go
@@ -492,26 +492,26 @@ func TestRangeIteratorDescending_HasNextSkipsTombstones(t *testing.T) {
 }
 
 func TestRangeIterator_DescendingOscillation(t *testing.T) {
-        t.Parallel()
+	t.Parallel()
 
-        iter := buildRangeIterOrder(t, RangeDesc, []kv{{key: "k1", value: "v1", seq: 1}, {key: "k2", value: "v2", seq: 2}, {key: "k3", value: "v3", seq: 3}})
+	iter := buildRangeIterOrder(t, RangeDesc, []kv{{key: "k1", value: "v1", seq: 1}, {key: "k2", value: "v2", seq: 2}, {key: "k3", value: "v3", seq: 3}})
 
-        mustNextValue(t, iter, "k3", "v3")
-        mustNextValue(t, iter, "k2", "v2")
-        mustPrevValue(t, iter, "k2", "v2")
-        mustNextValue(t, iter, "k2", "v2")
-        mustNextValue(t, iter, "k1", "v1")
+	mustNextValue(t, iter, "k3", "v3")
+	mustNextValue(t, iter, "k2", "v2")
+	mustPrevValue(t, iter, "k2", "v2")
+	mustNextValue(t, iter, "k2", "v2")
+	mustNextValue(t, iter, "k1", "v1")
 }
 
 func TestRangeIterator_DescendingPrevBeforeNext(t *testing.T) {
-        t.Parallel()
+	t.Parallel()
 
-        iter := buildRangeIterOrder(t, RangeDesc, []kv{{key: "k1", value: "v1", seq: 1}, {key: "k2", value: "v2", seq: 2}, {key: "k3", value: "v3", seq: 3}})
+	iter := buildRangeIterOrder(t, RangeDesc, []kv{{key: "k1", value: "v1", seq: 1}, {key: "k2", value: "v2", seq: 2}, {key: "k3", value: "v3", seq: 3}})
 
-        rec, err := iter.Prev()
-        require.NoError(t, err, "descending Prev should surface the upper bound when called first")
-        require.Equal(t, "k3", string(rec.GetKey()))
-        require.Equal(t, "v3", string(rec.GetValue()))
+	rec, err := iter.Prev()
+	require.NoError(t, err, "descending Prev should surface the upper bound when called first")
+	require.Equal(t, "k3", string(rec.GetKey()))
+	require.Equal(t, "v3", string(rec.GetValue()))
 }
 
 func TestRangeIterator_DescendingHasNextRecoversAfterPrev(t *testing.T) {

--- a/range_test.go
+++ b/range_test.go
@@ -492,15 +492,26 @@ func TestRangeIteratorDescending_HasNextSkipsTombstones(t *testing.T) {
 }
 
 func TestRangeIterator_DescendingOscillation(t *testing.T) {
-	t.Parallel()
+        t.Parallel()
 
-	iter := buildRangeIterOrder(t, RangeDesc, []kv{{key: "k1", value: "v1", seq: 1}, {key: "k2", value: "v2", seq: 2}, {key: "k3", value: "v3", seq: 3}})
+        iter := buildRangeIterOrder(t, RangeDesc, []kv{{key: "k1", value: "v1", seq: 1}, {key: "k2", value: "v2", seq: 2}, {key: "k3", value: "v3", seq: 3}})
 
-	mustNextValue(t, iter, "k3", "v3")
-	mustNextValue(t, iter, "k2", "v2")
-	mustPrevValue(t, iter, "k2", "v2")
-	mustNextValue(t, iter, "k2", "v2")
-	mustNextValue(t, iter, "k1", "v1")
+        mustNextValue(t, iter, "k3", "v3")
+        mustNextValue(t, iter, "k2", "v2")
+        mustPrevValue(t, iter, "k2", "v2")
+        mustNextValue(t, iter, "k2", "v2")
+        mustNextValue(t, iter, "k1", "v1")
+}
+
+func TestRangeIterator_DescendingPrevBeforeNext(t *testing.T) {
+        t.Parallel()
+
+        iter := buildRangeIterOrder(t, RangeDesc, []kv{{key: "k1", value: "v1", seq: 1}, {key: "k2", value: "v2", seq: 2}, {key: "k3", value: "v3", seq: 3}})
+
+        rec, err := iter.Prev()
+        require.NoError(t, err, "descending Prev should surface the upper bound when called first")
+        require.Equal(t, "k3", string(rec.GetKey()))
+        require.Equal(t, "v3", string(rec.GetValue()))
 }
 
 func TestRangeIterator_DescendingHasNextRecoversAfterPrev(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a regression test that exercises Prev() before Next() on descending range iterators
- highlight that descending scans lack forward priming, leaving Prev() unable to surface the upper-bound record

## Testing
- go test ./... -run TestRangeIterator_DescendingPrevBeforeNext -count=1 (fails as expected)


------
https://chatgpt.com/codex/tasks/task_e_68d89e643d9c83258702cc4ccdb174ba