### PR TITLE
perf: accelerate skip list level sampling

### DIFF
--- a/skiplist.go
+++ b/skiplist.go
@@ -1,9 +1,9 @@
 package rindb
 
 import (
-	"crypto/rand"
 	"errors"
-	"math/big"
+	"math/bits"
+	randv2 "math/rand/v2"
 )
 
 var (
@@ -36,6 +36,7 @@ type SkipList[K Comparable, V any] struct {
 	headNote *SLNode[K, V]
 	tail     *SLNode[K, V]
 	config   Config
+	rng      randv2.Source
 }
 
 // InitSkipList creates a new empty SkipList using the provided configuration.
@@ -48,10 +49,13 @@ func InitSkipList[K Comparable, V any](config Config) (*SkipList[K, V], error) {
 		return nil, err
 	}
 
+	rng := randv2.NewPCG(randv2.Uint64(), randv2.Uint64())
+
 	return &SkipList[K, V]{
 		level:    config.skipListDefaultLevel,
 		headNote: &SLNode[K, V]{forwards: make([]*SLNode[K, V], config.skipListDefaultLevel)},
 		config:   config,
+		rng:      rng,
 	}, nil
 }
 
@@ -74,7 +78,7 @@ func (list *SkipList[K, V]) Put(searchKey K, newValue V) {
 	if Compare(rn.Key, searchKey) == CmpEqual {
 		rn.Value = newValue
 	} else {
-		newLevel := randomLevel(list.config)
+		newLevel := list.randomLevel()
 		if newLevel > list.level {
 			rl := newLevel
 			for rl > list.level {
@@ -234,6 +238,7 @@ func (list *SkipList[K, V]) Clear() {
 	list.length = newList.length
 	list.headNote = newList.headNote
 	list.tail = nil
+	list.rng = newList.rng
 }
 
 // Len returns the number of elements currently stored in the list.
@@ -421,27 +426,37 @@ func (list *SkipList[K, V]) IRange(start, end K, order RangeOrder) Iterator[V] {
 	}
 }
 
-func intn(m int64) int64 {
-	nBig, err := rand.Int(rand.Reader, big.NewInt(m))
-	if err != nil {
-		panic(err)
-	}
-	return nBig.Int64()
-}
+const (
+	float64Unit = 1.0 / (1 << 53)
+)
 
-func randF64() float64 {
-	const m = 53
-	return float64(intn(1<<m)) / (1 << m)
-}
-
-func randomLevel(config Config) uint {
+func (list *SkipList[K, V]) randomLevel() uint {
 	lvl := uint(1)
-	for lvl < config.skipListMaxLevel {
-		randFloat := randF64()
-		if randFloat >= config.skipListP {
+	if list == nil || list.rng == nil {
+		panic(ErrMalformedList)
+	}
+
+	maxLevel := list.config.skipListMaxLevel
+	if maxLevel <= 1 {
+		return lvl
+	}
+
+	if list.config.skipListP == 0.5 {
+		zeros := uint(bits.TrailingZeros64(list.rng.Uint64()))
+		if zeros > maxLevel-1 {
+			zeros = maxLevel - 1
+		}
+		lvl += zeros
+		return lvl
+	}
+
+	for lvl < maxLevel {
+		randFloat := float64(list.rng.Uint64()>>11) * float64Unit
+		if randFloat >= list.config.skipListP {
 			break
 		}
 		lvl++
 	}
+
 	return lvl
 }

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -2,10 +2,12 @@ package rindb
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	randv2 "math/rand/v2"
 )
 
 func TestSkipList_Init(t *testing.T) {
@@ -1035,4 +1037,31 @@ func TestSkipList_FindGreaterOrEqual(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestSkipList_randomLevelDistribution(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	list.rng = randv2.NewPCG(1, 2)
+
+	const sampleSize = 1 << 15
+	counts := make([]int, int(cfg.skipListMaxLevel))
+
+	for i := 0; i < sampleSize; i++ {
+		lvl := list.randomLevel()
+		counts[int(lvl-1)]++
+	}
+
+	for level := uint(1); level <= cfg.skipListMaxLevel; level++ {
+		expected := math.Pow(cfg.skipListP, float64(level-1))
+		if level < cfg.skipListMaxLevel {
+			expected *= 1 - cfg.skipListP
+		}
+		actual := float64(counts[level-1]) / sampleSize
+		assert.InDeltaf(t, expected, actual, 0.02, "level %d", level)
+	}
 }

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -10,6 +10,25 @@ import (
 	randv2 "math/rand/v2"
 )
 
+type stubRandSource struct {
+	values []uint64
+	idx    int
+}
+
+func (s *stubRandSource) Uint64() uint64 {
+	if len(s.values) == 0 {
+		return 0
+	}
+	if s.idx >= len(s.values) {
+		return s.values[len(s.values)-1]
+	}
+	value := s.values[s.idx]
+	s.idx++
+	return value
+}
+
+func (s *stubRandSource) Seed(uint64) {}
+
 func TestSkipList_Init(t *testing.T) {
 	t.Parallel()
 	cfg := testConfig(t)
@@ -1064,4 +1083,62 @@ func TestSkipList_randomLevelDistribution(t *testing.T) {
 		actual := float64(counts[level-1]) / sampleSize
 		assert.InDeltaf(t, expected, actual, 0.02, "level %d", level)
 	}
+}
+
+func TestSkipList_randomLevelTrailingZeros(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	cfg.skipListDefaultLevel = 1
+	cfg.skipListMaxLevel = 4
+	cfg.skipListP = 0.5
+
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	list.rng = &stubRandSource{values: []uint64{1, 1 << 1, 1 << 4, 0}}
+
+	levels := []uint{
+		list.randomLevel(),
+		list.randomLevel(),
+		list.randomLevel(),
+		list.randomLevel(),
+	}
+
+	assert.Equal(t, []uint{1, 2, 4, 4}, levels)
+}
+
+func TestSkipList_randomLevelWithCustomProbability(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	cfg.skipListDefaultLevel = 1
+	cfg.skipListMaxLevel = 5
+	cfg.skipListP = 0.25
+
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	list.rng = &stubRandSource{values: []uint64{0, 0, 0, 1 << 63}}
+
+	level := list.randomLevel()
+
+	assert.Equal(t, uint(4), level)
+}
+
+func TestSkipList_randomLevelMaxLevelOne(t *testing.T) {
+	t.Parallel()
+
+	cfg := testConfig(t)
+	cfg.skipListDefaultLevel = 1
+	cfg.skipListMaxLevel = 1
+
+	list, err := InitSkipList[int, int](cfg)
+	assert.NoError(t, err)
+
+	list.rng = &stubRandSource{values: []uint64{1 << 10}}
+
+	level := list.randomLevel()
+
+	assert.Equal(t, uint(1), level)
 }


### PR DESCRIPTION
## Summary
- add a per-list PCG-based RNG and use trailing-zero sampling to speed skip list height selection while supporting arbitrary promotion probabilities
- ensure skip list resets its RNG on Clear and remove crypto/rand usages
- add a distribution test to confirm the level sampler matches the configured probability

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68dbbaaf54148325bbf86a91d9eb62fd