### PR TITLE
test: expose descending range tombstone regression

### DIFF
--- a/rindb_test.go
+++ b/rindb_test.go
@@ -355,19 +355,70 @@ func TestRindb_IRangeDescendingSkipsTombstonedKeys(t *testing.T) {
 	require.NoError(t, rin.Put(ctx, Bytes("b"), Bytes("vb")))
 	require.NoError(t, rin.Remove(ctx, Bytes("b")))
 	require.NoError(t, rin.Put(ctx, Bytes("c"), Bytes("vc")))
+	require.NoError(t, rin.Put(ctx, Bytes("d"), Bytes("vd")))
+	require.NoError(t, rin.Remove(ctx, Bytes("d")))
+	require.NoError(t, rin.Put(ctx, Bytes("e"), Bytes("ve")))
 
-	iter, err := rin.IRange(ctx, Bytes("a"), Bytes("z"), IRangeOrder(RangeDesc))
-	require.NoError(t, err)
-	defer func() { assert.NoError(t, iter.Close()) }()
-
-	var keys []string
-	for iter.HasNext() {
-		rec, err := iter.Next()
-		require.NoError(t, err)
-		keys = append(keys, string(rec.GetKey()))
+	tests := []struct {
+		name     string
+		start    []byte
+		end      []byte
+		expected []string
+	}{
+		{
+			name:     "range with tombstone in middle",
+			start:    Bytes("a"),
+			end:      Bytes("c"),
+			expected: []string{"c", "a"},
+		},
+		{
+			name:     "range ending on a tombstone",
+			start:    Bytes("c"),
+			end:      Bytes("d"),
+			expected: []string{"c"},
+		},
+		{
+			name:     "range starting on a tombstone",
+			start:    Bytes("d"),
+			end:      Bytes("e"),
+			expected: []string{"e"},
+		},
+		{
+			name:     "full range with multiple tombstones",
+			start:    Bytes("a"),
+			end:      Bytes("z"),
+			expected: []string{"e", "c", "a"},
+		},
+		{
+			name:     "range over a single tombstone",
+			start:    Bytes("b"),
+			end:      Bytes("b"),
+			expected: nil,
+		},
 	}
 
-	assert.Equal(t, []string{"c", "a"}, keys)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			iter, err := rin.IRange(ctx, tt.start, tt.end, IRangeOrder(RangeDesc))
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, iter.Close()) }()
+
+			var keys []string
+			for iter.HasNext() {
+				rec, err := iter.Next()
+				require.NoError(t, err)
+				keys = append(keys, string(rec.GetKey()))
+			}
+
+			if tt.expected == nil {
+				assert.Empty(t, keys)
+				return
+			}
+
+			assert.Equal(t, tt.expected, keys)
+		})
+	}
 }
 
 func TestRindb_IRangeDescendingHighToLowBounds(t *testing.T) {

--- a/rindb_test.go
+++ b/rindb_test.go
@@ -345,6 +345,31 @@ func TestRindb_IRangeDescending(t *testing.T) {
 	assert.Equal(t, Bytes("a"), rec.GetKey())
 }
 
+func TestRindb_IRangeDescendingSkipsTombstonedKeys(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	rin, cleanup := initRinDBWithCleanup(t, testOptions(t)...)
+	defer cleanup()
+
+	require.NoError(t, rin.Put(ctx, Bytes("a"), Bytes("va")))
+	require.NoError(t, rin.Put(ctx, Bytes("b"), Bytes("vb")))
+	require.NoError(t, rin.Remove(ctx, Bytes("b")))
+	require.NoError(t, rin.Put(ctx, Bytes("c"), Bytes("vc")))
+
+	iter, err := rin.IRange(ctx, Bytes("a"), Bytes("z"), IRangeOrder(RangeDesc))
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, iter.Close()) }()
+
+	var keys []string
+	for iter.HasNext() {
+		rec, err := iter.Next()
+		require.NoError(t, err)
+		keys = append(keys, string(rec.GetKey()))
+	}
+
+	assert.Equal(t, []string{"c", "a"}, keys)
+}
+
 func TestRindb_IRangeDescendingHighToLowBounds(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- add a regression test that exercises descending range iteration across a tombstoned key

## Testing
- go test ./... -count=1 *(fails: descending iterator surfaces tombstoned key)*

------
https://chatgpt.com/codex/tasks/task_e_68d89e643d9c83258702cc4ccdb174ba