### PR TITLE
chore: refresh pkg.go.dev after release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,5 +17,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: go
+      - name: Refresh pkg.go.dev
+        if: steps.release.outputs.release_created == 'true'
+        run: |
+          curl https://sum.golang.org/lookup/github.com/metailurini/rindb@${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- capture release-please outputs by adding an id
- trigger pkg.go.dev to refresh the latest release tag

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68de1886b7cc8325acf4599587801117