### PR TITLE
fix: disable telemetry during tests

### DIFF
--- a/rindb_benchmark_test.go
+++ b/rindb_benchmark_test.go
@@ -21,14 +21,6 @@ func benchmarkOptions(b *testing.B) []Option {
 	b.Helper()
 
 	opts := []Option{WithDatabaseDir(b.TempDir())}
-	if isTempoEndpointResolvable() {
-		opts = append(opts,
-			WithEnableTelemetry(true),
-			WithExporterEndpoint("tempo.magpie-gopher.ts.net:4317"),
-			WithExporterInsecure(true),
-			WithTelemetrySamplingRate(1.0),
-		)
-	}
 	return opts
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,23 +7,10 @@ import (
 	"io"
 	"math/rand"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// isTempoEndpointResolvable checks if tempo.magpie-gopher.ts.net is resolvable via DNS.
-// This function executes `nslookup` and checks for a successful resolution.
-func isTempoEndpointResolvable() bool {
-	cmd := exec.Command("nslookup", "tempo.magpie-gopher.ts.net")
-	_, err := cmd.Output()
-	if err != nil {
-		fmt.Printf("tempo.magpie-gopher.ts.net is not resolvable: %v\n", err)
-		return false
-	}
-	return true
-}
 
 func testOptions(t *testing.T) []Option {
 	t.Helper()
@@ -32,15 +19,6 @@ func testOptions(t *testing.T) []Option {
 		WithDatabaseDir(t.TempDir()),
 	}
 
-	// Conditionally enable telemetry based on Tempo endpoint resolvability.
-	if isTempoEndpointResolvable() {
-		opts = append(opts,
-			WithEnableTelemetry(true),
-			WithExporterEndpoint("tempo.magpie-gopher.ts.net:4317"),
-			WithExporterInsecure(true),
-			WithTelemetrySamplingRate(1.0),
-		)
-	}
 	return opts
 }
 


### PR DESCRIPTION
## Summary
- remove Tempo endpoint checks from shared test options
- ensure benchmarks and tests no longer enable telemetry

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68db8dd3326483258e87fc76a6cf9995