### PR TITLE
fix: stabilize descending range iteration

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -383,7 +383,7 @@ func (m *MergingIterator) prepareNext() {
 		// to expose to callers.
 		item := m.fwd.PopItem()
 		if m.matchesCrossingAnchor(item) {
-			if !m.forward {
+			if !m.forward || m.order == RangeDesc {
 				// Allow the boundary element to surface once when
 				// changing direction.
 				m.crossingAnchorSet = false
@@ -398,7 +398,7 @@ func (m *MergingIterator) prepareNext() {
 		m.reversePrimed = false
 		m.reverseErr = nil
 
-		skipAdvance := m.order == RangeDesc && !m.forward
+		skipAdvance := m.order == RangeDesc
 		if !skipAdvance && item.iter.HasNext() {
 			rec, err := item.iter.Next()
 			switch {

--- a/range.go
+++ b/range.go
@@ -154,6 +154,17 @@ func (r *RangeIterator) allowAnchorOnPrevForOrder(order RangeOrder) bool {
 
 func (r *RangeIterator) primeNext() {
 	if r.order == RangeDesc && r.forward && r.crossingAnchorSet {
+		if !r.reversePrimed && r.reverseErr == nil {
+			r.ensureReversePrimed()
+		}
+		if r.reversePrimed && r.reverseCached != nil && recordsEqual(r.reverseCached, r.crossingAnchor) {
+			r.consumePeekedReverse()
+		}
+		r.reversePrimed = false
+		r.reverseCached = nil
+		if !errors.Is(r.reverseErr, EOI) {
+			r.reverseErr = nil
+		}
 		r.next = r.crossingAnchor
 		r.nextPrepared = true
 		r.crossingAnchorSet = false
@@ -239,6 +250,13 @@ func (r *RangeIterator) primePrev() {
 }
 
 func (r *RangeIterator) primePrevWithOrder(order RangeOrder) {
+	if order == RangeDesc {
+		r.reversePrimed = false
+		r.reverseCached = nil
+		if !errors.Is(r.reverseErr, EOI) {
+			r.reverseErr = nil
+		}
+	}
 	if order == RangeDesc && !r.forward && r.crossingAnchorSet {
 		r.prev = r.crossingAnchor
 		r.prevPrepared = true


### PR DESCRIPTION
## Summary
- allow descending merging iterators to surface anchors when changing direction and stop advancing underlying sources while walking forward again
- reset reverse peek caches when returning to descending iteration so RangeIterator resumes from the correct key after oscillating

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d9254a19f08325b13ec4fb4463750d