### PR TITLE
Refactor RangeIterator coordination across directions

### DIFF
--- a/range.go
+++ b/range.go
@@ -287,16 +287,12 @@ func (r *RangeIterator) pullDescendingTail() pullFunc {
 			candidate := seed
 			stagedItem := item
 			if r.shouldCollapseReverse(DirReverse) {
-				rec, staged, okCollapse, err := c.collapseDescendingRun(seed, item)
+				rec, staged, _, err := c.collapseDescendingRun(seed, item)
 				if err != nil {
 					return nil, false, err
 				}
-				if okCollapse {
-					candidate = rec
-					stagedItem = staged
-				} else {
-					candidate = nil
-				}
+				candidate = rec
+				stagedItem = staged
 			}
 
 			if candidate == nil {

--- a/range.go
+++ b/range.go
@@ -114,35 +114,68 @@ func (r *RangeIterator) Prev() (Record, error) {
 
 // Last implements Iterator[Record].
 func (r *RangeIterator) Last() (Record, error) {
-	var (
-		empty Record
-		last  Record
-	)
+	var empty Record
 
-	dir := r.nextDirection()
-	r.invalidate(dir)
-	r.invalidate(oppositeDirection(dir))
+	// Reset any prepared state so Last can reposition the iterator without
+	// leaking cached reads from prior traversal.
+	r.invalidate(DirForward)
+	r.invalidate(DirReverse)
 	r.anchors = anchorState{}
-	prevDir := r.prevDirection()
+	r.cursor = newRangeCursor(r.mi)
 
+	// Position the underlying merging iterator at the logical tail.
+	if _, err := r.mi.Last(); err != nil {
+		return empty, err
+	}
+
+	pullDir := r.prevDirection()
+	filterDir := pullDir
+	if r.order == RangeDesc {
+		pullDir = DirForward
+		filterDir = DirReverse
+	}
+	pull := r.pullFor(pullDir)
+	if r.order == RangeDesc && pullDir == DirForward {
+		pull = r.pullDescendingTail()
+	}
+
+	consumeAll := r.order == RangeDesc
+	var rec Record
 	for {
-		rec, err := r.Next()
+		candidate, ok, err := pull(r.cursor)
 		if err != nil {
 			if errors.Is(err, EOI) {
-				if last == nil {
-					return empty, EOI
-				}
-				r.filter.MarkEmitted(last, prevDir)
-				r.anchors = anchorState{lastDir: prevDir, dirSet: true}
-				r.lastEmitted = last
-				r.invalidate(dir)
-				r.invalidate(oppositeDirection(dir))
-				return last, nil
+				break
 			}
 			return empty, err
 		}
-		last = rec
+		if !ok {
+			continue
+		}
+		if candidate == nil {
+			continue
+		}
+		if accepted, ok := r.filter.Accept(candidate, filterDir); ok {
+			rec = accepted
+			if !consumeAll {
+				break
+			}
+		}
 	}
+
+	if rec == nil {
+		return empty, EOI
+	}
+
+	if consumeAll && r.cursor.it.fwd.Len() > 0 {
+		_ = r.cursor.it.fwd.PopItem()
+	}
+
+	r.lastEmitted = rec
+	r.anchors = anchorState{lastDir: pullDir, dirSet: true}
+	r.invalidate(DirForward)
+	r.invalidate(DirReverse)
+	return rec, nil
 }
 
 // Close releases any resources held by the iterator.
@@ -168,14 +201,12 @@ func (r *RangeIterator) prepare(dir Direction, pull pullFunc) *preparedState {
 }
 
 func (r *RangeIterator) advance(dir Direction, pull pullFunc) (Record, error) {
-	if changed := r.anchors.OnDirectionChange(dir, r.lastEmitted); changed {
+	if r.anchors.OnDirectionChange(dir, r.lastEmitted) {
 		if rec, ok := r.anchors.popPending(); ok {
 			r.filter.MarkEmitted(rec, dir)
 			return rec, nil
 		}
-	}
-
-	if rec, ok := r.anchors.popPending(); ok {
+	} else if rec, ok := r.anchors.popPending(); ok {
 		r.filter.MarkEmitted(rec, dir)
 		return rec, nil
 	}
@@ -227,17 +258,55 @@ func (r *RangeIterator) pullFor(dir Direction) pullFunc {
 				return nil, false, nil
 			}
 			if r.order == RangeDesc && !candidate.staged {
-				if candidate.record == nil {
-					return nil, false, EOI
-				}
-				if r.lastEmitted == nil {
-					return nil, false, EOI
-				}
-				if candidate.record.GetKey().Compare(r.lastEmitted.GetKey()) != CmpGreater {
+				if r.lastEmitted == nil || candidate.record.GetKey().Compare(r.lastEmitted.GetKey()) != CmpGreater {
 					return nil, false, EOI
 				}
 			}
 			return candidate.record, true, nil
+		}
+	}
+}
+
+func (r *RangeIterator) pullDescendingTail() pullFunc {
+	return func(c *rangeCursor) (Record, bool, error) {
+		for {
+			if err := c.ensureReversePrimed(); err != nil {
+				if errors.Is(err, EOI) {
+					return nil, false, EOI
+				}
+				return nil, false, err
+			}
+			if !c.reversePrimed || c.reverseCached == nil {
+				return nil, false, nil
+			}
+			seed := c.reverseCached
+			item, ok := c.consumePeekedReverse()
+			if !ok {
+				return nil, false, nil
+			}
+
+			candidate := seed
+			stagedItem := item
+			if r.shouldCollapseReverse(DirReverse) {
+				rec, staged, okCollapse, err := c.collapseDescendingRun(seed, item)
+				if err != nil {
+					return nil, false, err
+				}
+				if okCollapse {
+					candidate = rec
+					stagedItem = staged
+				} else {
+					candidate = nil
+				}
+			}
+
+			if candidate == nil {
+				continue
+			}
+			if candidate.GetType() != TypeDeletion {
+				c.stageForPrev(stagedItem)
+			}
+			return candidate, true, nil
 		}
 	}
 }

--- a/range.go
+++ b/range.go
@@ -1,8 +1,6 @@
 package rindb
 
-import (
-	"errors"
-)
+import "errors"
 
 // RangeOrder represents the initial traversal direction for range iterators.
 type RangeOrder int
@@ -40,326 +38,110 @@ func IRangeSnapshot(seq uint64) RangeOption {
 	}
 }
 
-// RangeIterator is a user-facing iterator that hides tombstones and
-// duplicates. It wraps a MergingIterator which provides all records in key and
-// sequence order.
+type preparedState struct {
+	record Record
+	err    error
+	ready  bool
+}
+
+// RangeIterator is a user-facing iterator that hides tombstones and duplicates.
+// It wraps a MergingIterator which provides all records in key and sequence
+// order.
 type RangeIterator struct {
-	mi                *MergingIterator
-	cursor            *rangeCursor
-	lastKey           Bytes
-	lastKeySet        bool
-	next              Record
-	prev              Record
-	nextPrepared      bool
-	prevPrepared      bool
-	err               error
-	forward           bool
-	crossingAnchor    Record
-	crossingAnchorSet bool
-	order             RangeOrder
+	mi      *MergingIterator
+	cursor  *rangeCursor
+	filter  *recordFilter
+	anchors anchorState
+	order   RangeOrder
+
+	lastEmitted Record
+	prepared    [2]preparedState
 }
 
 // NewRangeIterator creates a new RangeIterator from a MergingIterator.
 func NewRangeIterator(mi *MergingIterator, order RangeOrder) *RangeIterator {
-	cursor := newRangeCursor(mi)
-	ri := &RangeIterator{mi: mi, cursor: cursor, order: order, forward: order != RangeDesc}
-	if order == RangeDesc {
-		if err := cursor.ensureReversePrimed(); err != nil && !errors.Is(err, EOI) {
-			ri.err = err
-		}
+	return &RangeIterator{
+		mi:     mi,
+		cursor: newRangeCursor(mi),
+		filter: newRecordFilter(nil),
+		order:  order,
 	}
-	return ri
-}
-
-func (r *RangeIterator) allowAnchorOnNext() bool {
-	if r.order == RangeDesc {
-		return r.forward
-	}
-	return !r.forward
-}
-
-func (r *RangeIterator) allowAnchorOnPrevForOrder(order RangeOrder) bool {
-	if order == RangeDesc {
-		return !r.forward
-	}
-	return r.forward
-}
-
-func (r *RangeIterator) primeNext() {
-	if r.order == RangeDesc && r.forward && r.crossingAnchorSet {
-		r.next = r.crossingAnchor
-		r.nextPrepared = true
-		r.crossingAnchorSet = false
-		return
-	}
-	direction := directionFromOrder(r.order)
-	for !r.nextPrepared && r.err == nil {
-		collapse := r.order == RangeDesc && r.err == nil && !r.forward
-		candidate, ok, err := r.cursor.next(direction, collapse)
-		if err != nil {
-			if errors.Is(err, EOI) {
-				return
-			}
-			r.err = err
-			return
-		}
-		if !ok {
-			if candidate.peeked {
-				r.forward = false
-			}
-			if direction == DirReverse {
-				continue
-			}
-			return
-		}
-
-		rec := candidate.record
-		peeked := candidate.peeked
-
-		sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
-		if sameKey {
-			if r.allowAnchorOnNext() && r.matchesCrossingAnchor(rec) {
-				r.crossingAnchorSet = false
-			} else {
-				if peeked {
-					// Ensure the discarded candidate remains available for Prev()
-					// so oscillating at the boundary can resurface the prior key.
-					r.cursor.stageForPrev(candidate.stagedItem)
-					r.forward = false
-				}
-				continue
-			}
-		}
-		r.lastKey = rec.GetKey().Clone()
-		r.lastKeySet = true
-		if rec.GetType() == TypeDeletion {
-			if peeked {
-				r.forward = false
-			}
-			continue
-		}
-		if peeked {
-			r.cursor.stageForPrev(candidate.stagedItem)
-			r.forward = false
-		}
-		r.next = rec
-		r.nextPrepared = true
-	}
-	if r.nextPrepared {
-		r.prevPrepared = false
-	}
-}
-
-func (r *RangeIterator) primePrev() {
-	r.primePrevWithOrder(r.order)
-}
-
-func (r *RangeIterator) primePrevWithOrder(order RangeOrder) {
-	if order == RangeDesc && !r.forward && r.crossingAnchorSet {
-		r.prev = r.crossingAnchor
-		r.prevPrepared = true
-		r.crossingAnchorSet = false
-		return
-	}
-	for !r.prevPrepared && r.err == nil {
-		var (
-			rec Record
-			err error
-		)
-		if order == RangeDesc {
-			if r.mi != nil {
-				r.mi.forward = false
-			}
-			rec, err = r.mi.Next()
-			if order == r.order && errors.Is(r.cursor.reverseError(), EOI) {
-				r.cursor.clearReverseError()
-			}
-		} else {
-			rec, err = r.mi.Prev()
-		}
-		switch {
-		case errors.Is(err, EOI):
-			return
-		case err != nil:
-			r.err = err
-			return
-		}
-
-		if !r.stagePrevCandidate(rec, order) {
-			continue
-		}
-	}
-	if r.prevPrepared {
-		r.nextPrepared = false
-	}
-}
-
-func (r *RangeIterator) stagePrevCandidate(rec Record, order RangeOrder) bool {
-	sameKey := r.lastKeySet && rec.GetKey().Compare(r.lastKey) == CmpEqual
-	if sameKey {
-		if r.allowAnchorOnPrevForOrder(order) && r.matchesCrossingAnchor(rec) {
-			r.crossingAnchorSet = false
-		} else if r.nextPrepared && recordsEqual(rec, r.next) {
-			// A forward peek staged this record; treat it as the anchor so Prev can surface it.
-			r.crossingAnchor = rec
-			r.crossingAnchorSet = true
-		} else {
-			return false
-		}
-	}
-	r.lastKey = rec.GetKey().Clone()
-	r.lastKeySet = true
-	if rec.GetType() == TypeDeletion {
-		return false
-	}
-	r.prev = rec
-	r.prevPrepared = true
-	r.nextPrepared = false
-	return true
 }
 
 // HasNext implements Iterator[Record].
 func (r *RangeIterator) HasNext() bool {
-	r.primeNext()
-	return r.nextPrepared
+	dir := r.nextDirection()
+	state := r.prepare(dir, r.pullFor(dir))
+	return state.err == nil
 }
 
 // Next implements Iterator[Record].
 func (r *RangeIterator) Next() (Record, error) {
-	if !r.nextPrepared {
-		r.primeNext()
-	}
-	if !r.nextPrepared {
+	dir := r.nextDirection()
+	state := r.prepare(dir, r.pullFor(dir))
+	defer r.invalidate(dir)
+	if state.err != nil {
 		var empty Record
-		if r.err != nil {
-			return empty, r.err
-		}
-		if r.order == RangeDesc && errors.Is(r.cursor.reverseError(), EOI) {
-			r.cursor.clearReverseError()
-			return empty, EOI
-		}
-		return empty, EOI
+		return empty, state.err
 	}
-	r.nextPrepared = false
-	r.forward = r.order != RangeDesc
-	rec := r.next
-	r.crossingAnchor = rec
-	r.crossingAnchorSet = true
+	rec := state.record
+	r.lastEmitted = rec
+	r.invalidate(oppositeDirection(dir))
 	return rec, nil
 }
 
 // HasPrev implements Iterator[Record].
 func (r *RangeIterator) HasPrev() bool {
-	r.primePrev()
-	return r.prevPrepared
+	dir := r.prevDirection()
+	state := r.prepare(dir, r.pullFor(dir))
+	return state.err == nil
 }
 
 // Prev implements Iterator[Record].
 func (r *RangeIterator) Prev() (Record, error) {
-	if !r.prevPrepared {
-		r.primePrev()
-	}
-	if !r.prevPrepared {
+	dir := r.prevDirection()
+	state := r.prepare(dir, r.pullFor(dir))
+	defer r.invalidate(dir)
+	if state.err != nil {
 		var empty Record
-		if r.err != nil {
-			return empty, r.err
-		}
-		return empty, EOI
+		return empty, state.err
 	}
-	r.prevPrepared = false
-	r.forward = r.order == RangeDesc
-	rec := r.prev
-	r.crossingAnchor = rec
-	r.crossingAnchorSet = true
+	rec := state.record
+	r.lastEmitted = rec
+	r.invalidate(oppositeDirection(dir))
 	return rec, nil
 }
 
 // Last implements Iterator[Record].
 func (r *RangeIterator) Last() (Record, error) {
-	var empty Record
-	r.err = nil
+	var (
+		empty Record
+		last  Record
+	)
 
-	rec, err := r.mi.Last()
-	if err != nil {
-		return empty, err
-	}
-
-	if r.order == RangeDesc {
-		for {
-			peekErr := r.cursor.ensureReversePrimed()
-			switch {
-			case errors.Is(peekErr, EOI):
-				rec = nil
-			case peekErr != nil:
-				return empty, peekErr
-			default:
-				peeked := r.cursor.currentReverseCandidate()
-				item, ok := r.cursor.consumePeekedReverse()
-				if !ok {
-					rec = nil
-					break
-				}
-				collapsed, stagedItem, ok, collapseErr := r.cursor.collapseDescendingRun(peeked, item)
-				if collapseErr != nil {
-					return empty, collapseErr
-				}
-				if ok {
-					rec = collapsed
-					r.cursor.stageForPrev(stagedItem)
-				} else {
-					rec = nil
-				}
-			}
-			if rec != nil {
-				break
-			}
-			if errors.Is(peekErr, EOI) {
-				break
-			}
-		}
-	}
-
-	r.prevPrepared = false
-	r.nextPrepared = false
-	r.forward = false
-	r.crossingAnchorSet = false
-	r.prev = nil
-	r.next = nil
-	r.err = nil
-	r.lastKeySet = false
-	r.cursor.resetReverse()
-
-	searchOrder := RangeAsc
-
-	lastValid := Record(nil)
-	if rec != nil {
-		r.stagePrevCandidate(rec, searchOrder)
-	}
+	dir := r.nextDirection()
+	r.invalidate(dir)
+	r.invalidate(oppositeDirection(dir))
+	r.anchors = anchorState{}
+	prevDir := r.prevDirection()
 
 	for {
-		if !r.prevPrepared {
-			r.primePrevWithOrder(searchOrder)
-			if !r.prevPrepared {
-				if r.err != nil {
-					return empty, r.err
-				}
-				if r.order == RangeDesc && lastValid != nil {
-					return lastValid, nil
-				}
-				return empty, EOI
-			}
-		}
-
-		current, err := r.Prev()
+		rec, err := r.Next()
 		if err != nil {
+			if errors.Is(err, EOI) {
+				if last == nil {
+					return empty, EOI
+				}
+				r.filter.MarkEmitted(last, prevDir)
+				r.anchors = anchorState{lastDir: prevDir, dirSet: true}
+				r.lastEmitted = last
+				r.invalidate(dir)
+				r.invalidate(oppositeDirection(dir))
+				return last, nil
+			}
 			return empty, err
 		}
-
-		if r.order != RangeDesc {
-			return current, nil
-		}
-
-		lastValid = current
+		last = rec
 	}
 }
 
@@ -368,18 +150,125 @@ func (r *RangeIterator) Close() error {
 	return r.mi.Close()
 }
 
-func (r *RangeIterator) matchesCrossingAnchor(rec Record) bool {
-	return r.crossingAnchorSet && recordsEqual(rec, r.crossingAnchor)
+func (r *RangeIterator) prepare(dir Direction, pull pullFunc) *preparedState {
+	state := &r.prepared[dir]
+	if state.ready {
+		return state
+	}
+	rec, err := r.advance(dir, pull)
+	if err != nil {
+		state.err = err
+		state.record = nil
+	} else {
+		state.record = rec
+		state.err = nil
+	}
+	state.ready = true
+	return state
 }
 
-func recordsEqual(a, b Record) bool {
-	if a == nil || b == nil {
-		return false
+func (r *RangeIterator) advance(dir Direction, pull pullFunc) (Record, error) {
+	if changed := r.anchors.OnDirectionChange(dir, r.lastEmitted); changed {
+		if rec, ok := r.anchors.popPending(); ok {
+			r.filter.MarkEmitted(rec, dir)
+			return rec, nil
+		}
 	}
-	return a.GetSequenceNumber() == b.GetSequenceNumber() &&
-		a.GetType() == b.GetType() &&
-		a.GetKey().Compare(b.GetKey()) == CmpEqual
+
+	if rec, ok := r.anchors.popPending(); ok {
+		r.filter.MarkEmitted(rec, dir)
+		return rec, nil
+	}
+
+	for {
+		rec, ok, err := pull(r.cursor)
+		if err != nil {
+			if errors.Is(err, EOI) {
+				if dir == DirReverse {
+					r.cursor.clearReverseError()
+				}
+				return nil, EOI
+			}
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if accepted, ok := r.filter.Accept(rec, dir); ok {
+			return accepted, nil
+		}
+	}
 }
+
+func (r *RangeIterator) pullFor(dir Direction) pullFunc {
+	switch dir {
+	case DirReverse:
+		collapse := r.shouldCollapseReverse(dir)
+		return func(c *rangeCursor) (Record, bool, error) {
+			candidate, ok, err := c.next(DirReverse, collapse)
+			if err != nil {
+				return nil, false, err
+			}
+			if !ok {
+				return nil, false, nil
+			}
+			if candidate.peeked && candidate.record != nil && candidate.record.GetType() != TypeDeletion {
+				c.stageForPrev(candidate.stagedItem)
+			}
+			return candidate.record, true, nil
+		}
+	default:
+		return func(c *rangeCursor) (Record, bool, error) {
+			candidate, ok, err := c.next(DirForward, false)
+			if err != nil {
+				return nil, false, err
+			}
+			if !ok {
+				return nil, false, nil
+			}
+			if r.order == RangeDesc && !candidate.staged {
+				if candidate.record == nil {
+					return nil, false, EOI
+				}
+				if r.lastEmitted == nil {
+					return nil, false, EOI
+				}
+				if candidate.record.GetKey().Compare(r.lastEmitted.GetKey()) != CmpGreater {
+					return nil, false, EOI
+				}
+			}
+			return candidate.record, true, nil
+		}
+	}
+}
+
+func (r *RangeIterator) shouldCollapseReverse(dir Direction) bool {
+	return r.order == RangeDesc && dir == DirReverse
+}
+
+func (r *RangeIterator) invalidate(dir Direction) {
+	r.prepared[dir] = preparedState{}
+}
+
+func (r *RangeIterator) nextDirection() Direction {
+	return directionFromOrder(r.order)
+}
+
+func (r *RangeIterator) prevDirection() Direction {
+	if r.nextDirection() == DirForward {
+		return DirReverse
+	}
+	return DirForward
+}
+
+func oppositeDirection(dir Direction) Direction {
+	if dir == DirForward {
+		return DirReverse
+	}
+	return DirForward
+}
+
+type pullFunc func(*rangeCursor) (Record, bool, error)
 
 func newEmptyRangeIterator() *RangeIterator {
 	mi, err := NewMergingIterator(nil, nil, RangeAsc)

--- a/range.go
+++ b/range.go
@@ -168,6 +168,9 @@ func (r *RangeIterator) Last() (Record, error) {
 	}
 
 	if consumeAll && r.cursor.it.fwd.Len() > 0 {
+		// pullDescendingTail stages the terminal forward candidate when the
+		// cursor switches directions. Trim that staging so a subsequent
+		// forward traversal doesn't replay the tail key we just emitted.
 		_ = r.cursor.it.fwd.PopItem()
 	}
 
@@ -201,12 +204,8 @@ func (r *RangeIterator) prepare(dir Direction, pull pullFunc) *preparedState {
 }
 
 func (r *RangeIterator) advance(dir Direction, pull pullFunc) (Record, error) {
-	if r.anchors.OnDirectionChange(dir, r.lastEmitted) {
-		if rec, ok := r.anchors.popPending(); ok {
-			r.filter.MarkEmitted(rec, dir)
-			return rec, nil
-		}
-	} else if rec, ok := r.anchors.popPending(); ok {
+	r.anchors.OnDirectionChange(dir, r.lastEmitted)
+	if rec, ok := r.anchors.popPending(); ok {
 		r.filter.MarkEmitted(rec, dir)
 		return rec, nil
 	}

--- a/range_cursor.go
+++ b/range_cursor.go
@@ -20,6 +20,7 @@ type cursorCandidate struct {
 	record     Record
 	stagedItem pqItem
 	peeked     bool
+	staged     bool
 }
 
 type rangeCursor struct {
@@ -28,6 +29,8 @@ type rangeCursor struct {
 	reverseCached Record
 	reversePrimed bool
 	reverseErr    error
+
+	stagedForPrev int
 }
 
 func newRangeCursor(mi *MergingIterator) *rangeCursor {
@@ -91,7 +94,7 @@ func (c *rangeCursor) collapseDescendingRun(seed Record, seedItem pqItem) (Recor
 	}
 
 	if candidate.GetType() == TypeDeletion {
-		return nil, pqItem{}, false, nil
+		return candidate, candidateItem, true, nil
 	}
 
 	return candidate, candidateItem, true, nil
@@ -112,7 +115,12 @@ func (c *rangeCursor) nextForward() (cursorCandidate, bool, error) {
 		}
 		return cursorCandidate{}, false, err
 	}
-	return cursorCandidate{record: rec}, true, nil
+	candidate := cursorCandidate{record: rec}
+	if c.stagedForPrev > 0 {
+		candidate.staged = true
+		c.stagedForPrev--
+	}
+	return candidate, true, nil
 }
 
 func (c *rangeCursor) nextReverse(collapse bool) (cursorCandidate, bool, error) {
@@ -153,22 +161,9 @@ func (c *rangeCursor) stageForPrev(item pqItem) {
 		return
 	}
 	c.it.stageForPrev(item)
-}
-
-func (c *rangeCursor) reverseError() error {
-	return c.reverseErr
+	c.stagedForPrev++
 }
 
 func (c *rangeCursor) clearReverseError() {
 	c.reverseErr = nil
-}
-
-func (c *rangeCursor) resetReverse() {
-	c.reversePrimed = false
-	c.reverseCached = nil
-	c.reverseErr = nil
-}
-
-func (c *rangeCursor) currentReverseCandidate() Record {
-	return c.reverseCached
 }

--- a/range_filter.go
+++ b/range_filter.go
@@ -12,12 +12,14 @@ type recordFilter struct {
 
 	snapshot    uint64
 	hasSnapshot bool
+
+	tombstoned map[string]struct{}
 }
 
 // newRecordFilter constructs a recordFilter bound to the provided snapshot. A
 // nil snapshot permits all sequence numbers.
 func newRecordFilter(snapshot *uint64) *recordFilter {
-	f := &recordFilter{}
+	f := &recordFilter{tombstoned: make(map[string]struct{})}
 	if snapshot != nil {
 		f.snapshot = *snapshot
 		f.hasSnapshot = true
@@ -39,12 +41,33 @@ func (f *recordFilter) Accept(rec Record, dir Direction) (Record, bool) {
 		f.dirSet = true
 	}
 
+	keyStr := string(rec.GetKey())
+	if _, tombstoned := f.tombstoned[keyStr]; tombstoned {
+		return nil, false
+	}
+
 	if f.hasSnapshot && rec.GetSequenceNumber() > f.snapshot {
 		return nil, false
 	}
 
 	if rec.GetType() == TypeDeletion {
+		f.tombstoned[keyStr] = struct{}{}
+		f.remember(rec.GetKey())
 		return nil, false
+	}
+
+	if f.lastKeySet {
+		cmp := rec.GetKey().Compare(f.lastKey)
+		switch dir {
+		case DirForward:
+			if cmp == CmpLess {
+				return nil, false
+			}
+		case DirReverse:
+			if cmp == CmpGreater {
+				return nil, false
+			}
+		}
 	}
 
 	if f.lastKeySet && rec.GetKey().Compare(f.lastKey) == CmpEqual {
@@ -57,10 +80,6 @@ func (f *recordFilter) Accept(rec Record, dir Direction) (Record, bool) {
 
 // Reset clears the stored key so the next Accept call treats the provided
 // record as unseen regardless of the user key.
-func (f *recordFilter) Reset() {
-	f.resetKey()
-}
-
 // MarkEmitted updates the deduplication state for a record that bypassed
 // Accept, such as when replaying an anchor during a direction switch.
 func (f *recordFilter) MarkEmitted(rec Record, dir Direction) {

--- a/range_filter.go
+++ b/range_filter.go
@@ -78,8 +78,6 @@ func (f *recordFilter) Accept(rec Record, dir Direction) (Record, bool) {
 	return rec, true
 }
 
-// Reset clears the stored key so the next Accept call treats the provided
-// record as unseen regardless of the user key.
 // MarkEmitted updates the deduplication state for a record that bypassed
 // Accept, such as when replaying an anchor during a direction switch.
 func (f *recordFilter) MarkEmitted(rec Record, dir Direction) {

--- a/range_filter.go
+++ b/range_filter.go
@@ -1,5 +1,7 @@
 package rindb
 
+import "bytes"
+
 // recordFilter coordinates record visibility and deduplication for range
 // iteration. It tracks the last emitted key so duplicate physical versions of a
 // user key are suppressed and applies snapshot and tombstone filtering.
@@ -13,13 +15,13 @@ type recordFilter struct {
 	snapshot    uint64
 	hasSnapshot bool
 
-	tombstoned map[string]struct{}
+	tombstoned map[uint64][]Bytes
 }
 
 // newRecordFilter constructs a recordFilter bound to the provided snapshot. A
 // nil snapshot permits all sequence numbers.
 func newRecordFilter(snapshot *uint64) *recordFilter {
-	f := &recordFilter{tombstoned: make(map[string]struct{})}
+	f := &recordFilter{tombstoned: make(map[uint64][]Bytes)}
 	if snapshot != nil {
 		f.snapshot = *snapshot
 		f.hasSnapshot = true
@@ -41,8 +43,8 @@ func (f *recordFilter) Accept(rec Record, dir Direction) (Record, bool) {
 		f.dirSet = true
 	}
 
-	keyStr := string(rec.GetKey())
-	if _, tombstoned := f.tombstoned[keyStr]; tombstoned {
+	key := rec.GetKey()
+	if f.isTombstoned(key) {
 		return nil, false
 	}
 
@@ -51,13 +53,13 @@ func (f *recordFilter) Accept(rec Record, dir Direction) (Record, bool) {
 	}
 
 	if rec.GetType() == TypeDeletion {
-		f.tombstoned[keyStr] = struct{}{}
-		f.remember(rec.GetKey())
+		f.markTombstoned(key)
+		f.remember(key)
 		return nil, false
 	}
 
 	if f.lastKeySet {
-		cmp := rec.GetKey().Compare(f.lastKey)
+		cmp := key.Compare(f.lastKey)
 		switch dir {
 		case DirForward:
 			if cmp == CmpLess {
@@ -70,11 +72,11 @@ func (f *recordFilter) Accept(rec Record, dir Direction) (Record, bool) {
 		}
 	}
 
-	if f.lastKeySet && rec.GetKey().Compare(f.lastKey) == CmpEqual {
+	if f.lastKeySet && key.Compare(f.lastKey) == CmpEqual {
 		return nil, false
 	}
 
-	f.remember(rec.GetKey())
+	f.remember(key)
 	return rec, true
 }
 
@@ -97,4 +99,34 @@ func (f *recordFilter) remember(key Bytes) {
 func (f *recordFilter) resetKey() {
 	f.lastKey = f.lastKey[:0]
 	f.lastKeySet = false
+}
+
+func (f *recordFilter) markTombstoned(key Bytes) {
+	hash := hashBytes(key)
+	cloned := append(Bytes(nil), key...)
+	f.tombstoned[hash] = append(f.tombstoned[hash], cloned)
+}
+
+func (f *recordFilter) isTombstoned(key Bytes) bool {
+	hash := hashBytes(key)
+	candidates := f.tombstoned[hash]
+	for _, existing := range candidates {
+		if bytes.Equal(existing, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func hashBytes(b Bytes) uint64 {
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	hash := uint64(offset64)
+	for _, by := range b {
+		hash ^= uint64(by)
+		hash *= prime64
+	}
+	return hash
 }

--- a/range_filter_test.go
+++ b/range_filter_test.go
@@ -55,22 +55,6 @@ func TestRecordFilterDeduplicatesKeysPerDirection(t *testing.T) {
 	require.Equal(t, older, third)
 }
 
-func TestRecordFilterResetClearsSeenKey(t *testing.T) {
-	filter := newRecordFilter(nil)
-	rec := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 6, Type: TypeValue}
-	older := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 3, Type: TypeValue}
-
-	accepted, ok := filter.Accept(rec, DirForward)
-	require.True(t, ok)
-	require.Equal(t, rec, accepted)
-
-	filter.Reset()
-
-	replay, ok := filter.Accept(older, DirForward)
-	require.True(t, ok)
-	require.Equal(t, older, replay)
-}
-
 func TestRecordFilterMarkEmittedUpdatesState(t *testing.T) {
 	filter := newRecordFilter(nil)
 	emitted := RecordImpl{Key: Bytes("alpha"), SequenceNumber: 6, Type: TypeValue}

--- a/range_test.go
+++ b/range_test.go
@@ -550,23 +550,30 @@ func TestRangeIterator_Prepare(t *testing.T) {
 			assert.NoError(t, err)
 
 			iter := NewRangeIterator(mi, RangeAsc)
-			// Emulate internal preparation flow used by HasNext/Next
-			iter.primeNext()
+
+			// Consume the first record to mirror the iterator state when preparing the next element.
 			_, err = iter.Next()
 			assert.NoError(t, err)
 
-			// Prepare the next element and validate expectations
-			iter.primeNext()
+			hasNext := iter.HasNext()
 			if tt.wantErr != "" {
-				assert.EqualError(t, iter.err, tt.wantErr)
-				iter.nextPrepared = false
-				iter.primeNext()
-				assert.False(t, iter.nextPrepared)
-			} else {
-				assert.Equal(t, tt.wantPrepared, iter.nextPrepared)
-				assert.Equal(t, tt.wantKey, string(iter.next.GetKey()))
-				assert.Equal(t, tt.wantValue, string(iter.next.GetValue()))
+				assert.False(t, hasNext)
+				_, err = iter.Next()
+				assert.EqualError(t, err, tt.wantErr)
+				return
 			}
+
+			assert.Equal(t, tt.wantPrepared, hasNext)
+			if !tt.wantPrepared {
+				_, err = iter.Next()
+				assert.ErrorIs(t, err, EOI)
+				return
+			}
+
+			rec, err := iter.Next()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantKey, string(rec.GetKey()))
+			assert.Equal(t, tt.wantValue, string(rec.GetValue()))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- rework `RangeIterator` to use a shared `advance`/`prepare` flow that coordinates the cursor, filter, and anchor state instead of the old prime helpers
- teach the cursor to track staged candidates and gate forward pulls so direction changes replay anchors without leaking new keys
- enforce directional monotonicity in the record filter and update iterator tests for the new iteration semantics

## Testing
- make check
- make test
- make test-integration-smoke

------
https://chatgpt.com/codex/tasks/task_e_68e29bcb81b88325bb8f30894c7e803b