### PR TITLE
fix: keep descending iter prev history consistent

### DIFF
--- a/merging_iterator.go
+++ b/merging_iterator.go
@@ -187,9 +187,9 @@ func (m *MergingIterator) peekReverse() (Record, error) {
 	return m.cachedReverse.rec, nil
 }
 
-func (m *MergingIterator) commitPeekedReverse() {
+func (m *MergingIterator) consumePeekedReverse() (pqItem, bool) {
 	if !m.reversePrimed {
-		return
+		return pqItem{}, false
 	}
 	defer func() {
 		m.reversePrimed = false
@@ -200,11 +200,10 @@ func (m *MergingIterator) commitPeekedReverse() {
 		if !errors.Is(m.reverseErr, EOI) {
 			m.err = m.reverseErr
 		}
-		return
+		return pqItem{}, false
 	}
 
 	item := m.rev.PopItem()
-	m.fwd.PushItem(item)
 	if item.iter.HasPrev() {
 		key := item.rec.GetKey()
 		for item.iter.HasPrev() {
@@ -213,17 +212,27 @@ func (m *MergingIterator) commitPeekedReverse() {
 			case err == nil:
 				m.rev.PushItem(pqItem{rec: prev, iter: item.iter})
 				if prev.GetKey().Compare(key) != CmpEqual {
-					return
+					m.forward = false
+					return item, true
 				}
 			case errors.Is(err, EOI):
-				return
+				m.forward = false
+				return item, true
 			default:
 				m.err = err
-				return
+				return pqItem{}, false
 			}
 		}
 	}
 	m.forward = false
+	return item, true
+}
+
+func (m *MergingIterator) stageForPrev(item pqItem) {
+	if item.rec == nil || item.iter == nil {
+		return
+	}
+	m.fwd.PushItem(item)
 }
 
 // HasNext implements Iterator[Record].

--- a/range.go
+++ b/range.go
@@ -95,16 +95,21 @@ func (r *RangeIterator) ensureReversePrimed() {
 	}
 }
 
-func (r *RangeIterator) consumePeekedReverse() {
-	r.mi.commitPeekedReverse()
+func (r *RangeIterator) consumePeekedReverse() (pqItem, bool) {
+	item, ok := r.mi.consumePeekedReverse()
 	r.reversePrimed = false
 	r.reverseCached = nil
 	r.reverseErr = nil
+	if !ok {
+		return pqItem{}, false
+	}
+	return item, true
 }
 
-func (r *RangeIterator) collapseDescendingRun(seed Record) (Record, bool) {
+func (r *RangeIterator) collapseDescendingRun(seed Record, seedItem pqItem) (Record, pqItem, bool) {
 	key := seed.GetKey()
 	candidate := seed
+	candidateItem := seedItem
 
 	// Consume all other versions of this key, tracking the one with the highest
 	// sequence number.
@@ -126,16 +131,20 @@ func (r *RangeIterator) collapseDescendingRun(seed Record) (Record, bool) {
 			break
 		}
 
-		if next.GetSequenceNumber() > candidate.GetSequenceNumber() {
+		candidateUpdated := next.GetSequenceNumber() > candidate.GetSequenceNumber()
+		if candidateUpdated {
 			candidate = next
 		}
-		r.consumePeekedReverse()
+		item, ok := r.consumePeekedReverse()
+		if candidateUpdated && ok {
+			candidateItem = item
+		}
 	}
 
 	if candidate.GetType() == TypeDeletion {
-		return nil, false
+		return nil, pqItem{}, false
 	}
-	return candidate, true
+	return candidate, candidateItem, true
 }
 
 func (r *RangeIterator) allowAnchorOnNext() bool {
@@ -192,12 +201,18 @@ func (r *RangeIterator) primeNext() {
 		}
 
 		peeked := recFromPeek
+		var stagedItem pqItem
 		if recFromPeek {
-			r.consumePeekedReverse()
+			item, ok := r.consumePeekedReverse()
+			if !ok {
+				r.forward = false
+				continue
+			}
+			stagedItem = item
 			if r.order == RangeDesc && r.err == nil && !r.forward {
-				var ok bool
-				rec, ok = r.collapseDescendingRun(rec)
-				if !ok {
+				var collapseOK bool
+				rec, stagedItem, collapseOK = r.collapseDescendingRun(rec, item)
+				if !collapseOK {
 					r.forward = false
 					continue
 				}
@@ -224,6 +239,7 @@ func (r *RangeIterator) primeNext() {
 			continue
 		}
 		if peeked {
+			r.mi.stageForPrev(stagedItem)
 			r.forward = false
 		}
 		r.next = rec
@@ -374,9 +390,15 @@ func (r *RangeIterator) Last() (Record, error) {
 			case peekErr != nil:
 				return empty, peekErr
 			default:
-				collapsed, ok := r.collapseDescendingRun(peeked)
+				item, ok := r.consumePeekedReverse()
+				if !ok {
+					rec = nil
+					break
+				}
+				collapsed, stagedItem, ok := r.collapseDescendingRun(peeked, item)
 				if ok {
 					rec = collapsed
+					r.mi.stageForPrev(stagedItem)
 				} else {
 					rec = nil
 				}


### PR DESCRIPTION
## Summary
- avoid staging unreturned descending records so Prev only sees keys that were surfaced
- update collapse logic to carry iterator items and stage them after acceptance

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d9254a19f08325b13ec4fb4463750d