### PR TITLE
refactor: add record filter helper

### DIFF
--- a/range_filter.go
+++ b/range_filter.go
@@ -16,8 +16,8 @@ type recordFilter struct {
 
 // newRecordFilter constructs a recordFilter bound to the provided snapshot. A
 // nil snapshot permits all sequence numbers.
-func newRecordFilter(snapshot *uint64) recordFilter {
-	f := recordFilter{}
+func newRecordFilter(snapshot *uint64) *recordFilter {
+	f := &recordFilter{}
 	if snapshot != nil {
 		f.snapshot = *snapshot
 		f.hasSnapshot = true
@@ -63,11 +63,12 @@ func (f *recordFilter) Reset() {
 
 // MarkEmitted updates the deduplication state for a record that bypassed
 // Accept, such as when replaying an anchor during a direction switch.
-func (f *recordFilter) MarkEmitted(rec Record) {
+func (f *recordFilter) MarkEmitted(rec Record, dir Direction) {
 	if rec == nil {
 		return
 	}
 	f.remember(rec.GetKey())
+	f.lastDir = dir
 	f.dirSet = true
 }
 
@@ -77,8 +78,6 @@ func (f *recordFilter) remember(key Bytes) {
 }
 
 func (f *recordFilter) resetKey() {
-	if f.lastKey != nil {
-		f.lastKey = f.lastKey[:0]
-	}
+	f.lastKey = f.lastKey[:0]
 	f.lastKeySet = false
 }

--- a/range_filter_test.go
+++ b/range_filter_test.go
@@ -76,11 +76,38 @@ func TestRecordFilterMarkEmittedUpdatesState(t *testing.T) {
 	emitted := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 6, Type: TypeValue}
 	older := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 3, Type: TypeValue}
 
-	filter.MarkEmitted(emitted)
+	filter.MarkEmitted(emitted, DirForward)
 
 	second, ok := filter.Accept(older, DirForward)
 	require.False(t, ok)
 	require.Nil(t, second)
+}
+
+func TestRecordFilterMarkEmittedMaintainsDirection(t *testing.T) {
+	filter := newRecordFilter(nil)
+	emitted := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 6, Type: TypeValue}
+	older := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 3, Type: TypeValue}
+
+	filter.MarkEmitted(emitted, DirReverse)
+
+	suppressed, ok := filter.Accept(older, DirReverse)
+	require.False(t, ok)
+	require.Nil(t, suppressed)
+
+	replay, ok := filter.Accept(older, DirForward)
+	require.True(t, ok)
+	require.Equal(t, older, replay)
+}
+
+func TestRecordFilterMarkEmittedIgnoresNilRecord(t *testing.T) {
+	filter := newRecordFilter(nil)
+	other := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 6, Type: TypeValue}
+
+	filter.MarkEmitted(nil, DirForward)
+
+	accepted, ok := filter.Accept(other, DirForward)
+	require.True(t, ok)
+	require.Equal(t, other, accepted)
 }
 
 func TestRecordFilterAcceptHandlesNilRecord(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a recordFilter helper to centralize snapshot, tombstone, and duplicate filtering for range iteration
- cover the new helper with focused unit tests exercising dedupe, reset, and mark semantics

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68e25b67ae8c8325beaf0460c98f450d