### PR TITLE
refactor: add anchor state helper for range iterator

### DIFF
--- a/range_anchor.go
+++ b/range_anchor.go
@@ -13,15 +13,18 @@ type anchorState struct {
 // record for replay when the traversal direction changes. It returns true when
 // a direction change occurred.
 func (a *anchorState) OnDirectionChange(next Direction, lastEmitted Record) bool {
+	prevDir := a.lastDir
+	a.lastDir = next
+
 	if !a.dirSet {
-		a.lastDir = next
 		a.dirSet = true
 		return false
 	}
-	if a.lastDir == next {
+
+	if prevDir == next {
 		return false
 	}
-	a.lastDir = next
+
 	a.pending = cloneRecord(lastEmitted)
 	return true
 }

--- a/range_anchor.go
+++ b/range_anchor.go
@@ -1,0 +1,38 @@
+package rindb
+
+// anchorState tracks the pending anchor record to replay after a direction
+// switch. It stages the last emitted record when the traversal direction
+// changes so oscillating iteration can surface the boundary element again.
+type anchorState struct {
+	pending Record
+	lastDir Direction
+	dirSet  bool
+}
+
+// OnDirectionChange records the new direction and stages the last emitted
+// record for replay when the traversal direction changes. It returns true when
+// a direction change occurred.
+func (a *anchorState) OnDirectionChange(next Direction, lastEmitted Record) bool {
+	if !a.dirSet {
+		a.lastDir = next
+		a.dirSet = true
+		return false
+	}
+	if a.lastDir == next {
+		return false
+	}
+	a.lastDir = next
+	a.pending = cloneRecord(lastEmitted)
+	return true
+}
+
+// popPending retrieves the staged anchor record, if any, clearing the pending
+// state once consumed.
+func (a *anchorState) popPending() (Record, bool) {
+	if a.pending == nil {
+		return nil, false
+	}
+	rec := a.pending
+	a.pending = nil
+	return rec, true
+}

--- a/range_anchor_test.go
+++ b/range_anchor_test.go
@@ -1,0 +1,51 @@
+package rindb
+
+import "testing"
+
+func TestAnchorState_OnDirectionChangeStagesClone(t *testing.T) {
+	state := &anchorState{}
+	rec := RecordImpl{Key: Bytes("key"), Value: Bytes("value"), SequenceNumber: 1}
+
+	if changed := state.OnDirectionChange(DirForward, nil); changed {
+		t.Fatalf("expected initial direction to report no change")
+	}
+
+	if changed := state.OnDirectionChange(DirReverse, rec); !changed {
+		t.Fatalf("expected direction switch to report change")
+	}
+
+	staged, ok := state.popPending()
+	if !ok {
+		t.Fatalf("expected pending record after direction change")
+	}
+	if staged.GetSequenceNumber() != rec.GetSequenceNumber() || staged.GetType() != rec.GetType() {
+		t.Fatalf("cloned record does not match original metadata")
+	}
+	if string(staged.GetKey()) != string(rec.GetKey()) || string(staged.GetValue()) != string(rec.GetValue()) {
+		t.Fatalf("cloned record does not match original key/value")
+	}
+
+	// Mutate the original record to confirm the staged copy is independent.
+	rec.Key[0] = 'x'
+	rec.Value[0] = 'y'
+	if staged.GetKey()[0] == rec.GetKey()[0] || staged.GetValue()[0] == rec.GetValue()[0] {
+		t.Fatalf("expected staged record to be independent clone")
+	}
+
+	if _, ok := state.popPending(); ok {
+		t.Fatalf("expected pending record to be cleared after pop")
+	}
+}
+
+func TestAnchorState_OnDirectionChangeIgnoresSameDirection(t *testing.T) {
+	state := &anchorState{}
+	rec := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 2}
+
+	state.OnDirectionChange(DirForward, rec)
+	if changed := state.OnDirectionChange(DirForward, rec); changed {
+		t.Fatalf("expected same direction to report no change")
+	}
+	if _, ok := state.popPending(); ok {
+		t.Fatalf("did not expect pending record when direction unchanged")
+	}
+}


### PR DESCRIPTION
## Summary
- add an anchorState helper to manage staging the last emitted record on direction changes
- cover the new helper with unit tests that verify cloning and no-op semantics when the direction does not change

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68e297309ef0832585bef4351794f215