### PR TITLE
perf: reuse skip list scratch buffers

### DIFF
--- a/skiplist.go
+++ b/skiplist.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"math/big"
+	"sync"
 )
 
 var (
@@ -36,6 +37,14 @@ type SkipList[K Comparable, V any] struct {
 	headNote *SLNode[K, V]
 	tail     *SLNode[K, V]
 	config   Config
+	// scratchPool stores reusable level-update slices for Put/Remove. The
+	// pool is per-list and safe for concurrent access as sync.Pool handles
+	// its own synchronization.
+	scratchPool sync.Pool
+}
+
+type skipListScratch[K Comparable, V any] struct {
+	nodes []*SLNode[K, V]
 }
 
 // InitSkipList creates a new empty SkipList using the provided configuration.
@@ -52,14 +61,46 @@ func InitSkipList[K Comparable, V any](config Config) (*SkipList[K, V], error) {
 		level:    config.skipListDefaultLevel,
 		headNote: &SLNode[K, V]{forwards: make([]*SLNode[K, V], config.skipListDefaultLevel)},
 		config:   config,
+		scratchPool: sync.Pool{
+			New: func() any {
+				return &skipListScratch[K, V]{
+					nodes: make([]*SLNode[K, V], config.skipListMaxLevel),
+				}
+			},
+		},
 	}, nil
+}
+
+func (list *SkipList[K, V]) acquireScratch() *skipListScratch[K, V] {
+	scratch := list.scratchPool.Get()
+	if scratch == nil {
+		return &skipListScratch[K, V]{
+			nodes: make([]*SLNode[K, V], list.config.skipListMaxLevel),
+		}
+	}
+	buf := scratch.(*skipListScratch[K, V])
+	if cap(buf.nodes) < int(list.config.skipListMaxLevel) {
+		buf.nodes = make([]*SLNode[K, V], list.config.skipListMaxLevel)
+	} else {
+		buf.nodes = buf.nodes[:list.config.skipListMaxLevel]
+	}
+	return buf
+}
+
+func (list *SkipList[K, V]) releaseScratch(buf *skipListScratch[K, V]) {
+	for i := range buf.nodes {
+		buf.nodes[i] = nil
+	}
+	list.scratchPool.Put(buf)
 }
 
 // Put inserts or replaces the value associated with searchKey.
 func (list *SkipList[K, V]) Put(searchKey K, newValue V) {
 	rn := list.Head()
 	rl := list.level
-	update := make([]*SLNode[K, V], list.config.skipListMaxLevel)
+	scratch := list.acquireScratch()
+	update := scratch.nodes
+	defer list.releaseScratch(scratch)
 	for rl > 0 {
 		rl--
 		for rn.forwards[rl] != nil && Compare(rn.forwards[rl].Key, searchKey) == CmpLess {
@@ -177,7 +218,9 @@ func (list *SkipList[K, V]) Head() *SLNode[K, V] {
 func (list *SkipList[K, V]) Remove(searchKey K) error {
 	rn := list.Head()
 	rl := list.level
-	update := make([]*SLNode[K, V], list.config.skipListMaxLevel)
+	scratch := list.acquireScratch()
+	update := scratch.nodes
+	defer list.releaseScratch(scratch)
 	for rl > 0 {
 		rl--
 		for rn.forwards[rl] != nil && Compare(rn.forwards[rl].Key, searchKey) == CmpLess {

--- a/skiplist_benchmark_test.go
+++ b/skiplist_benchmark_test.go
@@ -1,0 +1,49 @@
+package rindb
+
+import "testing"
+
+func BenchmarkSkipListPut(b *testing.B) {
+	cfg := testConfig(b)
+	list, err := InitSkipList[int, int](cfg)
+	if err != nil {
+		b.Fatalf("init skiplist: %v", err)
+	}
+
+	const ringSize = 1024
+	keys := make([]int, ringSize)
+	for i := range keys {
+		keys[i] = i
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		key := keys[i%ringSize]
+		list.Put(key, i)
+	}
+}
+
+func BenchmarkSkipListRemove(b *testing.B) {
+	cfg := testConfig(b)
+	list, err := InitSkipList[int, int](cfg)
+	if err != nil {
+		b.Fatalf("init skiplist: %v", err)
+	}
+
+	const ringSize = 1024
+	for i := 0; i < ringSize; i++ {
+		list.Put(i, i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		key := i % ringSize
+		if err := list.Remove(key); err != nil {
+			b.Fatalf("remove %d: %v", key, err)
+		}
+		list.Put(key, i)
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,19 +12,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testOptions(t *testing.T) []Option {
-	t.Helper()
+func testOptions(tb testing.TB) []Option {
+	tb.Helper()
 
 	opts := []Option{
-		WithDatabaseDir(t.TempDir()),
+		WithDatabaseDir(tb.TempDir()),
 	}
 
 	return opts
 }
 
-func testConfig(t *testing.T) Config {
-	t.Helper()
-	return NewConfig(testOptions(t)...)
+func testConfig(tb testing.TB) Config {
+	tb.Helper()
+	return NewConfig(testOptions(tb)...)
 }
 
 // testRindbSetup encapsulates setup and cleanup logic for rindb tests.


### PR DESCRIPTION
## Summary
- add a per-list sync.Pool to recycle SkipList update buffers and avoid repeated allocations
- refactor Put and Remove to reuse pooled scratch storage safely
- extend shared test helpers for benchmarks and add skip list allocation benchmarks

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68dbba8267a8832580dc51e76963cf48