### PR TITLE
test: capture descending range last prev regression

### DIFF
--- a/range_test.go
+++ b/range_test.go
@@ -567,20 +567,39 @@ func TestRangeIterator_LastHonorsOrder(t *testing.T) {
 func TestRangeIterator_DescendingLastThenPrev(t *testing.T) {
 	t.Parallel()
 
-	iter := buildRangeIterOrder(t, RangeDesc,
-		[]kv{{key: "a", value: "va", seq: 1}},
-		[]kv{{key: "b", value: "vb", seq: 2}},
-		[]kv{{key: "c", value: "vc", seq: 3}},
-	)
+	t.Run("basic", func(t *testing.T) {
+		iter := buildRangeIterOrder(t, RangeDesc,
+			[]kv{{key: "a", value: "va", seq: 1}},
+			[]kv{{key: "b", value: "vb", seq: 2}},
+			[]kv{{key: "c", value: "vc", seq: 3}},
+		)
 
-	rec, err := iter.Last()
-	require.NoError(t, err)
-	require.Equal(t, "a", string(rec.GetKey()))
-	require.Equal(t, "va", string(rec.GetValue()))
+		rec, err := iter.Last()
+		require.NoError(t, err)
+		require.Equal(t, "a", string(rec.GetKey()))
+		require.Equal(t, "va", string(rec.GetValue()))
 
-	mustPrevValue(t, iter, "b", "vb")
-	mustPrevValue(t, iter, "c", "vc")
-	mustPrevEOI(t, iter)
+		mustPrevValue(t, iter, "b", "vb")
+		mustPrevValue(t, iter, "c", "vc")
+		mustPrevEOI(t, iter)
+	})
+
+	t.Run("with duplicates", func(t *testing.T) {
+		iter := buildRangeIterOrder(t, RangeDesc,
+			[]kv{{key: "a", value: "va", seq: 1}},
+			[]kv{{key: "b", value: "vb2", seq: 3}, {key: "b", value: "vb1", seq: 2}},
+			[]kv{{key: "c", value: "vc", seq: 4}},
+		)
+
+		rec, err := iter.Last()
+		require.NoError(t, err)
+		require.Equal(t, "a", string(rec.GetKey()))
+		require.Equal(t, "va", string(rec.GetValue()))
+
+		mustPrevValue(t, iter, "b", "vb2")
+		mustPrevValue(t, iter, "c", "vc")
+		mustPrevEOI(t, iter)
+	})
 }
 
 func TestRangeIterator_DescendingSkipsTombstonedKey(t *testing.T) {
@@ -604,15 +623,27 @@ func TestRangeIterator_DescendingSkipsTombstonedKey(t *testing.T) {
 func TestRangeIterator_DescendingLastSkipsTombstone(t *testing.T) {
 	t.Parallel()
 
-	iter := buildRangeIterOrder(t, RangeDesc,
-		[]kv{{key: "a", value: "va", seq: 1}},
-		[]kv{{key: "b", seq: 3, typ: TypeDeletion}, {key: "b", value: "vb", seq: 2}},
-	)
+	t.Run("skips newest tombstone", func(t *testing.T) {
+		iter := buildRangeIterOrder(t, RangeDesc,
+			[]kv{{key: "a", value: "va", seq: 1}},
+			[]kv{{key: "b", seq: 3, typ: TypeDeletion}, {key: "b", value: "vb", seq: 2}},
+		)
 
-	rec, err := iter.Last()
-	require.NoError(t, err)
-	require.Equal(t, "a", string(rec.GetKey()))
-	require.Equal(t, "va", string(rec.GetValue()))
+		rec, err := iter.Last()
+		require.NoError(t, err)
+		require.Equal(t, "a", string(rec.GetKey()))
+		require.Equal(t, "va", string(rec.GetValue()))
+	})
+
+	t.Run("all keys tombstoned", func(t *testing.T) {
+		iter := buildRangeIterOrder(t, RangeDesc,
+			[]kv{{key: "a", seq: 2, typ: TypeDeletion}, {key: "a", value: "va", seq: 1}},
+			[]kv{{key: "b", seq: 4, typ: TypeDeletion}, {key: "b", value: "vb", seq: 3}},
+		)
+
+		_, err := iter.Last()
+		require.ErrorIs(t, err, EOI)
+	})
 }
 
 func mustNextValue(t *testing.T, iter *RangeIterator, key, value string) {

--- a/range_test.go
+++ b/range_test.go
@@ -564,6 +564,25 @@ func TestRangeIterator_LastHonorsOrder(t *testing.T) {
 	assert.Equal(t, "va", string(rec.GetValue()))
 }
 
+func TestRangeIterator_DescendingLastThenPrev(t *testing.T) {
+	t.Parallel()
+
+	iter := buildRangeIterOrder(t, RangeDesc,
+		[]kv{{key: "a", value: "va", seq: 1}},
+		[]kv{{key: "b", value: "vb", seq: 2}},
+		[]kv{{key: "c", value: "vc", seq: 3}},
+	)
+
+	rec, err := iter.Last()
+	require.NoError(t, err)
+	require.Equal(t, "a", string(rec.GetKey()))
+	require.Equal(t, "va", string(rec.GetValue()))
+
+	mustPrevValue(t, iter, "b", "vb")
+	mustPrevValue(t, iter, "c", "vc")
+	mustPrevEOI(t, iter)
+}
+
 func TestRangeIterator_DescendingSkipsTombstonedKey(t *testing.T) {
 	t.Parallel()
 
@@ -580,6 +599,20 @@ func TestRangeIterator_DescendingSkipsTombstonedKey(t *testing.T) {
 		t.Fatalf("unexpected record %s@%d", rec.GetKey(), rec.GetSequenceNumber())
 	}
 	require.ErrorIs(t, err, EOI)
+}
+
+func TestRangeIterator_DescendingLastSkipsTombstone(t *testing.T) {
+	t.Parallel()
+
+	iter := buildRangeIterOrder(t, RangeDesc,
+		[]kv{{key: "a", value: "va", seq: 1}},
+		[]kv{{key: "b", seq: 3, typ: TypeDeletion}, {key: "b", value: "vb", seq: 2}},
+	)
+
+	rec, err := iter.Last()
+	require.NoError(t, err)
+	require.Equal(t, "a", string(rec.GetKey()))
+	require.Equal(t, "va", string(rec.GetValue()))
 }
 
 func mustNextValue(t *testing.T, iter *RangeIterator, key, value string) {


### PR DESCRIPTION
## Summary
- add a regression test for descending ranges exercising Last followed by Prev, which currently fails
- add coverage to ensure descending Last skips tombstoned keys

## Testing
- `go test ./... -run ^TestRangeIterator_DescendingLastSkipsTombstone$ -count=1`
- `go test ./... -run TestRangeIterator_DescendingLastThenPrev -count=1` *(fails as expected to demonstrate the bug)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bb0eeafc83259962051f47e30b26