### PR TITLE
test: slow down benchmark operations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -155,7 +155,8 @@ jobs:
       - name: Run go benchmarks
         if: steps.should-run.outputs.value == 'true'
         run: |
-          go test -bench=. -benchmem -run='^$' ./... | tee benchmark-output.txt
+          set -euo pipefail
+          go test -bench=. -benchmem -run='^$' -count=1 ./... | tee benchmark-output.txt
 
       - name: Restore previous benchmark data
         if: steps.should-run.outputs.value == 'true'

--- a/rindb_benchmark_test.go
+++ b/rindb_benchmark_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"testing"
+	"time"
 )
 
 const (
@@ -16,6 +17,10 @@ var (
 	benchBytesSink  Bytes
 	benchRecordSink Record
 )
+
+func slowBenchmarkOperation() {
+	time.Sleep(2 * time.Millisecond)
+}
 
 func benchmarkOptions(b *testing.B) []Option {
 	b.Helper()
@@ -96,6 +101,7 @@ func BenchmarkRindb_Put(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
+		slowBenchmarkOperation()
 		if err := rin.Put(ctx, makeBenchKey(i), value); err != nil {
 			b.Fatalf("Put failed: %v", err)
 		}
@@ -118,6 +124,7 @@ func BenchmarkRindb_Get(b *testing.B) {
 			b.Fatalf("Get failed: %v", err)
 		}
 		benchBytesSink = val
+		slowBenchmarkOperation()
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a helper to introduce a fixed delay in benchmarks
- invoke the delay in the put and get benchmarks to slow them down and trigger regression alerts

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68daa7ab799883258139f6a2a4ba3694