### PR TITLE
Fix RangeIterator descending Last handling

### DIFF
--- a/range.go
+++ b/range.go
@@ -365,6 +365,31 @@ func (r *RangeIterator) Last() (Record, error) {
 		return empty, err
 	}
 
+	if r.order == RangeDesc {
+		for {
+			peeked, peekErr := r.mi.peekReverse()
+			switch {
+			case errors.Is(peekErr, EOI):
+				rec = nil
+			case peekErr != nil:
+				return empty, peekErr
+			default:
+				collapsed, ok := r.collapseDescendingRun(peeked)
+				if ok {
+					rec = collapsed
+				} else {
+					rec = nil
+				}
+			}
+			if rec != nil {
+				break
+			}
+			if errors.Is(peekErr, EOI) {
+				break
+			}
+		}
+	}
+
 	r.prevPrepared = false
 	r.nextPrepared = false
 	r.forward = false
@@ -380,7 +405,9 @@ func (r *RangeIterator) Last() (Record, error) {
 	searchOrder := RangeAsc
 
 	lastValid := Record(nil)
-	r.stagePrevCandidate(rec, searchOrder)
+	if rec != nil {
+		r.stagePrevCandidate(rec, searchOrder)
+	}
 
 	for {
 		if !r.prevPrepared {


### PR DESCRIPTION
## Summary
- ensure RangeIterator.Last collapses descending runs when scanning in RangeDesc mode so tombstoned keys are skipped
- guard the initial stage so we avoid staging nil records when no live keys remain

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d8c3268cf88325b5d6478c70bbf866