### PR TITLE
feat: integrate mmap-backed sstable reads

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"context"
+	"runtime"
 	"time"
 )
 
@@ -18,6 +19,9 @@ type NewSSTableManagerFunc func(ctx context.Context, cfg Config, vs *versionSet,
 type Config struct {
 	// databaseDir specifies the directory where WAL and SSTables are stored
 	databaseDir string
+
+	// enableSSTableMmap gates mmap-backed SSTable reads on supported OSes.
+	enableSSTableMmap bool
 
 	// repairMode forces a full directory scan of SSTables during startup,
 	// bypassing the manifest's versionSet.
@@ -120,6 +124,7 @@ func NewConfig(opts ...Option) Config {
 func DefaultConfig() Config {
 	return Config{
 		databaseDir:               "rindat",
+		enableSSTableMmap:         runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows",
 		maxMemtableSize:           1000,
 		level0CompactionThreshold: 2,
 		baseCompactionSizeMB:      10, // Default: Level 1 threshold = 10MB * (10^1) = 100MB
@@ -252,6 +257,11 @@ func WithDatabaseDir(dir string) Option {
 // WithRepairMode enables repair mode which scans SSTables from disk on startup.
 func WithRepairMode(v bool) Option {
 	return func(c *Config) { c.repairMode = v }
+}
+
+// WithSSTableMmap toggles mmap-backed SSTable reads.
+func WithSSTableMmap(enabled bool) Option {
+	return func(c *Config) { c.enableSSTableMmap = enabled }
 }
 
 // WithCacheBytes sets the total byte budget for the table cache.

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package rindb
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -13,12 +14,15 @@ func TestConfig_Default(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
 
+	wantMmap := runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows"
+
 	tests := []struct {
 		name string
 		got  any
 		want any
 	}{
 		{"databaseDir", cfg.databaseDir, "rindat"},
+		{"enableSSTableMmap", cfg.enableSSTableMmap, wantMmap},
 		{"maxMemtableSize", cfg.maxMemtableSize, uint(1000)},
 		{"level0CompactionThreshold", cfg.level0CompactionThreshold, 2},
 		{"baseCompactionSizeMB", cfg.baseCompactionSizeMB, 10},
@@ -70,6 +74,15 @@ func TestConfig_NewWithOptions(t *testing.T) {
 			verify: func(t *testing.T, cfg Config) {
 				if !cfg.repairMode {
 					t.Errorf("repairMode = %v, want %v", cfg.repairMode, true)
+				}
+			},
+		},
+		{
+			name: "WithSSTableMmap",
+			opts: []Option{WithSSTableMmap(false)},
+			verify: func(t *testing.T, cfg Config) {
+				if cfg.enableSSTableMmap {
+					t.Errorf("enableSSTableMmap = %v, want %v", cfg.enableSSTableMmap, false)
 				}
 			},
 		},

--- a/filesystem.go
+++ b/filesystem.go
@@ -307,12 +307,11 @@ func (fs *FileSystem) mmapBytes(off int64, length int) []byte {
 		return nil
 	}
 	start := int(off)
-	end := len(data)
 	if length <= 0 {
 		return data[start:start]
 	}
-	if candidate := off + int64(length); candidate < int64(len(data)) {
-		end = int(candidate)
+	if end := start + length; end > start && end <= len(data) {
+		return data[start:end]
 	}
-	return data[start:end]
+	return data[start:]
 }

--- a/filesystem.go
+++ b/filesystem.go
@@ -19,13 +19,20 @@ var (
 )
 
 type FileSystem struct {
-	mu       sync.RWMutex
-	filePath string
-	file     *os.File
+	mu          sync.RWMutex
+	filePath    string
+	file        *os.File
+	mmap        *mmapHandle
+	mmapEnabled bool
+	log         scopedLogger
+}
+
+func newFileSystem(filePath string) *FileSystem {
+	return &FileSystem{filePath: filePath, log: newScopedLogger(nopLogger{}, LogLevelWarn)}
 }
 
 func OpenFS(ctx context.Context, filePath string) (*FileSystem, error) {
-	fs := &FileSystem{filePath: filePath}
+	fs := newFileSystem(filePath)
 	if err := fs.Open(ctx); err != nil {
 		return nil, err
 	}
@@ -34,7 +41,7 @@ func OpenFS(ctx context.Context, filePath string) (*FileSystem, error) {
 
 // OpenExistingFS opens a file system for an existing file without creating it if missing.
 func OpenExistingFS(ctx context.Context, filePath string) (*FileSystem, error) {
-	fs := &FileSystem{filePath: filePath}
+	fs := newFileSystem(filePath)
 	if err := fs.OpenExisting(ctx); err != nil {
 		return nil, err
 	}
@@ -42,7 +49,9 @@ func OpenExistingFS(ctx context.Context, filePath string) (*FileSystem, error) {
 }
 
 func NewFS(file *os.File) *FileSystem {
-	return &FileSystem{filePath: file.Name(), file: file}
+	fs := newFileSystem(file.Name())
+	fs.file = file
+	return fs
 }
 
 func (fs *FileSystem) IsOpened() bool {
@@ -56,6 +65,7 @@ func (fs *FileSystem) Open(ctx context.Context) error {
 	defer fs.mu.Unlock()
 
 	if fs.file != nil {
+		fs.maybeMmapLocked(ctx)
 		return nil
 	}
 
@@ -64,6 +74,7 @@ func (fs *FileSystem) Open(ctx context.Context) error {
 		return fmt.Errorf("failed to open file %s: %w", fs.filePath, err)
 	}
 	fs.file = file
+	fs.maybeMmapLocked(ctx)
 	return nil
 }
 
@@ -74,6 +85,7 @@ func (fs *FileSystem) OpenExisting(ctx context.Context) error {
 	defer fs.mu.Unlock()
 
 	if fs.file != nil {
+		fs.maybeMmapLocked(ctx)
 		return nil
 	}
 
@@ -82,6 +94,7 @@ func (fs *FileSystem) OpenExisting(ctx context.Context) error {
 		return fmt.Errorf("failed to open file %s: %w", fs.filePath, err)
 	}
 	fs.file = file
+	fs.maybeMmapLocked(ctx)
 	return nil
 }
 
@@ -107,6 +120,7 @@ func (fs *FileSystem) Close() error {
 		return nil
 	}
 
+	fs.closeMmapLocked(context.Background())
 	if err := fs.file.Close(); err != nil {
 		return err
 	}
@@ -121,6 +135,7 @@ func (fs *FileSystem) Rename(newPath string) error {
 	defer fs.mu.Unlock()
 
 	if fs.file != nil {
+		fs.closeMmapLocked(context.Background())
 		if err := fs.file.Close(); err != nil {
 			return err
 		}
@@ -141,6 +156,7 @@ func (fs *FileSystem) Clean() error {
 		return ErrFileNotOpened
 	}
 
+	fs.closeMmapLocked(context.Background())
 	if err := fs.file.Close(); err != nil {
 		return fmt.Errorf("failed to close file %s before cleaning: %w", fs.Path(), err)
 	}
@@ -225,4 +241,78 @@ func (fs *FileSystem) WriteAt(p []byte, off int64) (int, error) {
 	}
 
 	return fs.file.WriteAt(p, off)
+}
+
+func (fs *FileSystem) configureMmap(ctx context.Context, enabled bool, log scopedLogger) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if log.Logger == nil {
+		log = newScopedLogger(nopLogger{}, LogLevelWarn)
+	}
+	fs.log = log
+	fs.mmapEnabled = enabled
+	if !enabled {
+		fs.closeMmapLocked(ctx)
+		return
+	}
+	fs.maybeMmapLocked(ctx)
+}
+
+func (fs *FileSystem) maybeMmapLocked(ctx context.Context) {
+	if !fs.mmapEnabled || fs.file == nil || fs.mmap != nil {
+		return
+	}
+	handle, err := mapFile(fs.file)
+	if err != nil {
+		fs.ensureLogger()
+		if errors.Is(err, errMmapUnsupported) {
+			fs.log.debug(ctx, "sstable mmap unsupported for %s: %v", fs.filePath, err)
+			return
+		}
+		fs.log.warn(ctx, "failed to mmap %s: %v", fs.filePath, err)
+		return
+	}
+	if handle == nil || handle.Bytes() == nil {
+		return
+	}
+	fs.mmap = handle
+}
+
+func (fs *FileSystem) closeMmapLocked(ctx context.Context) {
+	if fs.mmap == nil {
+		return
+	}
+	fs.ensureLogger()
+	if err := fs.mmap.Close(); err != nil {
+		fs.log.warn(ctx, "failed to close mmap for %s: %v", fs.filePath, err)
+	}
+	fs.mmap = nil
+}
+
+func (fs *FileSystem) ensureLogger() {
+	if fs.log.Logger == nil {
+		fs.log = newScopedLogger(nopLogger{}, LogLevelWarn)
+	}
+}
+
+func (fs *FileSystem) mmapBytes(off int64, length int) []byte {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	if fs.mmap == nil || off < 0 {
+		return nil
+	}
+	data := fs.mmap.Bytes()
+	if data == nil || off >= int64(len(data)) {
+		return nil
+	}
+	start := int(off)
+	end := len(data)
+	if length <= 0 {
+		return data[start:start]
+	}
+	if candidate := off + int64(length); candidate < int64(len(data)) {
+		end = int(candidate)
+	}
+	return data[start:end]
 }

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,6 +141,60 @@ func TestFileSystem_Clean_Errors(t *testing.T) {
 		// Clean up: Make writable again so defer closer() can remove it
 		_ = os.Chmod(filePath, 0o600)
 	})
+}
+
+func TestFileSystem_MmapFallback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fss, closer := initTempFileSystems(t, 1, nil)
+	defer closer()
+
+	fs := fss[0]
+	_, err := fs.Write([]byte("a"))
+	require.NoError(t, err)
+	_, err = fs.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+
+	fs.configureMmap(ctx, false, newScopedLogger(nopLogger{}, LogLevelWarn))
+
+	buf := make([]byte, 1)
+	n, err := fs.ReadAt(buf, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, []byte("a"), buf)
+	require.Nil(t, fs.mmapBytes(0, len(buf)))
+}
+
+func TestFileSystem_MmapEnabled(t *testing.T) {
+	t.Parallel()
+
+	switch runtime.GOOS {
+	case "linux", "darwin", "windows":
+	default:
+		t.Skip("mmap not supported on this platform")
+	}
+
+	ctx := context.Background()
+	payload := []byte("hello")
+	fss, closer := initTempFileSystems(t, 1, [][]byte{payload})
+	defer closer()
+
+	fs := fss[0]
+	cfg := testConfig(t)
+	cfg.enableSSTableMmap = true
+	fs.configureMmap(ctx, true, cfg.scopedLogger())
+
+	view := fs.mmapBytes(0, len(payload))
+	require.NotNil(t, view)
+	require.Equal(t, payload, view)
+	require.NotNil(t, fs.mmap)
+
+	buf := make([]byte, len(payload))
+	n, err := fs.ReadAt(buf, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(payload), n)
+	require.Equal(t, payload, buf)
 }
 
 //nolint:funlen

--- a/offset_reader.go
+++ b/offset_reader.go
@@ -15,6 +15,14 @@ func newOffsetReader(fs *FileSystem, off int64) *offsetReader {
 }
 
 func (r *offsetReader) Read(p []byte) (int, error) {
+	if data := r.fs.mmapBytes(r.offset, len(p)); data != nil {
+		n := copy(p, data)
+		r.offset += int64(n)
+		if n < len(p) {
+			return n, io.EOF
+		}
+		return n, nil
+	}
 	n, err := r.fs.ReadAt(p, r.offset)
 	if n > 0 {
 		r.offset += int64(n)

--- a/sstable.go
+++ b/sstable.go
@@ -87,6 +87,7 @@ func NewSSTable(ctx context.Context, config Config, fs *FileSystem) (SStable, er
 		bloom.Insert(ko.key)
 	}
 
+	fs.configureMmap(ctx, config.enableSSTableMmap, log)
 	log.info(ctx, "Successfully created SSTable at %s with %d sparse index entries", fs.Path(), len(sparseIndex))
 	return SStable{FileSystem: fs, SparseIndex: sparseIndex, Bloom: bloom, dataEnd: int64(f.indexOffset), log: log}, nil
 }

--- a/sstable_builder.go
+++ b/sstable_builder.go
@@ -169,6 +169,7 @@ func (b *SSTableBuilder) Build(ctx context.Context) (sst SStable, meta fileMeta,
 
 	b.built = true
 	sst = SStable{FileSystem: b.fs, SparseIndex: b.index, Bloom: b.bloom, dataEnd: indexOffset, log: b.config.scopedLogger()}
+	sst.FileSystem.configureMmap(ctx, b.config.enableSSTableMmap, sst.log)
 	num, nerr := fileNum(b.fs.Path())
 	if nerr != nil {
 		err = fmt.Errorf("invalid sstable path %s: %w", b.fs.Path(), nerr)

--- a/sstable_mmap.go
+++ b/sstable_mmap.go
@@ -3,5 +3,3 @@ package rindb
 import "errors"
 
 var errMmapUnsupported = errors.New("sstable mmap: unsupported platform")
-
-var _ = errMmapUnsupported

--- a/sstable_mmap.go
+++ b/sstable_mmap.go
@@ -1,0 +1,7 @@
+package rindb
+
+import "errors"
+
+var errMmapUnsupported = errors.New("sstable mmap: unsupported platform")
+
+var _ = errMmapUnsupported

--- a/sstable_mmap_posix.go
+++ b/sstable_mmap_posix.go
@@ -11,12 +11,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 type mmapHandle struct {
 	data []byte
 }
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 func mapFile(f *os.File) (*mmapHandle, error) {
 	info, err := f.Stat()
 	if err != nil {
@@ -36,7 +34,6 @@ func mapFile(f *os.File) (*mmapHandle, error) {
 	return &mmapHandle{data: data}, nil
 }
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 func (h *mmapHandle) Close() error {
 	if h == nil || h.data == nil {
 		return nil
@@ -46,7 +43,6 @@ func (h *mmapHandle) Close() error {
 	return unix.Munmap(data)
 }
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 func (h *mmapHandle) Bytes() []byte {
 	if h == nil {
 		return nil

--- a/sstable_mmap_posix.go
+++ b/sstable_mmap_posix.go
@@ -1,0 +1,55 @@
+//go:build darwin || linux
+
+package rindb
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+type mmapHandle struct {
+	data []byte
+}
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+func mapFile(f *os.File) (*mmapHandle, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := info.Size()
+	if size == 0 {
+		return nil, nil
+	}
+	if unsafe.Sizeof(uintptr(0)) == 4 && size > math.MaxInt32 {
+		return nil, fmt.Errorf("sstable mmap: file too large for 32-bit build (%d bytes)", size)
+	}
+	data, err := unix.Mmap(int(f.Fd()), 0, int(size), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, err
+	}
+	return &mmapHandle{data: data}, nil
+}
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+func (h *mmapHandle) Close() error {
+	if h == nil || h.data == nil {
+		return nil
+	}
+	data := h.data
+	h.data = nil
+	return unix.Munmap(data)
+}
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+func (h *mmapHandle) Bytes() []byte {
+	if h == nil {
+		return nil
+	}
+	return h.data
+}

--- a/sstable_mmap_stub.go
+++ b/sstable_mmap_stub.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux && !windows
+
+package rindb
+
+import "os"
+
+type mmapHandle struct{}
+
+func mapFile(*os.File) (*mmapHandle, error) { return nil, errMmapUnsupported }
+func (h *mmapHandle) Close() error          { return nil }
+func (h *mmapHandle) Bytes() []byte         { return nil }

--- a/sstable_mmap_windows.go
+++ b/sstable_mmap_windows.go
@@ -11,13 +11,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 type mmapHandle struct {
 	data   []byte
 	handle windows.Handle
 }
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 func mapFile(f *os.File) (*mmapHandle, error) {
 	info, err := f.Stat()
 	if err != nil {
@@ -43,7 +41,6 @@ func mapFile(f *os.File) (*mmapHandle, error) {
 	return &mmapHandle{data: data, handle: h}, nil
 }
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 func (h *mmapHandle) Close() error {
 	if h == nil || h.data == nil {
 		return nil
@@ -64,7 +61,6 @@ func (h *mmapHandle) Close() error {
 	return errClose
 }
 
-//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
 func (h *mmapHandle) Bytes() []byte {
 	if h == nil {
 		return nil

--- a/sstable_mmap_windows.go
+++ b/sstable_mmap_windows.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package rindb
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+type mmapHandle struct {
+	data   []byte
+	handle windows.Handle
+}
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+func mapFile(f *os.File) (*mmapHandle, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := info.Size()
+	if size == 0 {
+		return nil, nil
+	}
+	if unsafe.Sizeof(uintptr(0)) == 4 && size > math.MaxInt32 {
+		return nil, fmt.Errorf("sstable mmap: file too large for 32-bit build (%d bytes)", size)
+	}
+	h, err := windows.CreateFileMapping(windows.Handle(f.Fd()), nil, windows.PAGE_READONLY, 0, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	ptr, err := windows.MapViewOfFile(h, windows.FILE_MAP_READ, 0, 0, uintptr(size))
+	if err != nil {
+		windows.CloseHandle(h)
+		return nil, err
+	}
+	data := unsafe.Slice((*byte)(unsafe.Pointer(ptr)), int(size))
+	return &mmapHandle{data: data, handle: h}, nil
+}
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+func (h *mmapHandle) Close() error {
+	if h == nil || h.data == nil {
+		return nil
+	}
+	data := h.data
+	h.data = nil
+	errUnmap := windows.UnmapViewOfFile(uintptr(unsafe.Pointer(&data[0])))
+
+	var errClose error
+	if h.handle != 0 {
+		errClose = windows.CloseHandle(h.handle)
+		h.handle = 0
+	}
+
+	if errUnmap != nil {
+		return errUnmap
+	}
+	return errClose
+}
+
+//lint:ignore U1000 used when mmap-backed SSTable IO integration lands.
+func (h *mmapHandle) Bytes() []byte {
+	if h == nil {
+		return nil
+	}
+	return h.data
+}

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -164,6 +165,53 @@ func TestSSTable_BasicOperations(t *testing.T) {
 		value, err = sstable.GetValue(ctx, Bytes("a"))
 		assert.NoError(t, err)
 		assert.Equal(t, Bytes("new"), value)
+	})
+	t.Run("MmapEnabledRead", func(t *testing.T) {
+		ctx := context.Background()
+		mmapCfg := testConfig(t)
+		mmapCfg.enableSSTableMmap = true
+
+		fss, closer := initTempFileSystems(t, 1, nil)
+		defer closer()
+		fs := fss[0]
+
+		mem := InitMemtable(mmapCfg)
+		mem.Put(newRecord(Bytes("k1"), Bytes("v1"), 1))
+
+		sstable, meta, err := flush(ctx, mmapCfg, mem, fs)
+		assert.NoError(t, err)
+		require.NotZero(t, meta.Number)
+
+		value, err := sstable.GetValue(ctx, Bytes("k1"))
+		assert.NoError(t, err)
+		assert.Equal(t, Bytes("v1"), value)
+
+		switch runtime.GOOS {
+		case "linux", "darwin", "windows":
+			require.NotNil(t, sstable.FileSystem.mmap)
+		default:
+			require.Nil(t, sstable.FileSystem.mmap)
+		}
+
+		require.NoError(t, sstable.Close())
+
+		reopenedFS, err := OpenExistingFS(ctx, fs.Path())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, reopenedFS.Close()) })
+
+		reopened, err := NewSSTable(ctx, mmapCfg, reopenedFS)
+		require.NoError(t, err)
+
+		value, err = reopened.GetValue(ctx, Bytes("k1"))
+		assert.NoError(t, err)
+		assert.Equal(t, Bytes("v1"), value)
+
+		switch runtime.GOOS {
+		case "linux", "darwin", "windows":
+			require.NotNil(t, reopened.FileSystem.mmap)
+		default:
+			require.Nil(t, reopened.FileSystem.mmap)
+		}
 	})
 	t.Run("Iterator", func(t *testing.T) {
 		fss, closer := initTempFileSystems(t, 1, nil)


### PR DESCRIPTION
## Summary
- add FileSystem-managed mmap lifecycle with optional gating and slice helper
- serve offsetReader reads from mmapped pages and map SSTables when built or opened
- cover mmap-enabled and fallback behavior for FileSystem and SSTable reads in unit tests

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68daaa6321f083258bbbb34a35dedb13