### PR TITLE
Refactor range iterator cursor handling

### DIFF
--- a/range.go
+++ b/range.go
@@ -45,6 +45,7 @@ func IRangeSnapshot(seq uint64) RangeOption {
 // sequence order.
 type RangeIterator struct {
 	mi                *MergingIterator
+	cursor            *rangeCursor
 	lastKey           Bytes
 	lastKeySet        bool
 	next              Record
@@ -56,95 +57,18 @@ type RangeIterator struct {
 	crossingAnchor    Record
 	crossingAnchorSet bool
 	order             RangeOrder
-	reverseCached     Record
-	reverseErr        error
-	reversePrimed     bool
 }
 
 // NewRangeIterator creates a new RangeIterator from a MergingIterator.
 func NewRangeIterator(mi *MergingIterator, order RangeOrder) *RangeIterator {
-	ri := &RangeIterator{mi: mi, order: order, forward: order != RangeDesc}
+	cursor := newRangeCursor(mi)
+	ri := &RangeIterator{mi: mi, cursor: cursor, order: order, forward: order != RangeDesc}
 	if order == RangeDesc {
-		rec, err := mi.peekReverse()
-		switch {
-		case errors.Is(err, EOI):
-		// Empty range; leave reversePrimed false so HasNext falls through.
-		case err != nil:
+		if err := cursor.ensureReversePrimed(); err != nil && !errors.Is(err, EOI) {
 			ri.err = err
-		default:
-			ri.reverseCached = rec
-			ri.reversePrimed = true
 		}
 	}
 	return ri
-}
-
-func (r *RangeIterator) ensureReversePrimed() {
-	if r.reversePrimed || r.err != nil || r.reverseErr != nil {
-		return
-	}
-	rec, err := r.mi.peekReverse()
-	switch {
-	case errors.Is(err, EOI):
-		r.reverseErr = err
-	case err != nil:
-		r.err = err
-	default:
-		r.reverseCached = rec
-		r.reversePrimed = true
-	}
-}
-
-func (r *RangeIterator) consumePeekedReverse() (pqItem, bool) {
-	item, ok := r.mi.consumePeekedReverse()
-	r.reversePrimed = false
-	r.reverseCached = nil
-	r.reverseErr = nil
-	if !ok {
-		return pqItem{}, false
-	}
-	return item, true
-}
-
-func (r *RangeIterator) collapseDescendingRun(seed Record, seedItem pqItem) (Record, pqItem, bool) {
-	key := seed.GetKey()
-	candidate := seed
-	candidateItem := seedItem
-
-	// Consume all other versions of this key, tracking the one with the highest
-	// sequence number.
-	for r.err == nil {
-		if !r.reversePrimed && r.reverseErr == nil {
-			r.ensureReversePrimed()
-		}
-		if r.reverseErr != nil {
-			if !errors.Is(r.reverseErr, EOI) {
-				r.err = r.reverseErr
-			}
-			break
-		}
-		if !r.reversePrimed || r.reverseCached == nil {
-			break
-		}
-		next := r.reverseCached
-		if next.GetKey().Compare(key) != CmpEqual {
-			break
-		}
-
-		candidateUpdated := next.GetSequenceNumber() > candidate.GetSequenceNumber()
-		if candidateUpdated {
-			candidate = next
-		}
-		item, ok := r.consumePeekedReverse()
-		if candidateUpdated && ok {
-			candidateItem = item
-		}
-	}
-
-	if candidate.GetType() == TypeDeletion {
-		return nil, pqItem{}, false
-	}
-	return candidate, candidateItem, true
 }
 
 func (r *RangeIterator) allowAnchorOnNext() bool {
@@ -168,56 +92,29 @@ func (r *RangeIterator) primeNext() {
 		r.crossingAnchorSet = false
 		return
 	}
+	direction := directionFromOrder(r.order)
 	for !r.nextPrepared && r.err == nil {
-		var (
-			rec         Record
-			recFromPeek bool
-		)
-		if r.order == RangeDesc {
-			if !r.reversePrimed && r.reverseErr == nil {
-				r.ensureReversePrimed()
-			}
-			if r.reverseErr != nil {
-				if !errors.Is(r.reverseErr, EOI) {
-					r.err = r.reverseErr
-				}
+		collapse := r.order == RangeDesc && r.err == nil && !r.forward
+		candidate, ok, err := r.cursor.next(direction, collapse)
+		if err != nil {
+			if errors.Is(err, EOI) {
 				return
 			}
-			if !r.reversePrimed {
-				return
-			}
-			rec = r.reverseCached
-			recFromPeek = true
-		} else {
-			var err error
-			rec, err = r.mi.Next()
-			switch {
-			case errors.Is(err, EOI):
-				return
-			case err != nil:
-				r.err = err
-				return
-			}
+			r.err = err
+			return
 		}
-
-		peeked := recFromPeek
-		var stagedItem pqItem
-		if recFromPeek {
-			item, ok := r.consumePeekedReverse()
-			if !ok {
+		if !ok {
+			if candidate.peeked {
 				r.forward = false
+			}
+			if direction == DirReverse {
 				continue
 			}
-			stagedItem = item
-			if r.order == RangeDesc && r.err == nil && !r.forward {
-				var collapseOK bool
-				rec, stagedItem, collapseOK = r.collapseDescendingRun(rec, item)
-				if !collapseOK {
-					r.forward = false
-					continue
-				}
-			}
+			return
 		}
+
+		rec := candidate.record
+		peeked := candidate.peeked
 
 		sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
 		if sameKey {
@@ -227,7 +124,7 @@ func (r *RangeIterator) primeNext() {
 				if peeked {
 					// Ensure the discarded candidate remains available for Prev()
 					// so oscillating at the boundary can resurface the prior key.
-					r.mi.stageForPrev(stagedItem)
+					r.cursor.stageForPrev(candidate.stagedItem)
 					r.forward = false
 				}
 				continue
@@ -242,7 +139,7 @@ func (r *RangeIterator) primeNext() {
 			continue
 		}
 		if peeked {
-			r.mi.stageForPrev(stagedItem)
+			r.cursor.stageForPrev(candidate.stagedItem)
 			r.forward = false
 		}
 		r.next = rec
@@ -274,8 +171,8 @@ func (r *RangeIterator) primePrevWithOrder(order RangeOrder) {
 				r.mi.forward = false
 			}
 			rec, err = r.mi.Next()
-			if order == r.order && errors.Is(r.reverseErr, EOI) {
-				r.reverseErr = nil
+			if order == r.order && errors.Is(r.cursor.reverseError(), EOI) {
+				r.cursor.clearReverseError()
 			}
 		} else {
 			rec, err = r.mi.Prev()
@@ -337,8 +234,8 @@ func (r *RangeIterator) Next() (Record, error) {
 		if r.err != nil {
 			return empty, r.err
 		}
-		if r.order == RangeDesc && errors.Is(r.reverseErr, EOI) {
-			r.reverseErr = nil
+		if r.order == RangeDesc && errors.Is(r.cursor.reverseError(), EOI) {
+			r.cursor.clearReverseError()
 			return empty, EOI
 		}
 		return empty, EOI
@@ -389,22 +286,26 @@ func (r *RangeIterator) Last() (Record, error) {
 
 	if r.order == RangeDesc {
 		for {
-			peeked, peekErr := r.mi.peekReverse()
+			peekErr := r.cursor.ensureReversePrimed()
 			switch {
 			case errors.Is(peekErr, EOI):
 				rec = nil
 			case peekErr != nil:
 				return empty, peekErr
 			default:
-				item, ok := r.consumePeekedReverse()
+				peeked := r.cursor.currentReverseCandidate()
+				item, ok := r.cursor.consumePeekedReverse()
 				if !ok {
 					rec = nil
 					break
 				}
-				collapsed, stagedItem, ok := r.collapseDescendingRun(peeked, item)
+				collapsed, stagedItem, ok, collapseErr := r.cursor.collapseDescendingRun(peeked, item)
+				if collapseErr != nil {
+					return empty, collapseErr
+				}
 				if ok {
 					rec = collapsed
-					r.mi.stageForPrev(stagedItem)
+					r.cursor.stageForPrev(stagedItem)
 				} else {
 					rec = nil
 				}
@@ -426,9 +327,7 @@ func (r *RangeIterator) Last() (Record, error) {
 	r.next = nil
 	r.err = nil
 	r.lastKeySet = false
-	r.reversePrimed = false
-	r.reverseCached = nil
-	r.reverseErr = nil
+	r.cursor.resetReverse()
 
 	searchOrder := RangeAsc
 

--- a/range_cursor.go
+++ b/range_cursor.go
@@ -1,0 +1,180 @@
+package rindb
+
+import "errors"
+
+type Direction int
+
+const (
+	DirForward Direction = iota
+	DirReverse
+)
+
+func directionFromOrder(order RangeOrder) Direction {
+	if order == RangeAsc {
+		return DirForward
+	}
+	return DirReverse
+}
+
+type cursorCandidate struct {
+	record     Record
+	stagedItem pqItem
+	peeked     bool
+}
+
+type rangeCursor struct {
+	it *MergingIterator
+
+	reverseCached Record
+	reversePrimed bool
+	reverseErr    error
+}
+
+func newRangeCursor(mi *MergingIterator) *rangeCursor {
+	return &rangeCursor{it: mi}
+}
+
+func (c *rangeCursor) ensureReversePrimed() error {
+	if c.reversePrimed || c.reverseErr != nil {
+		return c.reverseErr
+	}
+	rec, err := c.it.peekReverse()
+	switch {
+	case errors.Is(err, EOI):
+		c.reverseErr = err
+		return err
+	case err != nil:
+		c.reverseErr = err
+		return err
+	default:
+		c.reverseCached = rec
+		c.reversePrimed = true
+		return nil
+	}
+}
+
+func (c *rangeCursor) consumePeekedReverse() (pqItem, bool) {
+	item, ok := c.it.consumePeekedReverse()
+	c.reversePrimed = false
+	c.reverseCached = nil
+	c.reverseErr = nil
+	if !ok {
+		return pqItem{}, false
+	}
+	return item, true
+}
+
+func (c *rangeCursor) collapseDescendingRun(seed Record, seedItem pqItem) (Record, pqItem, bool, error) {
+	key := seed.GetKey()
+	candidate := seed
+	candidateItem := seedItem
+
+	for {
+		if err := c.ensureReversePrimed(); err != nil {
+			if errors.Is(err, EOI) {
+				break
+			}
+			return nil, pqItem{}, false, err
+		}
+		if !c.reversePrimed || c.reverseCached == nil {
+			break
+		}
+		next := c.reverseCached
+		if next.GetKey().Compare(key) != CmpEqual {
+			break
+		}
+
+		candidateUpdated := next.GetSequenceNumber() > candidate.GetSequenceNumber()
+		item, ok := c.consumePeekedReverse()
+		if candidateUpdated && ok {
+			candidate = next
+			candidateItem = item
+		}
+		if !ok {
+			break
+		}
+	}
+
+	if candidate.GetType() == TypeDeletion {
+		return nil, pqItem{}, false, nil
+	}
+
+	return candidate, candidateItem, true, nil
+}
+
+func (c *rangeCursor) next(dir Direction, collapse bool) (cursorCandidate, bool, error) {
+	if dir == DirReverse {
+		return c.nextReverse(collapse)
+	}
+	return c.nextForward()
+}
+
+func (c *rangeCursor) nextForward() (cursorCandidate, bool, error) {
+	rec, err := c.it.Next()
+	switch {
+	case err == nil:
+		return cursorCandidate{record: rec}, true, nil
+	case errors.Is(err, EOI):
+		return cursorCandidate{}, false, EOI
+	default:
+		return cursorCandidate{}, false, err
+	}
+}
+
+func (c *rangeCursor) nextReverse(collapse bool) (cursorCandidate, bool, error) {
+	if err := c.ensureReversePrimed(); err != nil {
+		if errors.Is(err, EOI) {
+			return cursorCandidate{}, false, EOI
+		}
+		return cursorCandidate{}, false, err
+	}
+	if !c.reversePrimed || c.reverseCached == nil {
+		return cursorCandidate{}, false, nil
+	}
+	seed := c.reverseCached
+	item, ok := c.consumePeekedReverse()
+	if !ok {
+		return cursorCandidate{}, false, nil
+	}
+	candidate := cursorCandidate{peeked: true}
+	if !collapse {
+		candidate.record = seed
+		candidate.stagedItem = item
+		return candidate, true, nil
+	}
+	rec, stagedItem, okCollapse, err := c.collapseDescendingRun(seed, item)
+	if err != nil {
+		return cursorCandidate{}, false, err
+	}
+	if okCollapse {
+		candidate.record = rec
+		candidate.stagedItem = stagedItem
+		return candidate, true, nil
+	}
+	return candidate, false, nil
+}
+
+func (c *rangeCursor) stageForPrev(item pqItem) {
+	if item.rec == nil || item.iter == nil {
+		return
+	}
+	c.it.stageForPrev(item)
+}
+
+func (c *rangeCursor) reverseError() error {
+	return c.reverseErr
+}
+
+func (c *rangeCursor) clearReverseError() {
+	c.reverseErr = nil
+}
+
+func (c *rangeCursor) resetReverse() {
+	c.reversePrimed = false
+	c.reverseCached = nil
+	c.reverseErr = nil
+}
+
+func (c *rangeCursor) currentReverseCandidate() Record {
+	return c.reverseCached
+}

--- a/range_cursor.go
+++ b/range_cursor.go
@@ -39,18 +39,13 @@ func (c *rangeCursor) ensureReversePrimed() error {
 		return c.reverseErr
 	}
 	rec, err := c.it.peekReverse()
-	switch {
-	case errors.Is(err, EOI):
+	if err != nil {
 		c.reverseErr = err
 		return err
-	case err != nil:
-		c.reverseErr = err
-		return err
-	default:
-		c.reverseCached = rec
-		c.reversePrimed = true
-		return nil
 	}
+	c.reverseCached = rec
+	c.reversePrimed = true
+	return nil
 }
 
 func (c *rangeCursor) consumePeekedReverse() (pqItem, bool) {
@@ -111,14 +106,13 @@ func (c *rangeCursor) next(dir Direction, collapse bool) (cursorCandidate, bool,
 
 func (c *rangeCursor) nextForward() (cursorCandidate, bool, error) {
 	rec, err := c.it.Next()
-	switch {
-	case err == nil:
-		return cursorCandidate{record: rec}, true, nil
-	case errors.Is(err, EOI):
-		return cursorCandidate{}, false, EOI
-	default:
+	if err != nil {
+		if errors.Is(err, EOI) {
+			return cursorCandidate{}, false, EOI
+		}
 		return cursorCandidate{}, false, err
 	}
+	return cursorCandidate{record: rec}, true, nil
 }
 
 func (c *rangeCursor) nextReverse(collapse bool) (cursorCandidate, bool, error) {


### PR DESCRIPTION
## Summary
- introduce a Direction enum and rangeCursor helper to encapsulate reverse traversal logic
- update RangeIterator to delegate reverse staging and collapsing to the new cursor abstraction

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68e2306b2a7483258f23d52bfde14de4